### PR TITLE
fix(setup): check resource type when filtering rooms

### DIFF
--- a/src/calendars/google.js
+++ b/src/calendars/google.js
@@ -85,8 +85,16 @@ export default {
                 + 'my_customer/resources/calendars';
 
         return gapi.client.request(roomsListEndpoint)
-            .then(response => response.result.items.filter(calendar =>
-                calendar.resourceCategory === 'CONFERENCE_ROOM'));
+            .then(response => response.result.items.filter(
+                ({ resourceCategory, resourceType = '' }) => {
+                    if (resourceCategory === 'CONFERENCE_ROOM') {
+                        return true;
+                    }
+
+                    const lowercaseResourceType = resourceType.toLowerCase();
+
+                    return lowercaseResourceType.includes('conference');
+                }));
     },
 
     /**

--- a/src/features/setup/select-room.js
+++ b/src/features/setup/select-room.js
@@ -90,7 +90,7 @@ export class SelectRoom extends React.Component {
         }
 
         return (
-            <div className = { styles.step }>
+            <div className = { `${styles.step} ${styles.roomList}` }>
                 <div className = { styles.title }>
                     Select A Room
                 </div>
@@ -107,7 +107,9 @@ export class SelectRoom extends React.Component {
                     </div>
                     <div>
                         <h1>Or select a rooms:</h1>
-                        { content }
+                        <div>
+                            { content }
+                        </div>
                     </div>
                 </div>
                 <div className = { styles.buttons }>

--- a/src/features/setup/setup.css
+++ b/src/features/setup/setup.css
@@ -2,6 +2,10 @@
     flex: 1;
 }
 
+.roomList {
+    overflow: auto;
+}
+
 .setup {
     background-color: white;
     border-radius: 25px;


### PR DESCRIPTION
It may be that conference rooms configured in Google
are not set to the proper resource category but have
a manual resource type set.