### PR TITLE
ref(remote-control): move popup handling management to class 

### DIFF
--- a/src/remote-control/index.js
+++ b/src/remote-control/index.js
@@ -1,2 +1,3 @@
 export * from './constants';
+export { default as RemoteControlWindowService } from './popup-handler';
 export { default as remoteControlService } from './xmpp';

--- a/src/remote-control/popup-handler.js
+++ b/src/remote-control/popup-handler.js
@@ -1,0 +1,79 @@
+import { windowHandler } from 'utils';
+
+/**
+ * A class for managing the remote control window.
+ */
+export default class RemoteControlWindowService {
+    /**
+     * Initializes a new {@code RemoteControlWindowService} instance.
+     *
+     * @param {Object} config
+     * @param {Function} urlGenerator - A function to invoke when generating
+     * the URL to the remote control.
+     */
+    constructor(config) {
+        /**
+         * The interval to check if the remote control window instance has
+         * been closed. This interval instance variable is set on window open
+         * and unset on window close.
+         */
+        this._closeCheckerInterval = null;
+
+        this._remoteControlUrlGenerator = config.urlGenerator;
+
+        /**
+         * The reference to the popup window showing the remote control.
+         */
+        this._windowInstance = null;
+    }
+
+    /**
+     * Generates the URL for the remote control instance.
+     *
+     * @returns {string}
+     */
+    getUrl(...args) {
+        return this._remoteControlUrlGenerator(...args);
+    }
+
+    /**
+     * Opens a window that allows remote control over the provided user id.
+     *
+     * @returns {void}
+     * @private
+     */
+    open(targetId) {
+        if (this._windowInstance) {
+            this._windowInstance.focus();
+
+            return;
+        }
+
+        this._windowInstance = windowHandler.openNewWindow(
+            this.getUrl(targetId), 'spot-remote-control',
+            {
+                width: 400,
+                height: 800
+            }
+        );
+
+        this._startWindowCloseChecker();
+    }
+
+    /**
+     * Triggers an interval to check if the popup window has been closed. An
+     * interval is used for cross origin support, versus attaching handlers
+     * directly to the window.
+     *
+     * @returns {void}
+     * @private
+     */
+    _startWindowCloseChecker() {
+        this._closeCheckerInterval = setInterval(() => {
+            if (!this._windowInstance || this._windowInstance.closed) {
+                clearInterval(this._closeCheckerInterval);
+                this._windowInstance = null;
+            }
+        }, 1000);
+    }
+}

--- a/src/utils/window-handler.js
+++ b/src/utils/window-handler.js
@@ -17,10 +17,16 @@ export default {
      * Opens a popup window with the provided url.
      *
      * @param {string} url - The url to go to in the new window.
-     * @returns {void}
+     * @param {string} name - The identifying name to give the new window.
+     * @param {Object} options - The windows features settings to override.
+     * @returns {Window}
      */
-    openNewWindow(url) {
-        window.open(url, '_blank', 'noopener');
+    openNewWindow(url, name = '_blank', options = {}) {
+        const windowFeatures = Object.entries(options)
+            .map(([ key, value ]) => `${key}=${value}`)
+            .join(',');
+
+        return window.open(url, name, windowFeatures);
     },
 
     /**

--- a/src/views/calendar.js
+++ b/src/views/calendar.js
@@ -14,7 +14,7 @@ import {
     getLocalRemoteControlId,
     isSetupComplete
 } from 'reducers';
-import { keyboardNavigation, windowHandler } from 'utils';
+import { keyboardNavigation } from 'utils';
 
 import View from './view';
 import styles from './view.css';
@@ -36,7 +36,8 @@ export class Calendar extends React.Component {
         isSetupComplete: PropTypes.bool,
         localRemoteControlId: PropTypes.string,
         history: PropTypes.object,
-        remoteControlService: PropTypes.object
+        remoteControlService: PropTypes.object,
+        remoteControlWindowService: PropTypes.object
     };
 
     state = {
@@ -112,7 +113,8 @@ export class Calendar extends React.Component {
                 onMeetingClick = { this._onGoToMeeting } />;
         }
 
-        const remoteControlUrl = this._getRemoteControlUrl();
+        const remoteControlUrl = this.props.remoteControlWindowService.getUrl(
+            this.props.localRemoteControlId);
 
         return (
             <View name = 'calendar'>
@@ -126,30 +128,11 @@ export class Calendar extends React.Component {
                     <div
                         className = { styles.qrcode }
                         onClick = { this._openQRCodeUrl }>
-                        { remoteControlUrl
-                            ? <QRCode text = { remoteControlUrl } />
-                            : null }
+                        <QRCode text = { remoteControlUrl } />
                     </div>
                 </div>
             </View>
         );
-    }
-
-    /**
-     * Generates the full URL for opening a remote control for the application.
-     *
-     * @private
-     * @returns void
-     */
-    _getRemoteControlUrl() {
-        const { localRemoteControlId } = this.props;
-
-        if (!localRemoteControlId) {
-            return '';
-        }
-
-        return `${windowHandler.getBaseUrl()}#/remote-control/${
-            window.encodeURIComponent(localRemoteControlId)}`;
     }
 
     /**
@@ -197,7 +180,9 @@ export class Calendar extends React.Component {
      * @returns {void}
      */
     _openQRCodeUrl() {
-        windowHandler.openNewWindow(this._getRemoteControlUrl());
+        const { localRemoteControlId, remoteControlWindowService } = this.props;
+
+        remoteControlWindowService.open(localRemoteControlId);
     }
 
     /**

--- a/src/views/calendar.js
+++ b/src/views/calendar.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { setCalendarEvents } from 'actions';
-import { google } from 'calendars';
 import { Clock } from 'features/clock';
 import { LoadingIcon } from 'features/loading-icon';
 import { MeetingNameEntry } from 'features/meeting-name-entry';
@@ -15,7 +14,6 @@ import {
     getLocalRemoteControlId,
     isSetupComplete
 } from 'reducers';
-import { remoteControlService } from 'remote-control';
 import { keyboardNavigation, windowHandler } from 'utils';
 
 import View from './view';
@@ -31,12 +29,14 @@ import { withCalendar, withRemoteControl } from './loaders';
  */
 export class Calendar extends React.Component {
     static propTypes = {
+        calendarService: PropTypes.object,
         calendarName: PropTypes.string,
         dispatch: PropTypes.func,
         events: PropTypes.array,
         isSetupComplete: PropTypes.bool,
         localRemoteControlId: PropTypes.string,
-        history: PropTypes.object
+        history: PropTypes.object,
+        remoteControlService: PropTypes.object
     };
 
     state = {
@@ -76,7 +76,7 @@ export class Calendar extends React.Component {
                 = setInterval(this._pollForEvents, 30000);
         }
 
-        remoteControlService.addCommandListener(this._onCommand);
+        this.props.remoteControlService.addCommandListener(this._onCommand);
     }
 
     /**
@@ -87,7 +87,7 @@ export class Calendar extends React.Component {
     componentWillUnmount() {
         this._isUnmounting = true;
 
-        remoteControlService.removeCommandListener(this._onCommand);
+        this.props.remoteControlService.removeCommandListener(this._onCommand);
 
         keyboardNavigation.stopListening();
 
@@ -167,7 +167,7 @@ export class Calendar extends React.Component {
             this._onGoToMeeting(options.meetingName);
             break;
         case 'requestCalendar':
-            remoteControlService.sendCommand(
+            this.props.remoteControlService.sendCommand(
                 options.requester,
                 'calendarData',
                 { events: this.props.events });
@@ -215,7 +215,7 @@ export class Calendar extends React.Component {
         }
 
         // TODO: prevent multiple requests being in flight at the same time
-        google.getCalendar(calendarName)
+        this.props.calendarService.getCalendar(calendarName)
             .then(events => {
                 if (this._isUnmounting) {
                     return;

--- a/src/views/loaders/abstract-loader.js
+++ b/src/views/loaders/abstract-loader.js
@@ -43,10 +43,25 @@ export class AbstractLoader extends React.Component {
      */
     render() {
         if (this.state.loaded) {
-            return this.props.children;
+            const { children } = this.props;
+            const childProps = this._getPropsForChildren();
+
+            return React.Children.map(children, child =>
+                React.cloneElement(child, childProps));
         }
 
         return <Loading />;
+    }
+
+    /**
+     * Creates props the service should pass into children so the service can
+     * be called.
+     *
+     * @abstract
+     * @returns {Object | null}
+     */
+    _getPropsForChildren() {
+        throw new Error('Method _loadService must be implemented by subclass');
     }
 
     /**
@@ -72,7 +87,7 @@ AbstractLoader.propTypes = {
  */
 export function generateWrapper(LoaderImpl) {
     return function withLoader(WrappedComponent) {
-        return class WithRemoteControl extends React.Component {
+        return class ComponentWrappedWithService extends React.Component {
             /**
              * Implements React's {@link Component#render()}.
              *

--- a/src/views/loaders/withCalendar.js
+++ b/src/views/loaders/withCalendar.js
@@ -13,6 +13,15 @@ export class CalendarLoader extends AbstractLoader {
     /**
      * @override
      */
+    _getPropsForChildren() {
+        return {
+            calendarService: google
+        };
+    }
+
+    /**
+     * @override
+     */
     _loadService() {
         return google.initialize();
     }

--- a/src/views/loaders/withRemoteControl.js
+++ b/src/views/loaders/withRemoteControl.js
@@ -3,8 +3,11 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { setLocalRemoteControlID } from 'actions';
-import { remoteControlService } from 'remote-control';
-import { logger } from 'utils';
+import {
+    remoteControlService,
+    RemoteControlWindowService
+} from 'remote-control';
+import { logger, windowHandler } from 'utils';
 
 import { AbstractLoader, generateWrapper } from './abstract-loader';
 
@@ -19,6 +22,28 @@ export class RemoteControlLoader extends AbstractLoader {
         ...AbstractLoader.propTypes,
         dispatch: PropTypes.func
     };
+
+    /**
+     *
+     * @param {*} props
+     */
+    constructor(props) {
+        super(props);
+
+        this._generateUrl = this._generateUrl.bind(this);
+        this._remoteControlWindowService = new RemoteControlWindowService({
+            urlGenerator: this._generateUrl
+        });
+    }
+
+    /**
+     *
+     * @param {*} targetId
+     */
+    _generateUrl(targetId) {
+        return `${windowHandler.getBaseUrl()}#/remote-control/${
+            window.encodeURIComponent(targetId)}`;
+    }
 
     /**
      * Returns the name of the muc to join. The name is taken from the query
@@ -44,7 +69,8 @@ export class RemoteControlLoader extends AbstractLoader {
      */
     _getPropsForChildren() {
         return {
-            remoteControlService
+            remoteControlService,
+            remoteControlWindowService: this._remoteControlWindowService
         };
     }
 

--- a/src/views/loaders/withRemoteControl.js
+++ b/src/views/loaders/withRemoteControl.js
@@ -42,6 +42,15 @@ export class RemoteControlLoader extends AbstractLoader {
     /**
      * @override
      */
+    _getPropsForChildren() {
+        return {
+            remoteControlService
+        };
+    }
+
+    /**
+     * @override
+     */
     _loadService() {
         return remoteControlService.init()
             .then(jid => this.props.dispatch(setLocalRemoteControlID(jid)))

--- a/src/views/remote-control.js
+++ b/src/views/remote-control.js
@@ -7,7 +7,6 @@ import { MeetingNameEntry } from 'features/meeting-name-entry';
 import { FeedbackForm, RemoteControlMenu } from 'features/remote-control-menu';
 import { ScheduledMeetings } from 'features/scheduled-meetings';
 import { getLocalRemoteControlId } from 'reducers';
-import { remoteControlService } from 'remote-control';
 
 import { withRemoteControl } from './loaders';
 import View from './view';
@@ -23,7 +22,8 @@ export class RemoteControl extends React.Component {
     static propTypes = {
         dispatch: PropTypes.func,
         localRemoteControlId: PropTypes.string,
-        match: PropTypes.object
+        match: PropTypes.object,
+        remoteControlService: PropTypes.object
     };
 
     /**
@@ -53,6 +53,8 @@ export class RemoteControl extends React.Component {
      * @inheritdoc
      */
     componentDidMount() {
+        const { remoteControlService } = this.props;
+
         remoteControlService.addCommandListener(this._onCommand);
 
         remoteControlService.sendCommand(
@@ -70,7 +72,7 @@ export class RemoteControl extends React.Component {
      * @inheritdoc
      */
     componentWillUnmount() {
-        remoteControlService.removeCommandListener(this._onCommand);
+        this.props.remoteControlService.removeCommandListener(this._onCommand);
     }
 
     /**
@@ -200,7 +202,7 @@ export class RemoteControl extends React.Component {
      * @returns {void}
      */
     _onGoToMeeting(meetingName) {
-        remoteControlService.sendCommand(
+        this.props.remoteControlService.sendCommand(
             this._getRemoteId(), 'goToMeeting', { meetingName });
     }
 


### PR DESCRIPTION
Built on top of #29.

Instead of remote control window opening logic being in the calendar view, move it to its own class so it can be aware of the popup and interact with it. This is done to separate calendar view from popup handling, in case the popup becomes more than a debug feature.