### PR TITLE
ref(config): access through redux only

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,7 @@
 import {
     CALENDAR_ADD_ACCOUNT,
     CALENDAR_SET_EVENTS,
+    CONFIG_UPDATED,
     LOAD_COMPLETED,
     REMOTE_CONTROL_SET_LOCAL_ID,
     SETUP_COMPLETED
@@ -70,5 +71,18 @@ export function setLocalRemoteControlID(id) {
 export function setSetupCompleted() {
     return {
         type: SETUP_COMPLETED
+    };
+}
+
+/**
+ * Signals to update some fields of the current application configuration.
+ *
+ * @param {Object} newConfig
+ * @returns {Object}
+ */
+export function updateConfig(newConfig) {
+    return {
+        type: CONFIG_UPDATED,
+        newConfig
     };
 }

--- a/src/calendars/google.js
+++ b/src/calendars/google.js
@@ -1,6 +1,5 @@
 /* global gapi */
 
-import { CLIENT_ID } from 'config';
 import { date } from 'utils';
 
 /**
@@ -10,15 +9,17 @@ export default {
     /**
      * Loads the external script for accessing the Google API.
      *
+     * @param {string} clientId - The Google application id used for accessing
+     * the calendar API.
      * @returns {Promise} Resolves when the Google API javascript has loaded.
      */
-    initialize() {
+    initialize(clientId) {
         const loadGapi = new Promise(resolve =>
             gapi.load('client:auth2', () => resolve()));
 
         return loadGapi
             .then(() => gapi.client.init({
-                clientId: CLIENT_ID,
+                clientId,
                 scope: [
                     'https://www.googleapis.com/auth/'
                         + 'admin.directory.resource.calendar.readonly',
@@ -88,7 +89,6 @@ export default {
      * @returns {Promise} Resolves when sign in completes successfully.
      */
     triggerSignIn() {
-        return this.initialize()
-            .then(() => gapi.auth2.getAuthInstance().signIn());
+        return gapi.auth2.getAuthInstance().signIn();
     }
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,42 +1,57 @@
 /* global process */
 
 /**
- * The Google application client id to be used for interacting with a Google
- * calendar.
+ * Aggregates all globally defined configuration values.
  */
-export const CLIENT_ID = process.env.CLIENT_ID;
+export default {
 
-/**
- * The avatar image to display in the meetings list when a participant of the
- * meeting has no gravatar configured.
- */
-export const DEFAULT_AVATAR_URL
-    = process.env.DEFAULT_AVATAR_URL || 'https://meet.jit.si/images/avatar.png';
+    /**
+     * The Google application client id to be used for interacting with a Google
+     * calendar.
+     */
+    CLIENT_ID: process.env.CLIENT_ID,
 
-/**
- * The app background image to display. An empty string will load no background
- * image and instead display a solid color.
- */
-export const DEFAULT_BACKGROUND_IMAGE_URL
-    = process.env.DEFAULT_BACKGROUND_IMAGE_URL || '';
+    /**
+     * The avatar image to display in the meetings list when a participant of
+     * the meeting has no gravatar configured.
+     */
+    DEFAULT_AVATAR_URL: process.env.DEFAULT_AVATAR_URL
+        || 'https://meet.jit.si/images/avatar.png',
 
-export const DEFAULT_MEETING_DOMAIN
-    = process.env.DEFAULT_MEETING_DOMAIN || 'meet.jit.si';
+    /**
+     * The host for meetings when a meeting name is provided with no detected
+     * domain.
+     */
+    DEFAULT_MEETING_DOMAIN: process.env.DEFAULT_MEETING_DOMAIN || 'meet.jit.si',
 
-/**
- * This configuration is used to establish a connection with the XMPP service
- * used for jitsi conferences. The service is re-used to support communication
- * between the remote control and main application window. More details about
- * what these configuration values mean be found in the lib-jitsi-meet
- * repository, https://github.com/jitsi/lib-jitsi-meet. This configuration
- * can essentially copy the configuration already being used by the jitsi
- * conference UI.
- */
-export const XMPP_CONFIG = {
-    bosh: process.env.XMPP_BOSH,
-    hosts: {
-        domain: process.env.XMPP_HOSTS_DOMAIN,
-        muc: process.env.XMPP_HOSTS_MUC_URL,
-        focus: process.env.XMPP_HOSTS_FOCUS
+    /**
+     * The app background image to display. An empty string will load no
+     * background image and instead display a solid color.
+     */
+    DEFAULT_BACKGROUND_IMAGE_URL:
+        process.env.DEFAULT_BACKGROUND_IMAGE_URL || '',
+
+    /**
+     * The domain on which all meeting URLs should redirect to join a jitsi
+     * conference.
+     */
+    MEETING_DOMAIN: process.env.MEETING_DOMAINS || 'meet.jit.si',
+
+    /**
+     * This configuration is used to establish a connection with the XMPP
+     * service used for jitsi conferences. The service is re-used to support
+     * communication between the remote control and main application window.
+     * More details about what these configuration values mean be found in the
+     * lib-jitsi-meet repository, https://github.com/jitsi/lib-jitsi-meet. This
+     * configuration can essentially copy the configuration already being used
+     * by the jitsi conference UI.
+     */
+    XMPP_CONFIG: {
+        bosh: process.env.XMPP_BOSH,
+        hosts: {
+            domain: process.env.XMPP_HOSTS_DOMAIN,
+            muc: process.env.XMPP_HOSTS_MUC_URL,
+            focus: process.env.XMPP_HOSTS_FOCUS
+        }
     }
 };

--- a/src/features/scheduled-meetings/avatar.js
+++ b/src/features/scheduled-meetings/avatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { DEFAULT_AVATAR_URL } from 'config';
 import { hash } from 'utils';
 
 import styles from './scheduled-meeting.css';
@@ -13,11 +13,11 @@ import styles from './scheduled-meeting.css';
  * instance is to be initialized.
  * @returns {ReactElement}
  */
-export default function Avatar({ email }) {
+export function Avatar({ defaultAvatarUrl, email }) {
     const avatarUrl = email
         ? `https://www.gravatar.com/avatar/${
             hash(email.trim().toLowerCase())}?d=wavatar`
-        : DEFAULT_AVATAR_URL;
+        : defaultAvatarUrl;
 
     return (
         <img
@@ -32,5 +32,21 @@ Avatar.defaultProps = {
 };
 
 Avatar.propTypes = {
+    defaultAvatarUrl: PropTypes.string,
     email: PropTypes.string
 };
+
+/**
+ * Selects parts of the Redux state to pass in with the props of {@code Avatar}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        defaultAvatarUrl: state.config.DEFAULT_AVATAR_URL
+    };
+}
+
+export default connect(mapStateToProps)(Avatar);

--- a/src/features/setup/google-auth.js
+++ b/src/features/setup/google-auth.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { google } from 'calendars';
 import { Button } from 'features/button';
@@ -13,8 +14,10 @@ import styles from './setup.css';
  */
 export class GoogleAuth extends React.Component {
     static propTypes = {
+        clientId: PropTypes.string,
         dispatch: PropTypes.func,
-        onSuccess: PropTypes.func
+        onSuccess: PropTypes.func,
+        remoteControlServiceConfig: PropTypes.object
     };
 
     /**
@@ -57,10 +60,25 @@ export class GoogleAuth extends React.Component {
      * @returns {Promise}
      */
     _onAuthEnter() {
-        return google.triggerSignIn()
+        google.initialize(this.props.clientId)
+            .then(() => google.triggerSignIn())
             .then(() => this.props.onSuccess())
             .catch(error => logger.error(error));
     }
 }
 
-export default GoogleAuth;
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code GoogleAuth}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        clientId: state.config.CLIENT_ID
+    };
+}
+
+export default connect(mapStateToProps)(GoogleAuth);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
+import config from 'config';
 import { protoState } from 'reducers';
 import { remoteControlService } from 'remote-control';
 import { getPersistedState, setPersistedState } from 'utils';
@@ -15,7 +16,15 @@ import './reset.css';
 // I copied from https://github.com/css-modules/css-modules/issues/164
 import '!style-loader!css-loader!fonts/fonts.css';
 
-const store = createStore(protoState, getPersistedState());
+const persistedState = getPersistedState();
+const initialState = {
+    ...persistedState,
+    config: {
+        ...persistedState.config,
+        ...config
+    }
+};
+const store = createStore(protoState, initialState);
 
 store.subscribe(() => {
     setPersistedState(store);

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -1,0 +1,23 @@
+export const CONFIG_UPDATED = 'CONFIG_UPDATED';
+
+/**
+ * A {@code Reducer} to update the current Redux state for the 'config'
+ * feature. The 'config' feature stores current application wide feature
+ * settings.
+ *
+ * @param {Object} state - The current Redux state for the 'setup' feature.
+ * @param {Object} action - The Redux state update payload.
+ */
+const config = (state = {}, action) => {
+    switch (action.type) {
+    case CONFIG_UPDATED:
+        return {
+            ...state,
+            ...action.newConfig
+        };
+    }
+
+    return state;
+};
+
+export default config;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,14 +1,17 @@
 import { combineReducers } from 'redux';
 import calendars from './calendars';
+import config from './config';
 import remoteControl from './remote-control';
 import setup from './setup';
 
 export const protoState = combineReducers({
     calendars,
+    config,
     remoteControl,
     setup
 });
 
 export * from './calendars';
+export * from './config';
 export * from './remote-control';
 export * from './setup';

--- a/src/remote-control/xmpp.js
+++ b/src/remote-control/xmpp.js
@@ -1,6 +1,5 @@
 /* global JitsiMeetJS */
 
-import { XMPP_CONFIG } from 'config';
 import { $msg } from 'strophe.js';
 import { logger } from 'utils';
 import { setLocalRemoteControlID } from 'actions';
@@ -21,9 +20,11 @@ const xmppControl = {
      *
      * @param {Function} dispatch - The Redux dispatch function used to signal
      * state updates.
+     * @param {Object} config - Describes endpoints to use for establishting the
+     * connection.
      * @returns {Promise<void>}
      */
-    init(dispatch) {
+    init(dispatch, config) {
         if (initPromise) {
             return initPromise;
         }
@@ -34,15 +35,15 @@ const xmppControl = {
             JitsiMeetJS.init({})
             .then(() => {
                 JitsiMeetJS.setLogLevel('error');
-                this.xmppConnection
-                    = new JitsiMeetJS.JitsiConnection(null, null, XMPP_CONFIG);
+                this.xmppConnection = new JitsiMeetJS.JitsiConnection(
+                    null, null, config);
 
                 this.xmppConnection.addEventListener(
                     JitsiMeetJS.events.connection.CONNECTION_ESTABLISHED,
                     () => {
                         dispatch(setLocalRemoteControlID(this.getJid()));
 
-                        resolve();
+                        resolve(this.getJid());
                     });
 
                 this.xmppConnection.addEventListener(

--- a/src/utils/background.js
+++ b/src/utils/background.js
@@ -1,5 +1,3 @@
-import { DEFAULT_BACKGROUND_IMAGE_URL } from 'config';
-
 /**
  * Utilities for interacting with the application background image.
  */
@@ -21,13 +19,5 @@ export default {
 
             image.src = imageUrl;
         });
-    },
-
-    /**
-     * Returns the url of the background image currently configured for display
-     * in the application background.
-     */
-    getBackgroundUrl() {
-        return DEFAULT_BACKGROUND_IMAGE_URL;
     }
 };

--- a/src/utils/store-persistence.js
+++ b/src/utils/store-persistence.js
@@ -31,7 +31,8 @@ let cachedState = null;
 function hasUpdateOfInterest(oldState, newState) {
     return oldState.calendars.name !== newState.calendars.name
         || oldState.calendars.displayName !== newState.calendars.displayName
-        || oldState.setup.completed !== newState.setup.completed;
+        || oldState.setup.completed !== newState.setup.completed
+        || oldState.config !== newState.config;
 }
 
 /**
@@ -47,6 +48,7 @@ function parsePersistedState(state) {
             name: state.calendars.name,
             displayName: state.calendars.displayName
         },
+        config: state.config,
         setup: {
             completed: state.setup.completed
         }

--- a/src/views/admin.js
+++ b/src/views/admin.js
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { CalendarStatus, ResetState } from 'features/admin';
 
@@ -10,9 +12,11 @@ import styles from './view.css';
  *
  * @returns {ReactElement}
  */
-export default function AdminView() {
+export function AdminView({ backgroundImageUrl }) {
     return (
-        <View name = 'admin'>
+        <View
+            backgroundImageUrl = { backgroundImageUrl }
+            name = 'admin'>
             <div className = { styles.container }>
                 <div className = { styles.admin }>
                     <CalendarStatus />
@@ -22,3 +26,24 @@ export default function AdminView() {
         </View>
     );
 }
+
+AdminView.propTypes = {
+    backgroundImageUrl: PropTypes.string
+};
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code AdminView}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        backgroundImageUrl: state.config.DEFAULT_BACKGROUND_IMAGE_URL
+    };
+}
+
+
+export default connect(mapStateToProps)(AdminView);

--- a/src/views/calendar.js
+++ b/src/views/calendar.js
@@ -29,6 +29,7 @@ import styles from './view.css';
  */
 export class Calendar extends React.Component {
     static propTypes = {
+        backgroundImageUrl: PropTypes.string,
         calendarName: PropTypes.string,
         dispatch: PropTypes.func,
         events: PropTypes.array,
@@ -107,7 +108,9 @@ export class Calendar extends React.Component {
         const remoteControlUrl = this._getRemoteControlUrl();
 
         return (
-            <View name = 'calendar'>
+            <View
+                backgroundImageUrl = { this.props.backgroundImageUrl }
+                name = 'calendar'>
                 <div className = { styles.container }>
                     <Clock />
                     <MeetingNameEntry onSubmit = { this._onGoToMeeting } />
@@ -231,6 +234,7 @@ export class Calendar extends React.Component {
  */
 function mapStateToProps(state) {
     return {
+        backgroundImageUrl: state.config.DEFAULT_BACKGROUND_IMAGE_URL,
         calendarName: getCalendarName(state),
         events: getCalendarEvents(state) || [],
         localRemoteControlId: getLocalRemoteControlId(state)

--- a/src/views/meeting.js
+++ b/src/views/meeting.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { DEFAULT_MEETING_DOMAIN } from 'config';
 import { MeetingFrame } from 'features/meeting-frame';
 import { getDisplayName } from 'reducers';
 import { isValidMeetingName, isValidMeetingUrl, logger } from 'utils';
@@ -16,6 +15,7 @@ import View from './view';
  */
 export class Meeting extends React.Component {
     static propTypes = {
+        defautMeetingDomain: PropTypes.string,
         displayName: PropTypes.string,
         history: PropTypes.object,
         location: PropTypes.object,
@@ -85,7 +85,7 @@ export class Meeting extends React.Component {
         if (isValidMeetingUrl(location)) {
             return location;
         } else if (isValidMeetingName(location)) {
-            return `https://${DEFAULT_MEETING_DOMAIN}/${location}`;
+            return `https://${this.props.defautMeetingDomain}/${location}`;
         }
 
         return null;
@@ -110,6 +110,7 @@ export class Meeting extends React.Component {
  */
 function mapStateToProps(state) {
     return {
+        defautMeetingDomain: state.config.DEFAULT_MEETING_DOMAIN,
         displayName: getDisplayName(state)
     };
 }

--- a/src/views/remote-control.js
+++ b/src/views/remote-control.js
@@ -7,7 +7,6 @@ import { MeetingNameEntry } from 'features/meeting-name-entry';
 import { FeedbackForm, RemoteControlMenu } from 'features/remote-control-menu';
 import { ScheduledMeetings } from 'features/scheduled-meetings';
 import { remoteControlService } from 'remote-control';
-import { getLocalRemoteControlId } from 'reducers';
 
 import View from './view';
 import styles from './view.css';
@@ -21,8 +20,8 @@ import styles from './view.css';
 export class RemoteControl extends React.Component {
     static propTypes = {
         dispatch: PropTypes.func,
-        localRemoteControlId: PropTypes.string,
-        match: PropTypes.object
+        match: PropTypes.object,
+        remoteControlServiceConfiguration: PropTypes.object
     };
 
     /**
@@ -52,14 +51,19 @@ export class RemoteControl extends React.Component {
      * @inheritdoc
      */
     componentDidMount() {
-        remoteControlService.init(this.props.dispatch)
-            .then(() => {
+        const {
+            dispatch,
+            remoteControlServiceConfiguration
+        } = this.props;
+
+        remoteControlService.init(dispatch, remoteControlServiceConfiguration)
+            .then(jid => {
                 remoteControlService.addCommandListener(this._onCommand);
 
                 remoteControlService.sendCommand(
                     this._getRemoteId(),
                     'requestCalendar',
-                    { requester: this.props.localRemoteControlId }
+                    { requester: jid }
                 );
 
                 remoteControlService.createMuc(this._getRemoteNode());
@@ -252,7 +256,7 @@ export class RemoteControl extends React.Component {
  */
 function mapStateToProps(state) {
     return {
-        localRemoteControlId: getLocalRemoteControlId(state)
+        remoteControlServiceConfiguration: state.config.XMPP_CONFIG
     };
 }
 

--- a/src/views/setup.js
+++ b/src/views/setup.js
@@ -14,6 +14,7 @@ import styles from './view.css';
  */
 export class Setup extends React.Component {
     static propTypes = {
+        backgroundImageUrl: PropTypes.string,
         history: PropTypes.object
     };
 
@@ -36,7 +37,9 @@ export class Setup extends React.Component {
      */
     render() {
         return (
-            <View name = 'setup'>
+            <View
+                backgroundImageUrl = { this.props.backgroundImageUrl }
+                name = 'setup'>
                 <div className = { styles.container }>
                     <SetupSteps onSuccess = { this._redirectToCalendar } />
                 </div>
@@ -55,4 +58,18 @@ export class Setup extends React.Component {
     }
 }
 
-export default connect()(Setup);
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code Setup}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        backgroundImageUrl: state.config.DEFAULT_BACKGROUND_IMAGE_URL
+    };
+}
+
+export default connect(mapStateToProps)(Setup);

--- a/src/views/view.js
+++ b/src/views/view.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { remoteControlService } from 'remote-control';
-import { backgroundService } from 'utils';
 
 import styles from './view.css';
 
@@ -14,7 +13,7 @@ import styles from './view.css';
  */
 export default class View extends React.Component {
     static propTypes = {
-        hideBackground: PropTypes.bool,
+        backgroundImageUrl: PropTypes.string,
         children: PropTypes.node,
         name: PropTypes.string
     };
@@ -39,14 +38,10 @@ export default class View extends React.Component {
     render() {
         let backgroundStyles;
 
-        if (!this.props.hideBackground) {
-            const backgroundUrl = backgroundService.getBackgroundUrl();
-
-            if (backgroundUrl) {
-                backgroundStyles = {
-                    backgroundImage: `url('${backgroundUrl}')`
-                };
-            }
+        if (this.props.backgroundImageUrl) {
+            backgroundStyles = {
+                backgroundImage: `url('${this.props.backgroundImageUrl}')`
+            };
         }
 
         return (


### PR DESCRIPTION
Right now the config exists in a file built into the repo and overridable by environment variables at build time. This change makes it so accessing of config values, aside from initial redux hydration, is done through redux to avoid direct access.