### PR TITLE
fix(remote): use screenshare status from api

### DIFF
--- a/src/features/remote-control-menu/remote-control-menu.js
+++ b/src/features/remote-control-menu/remote-control-menu.js
@@ -18,6 +18,7 @@ import styles from './remote-control-menu.css';
 export default class RemoteControlMenu extends React.Component {
     static propTypes = {
         audioMuted: PropTypes.bool,
+        screensharing: PropTypes.bool,
         targetResource: PropTypes.string,
         videoMuted: PropTypes.bool
     };
@@ -31,15 +32,6 @@ export default class RemoteControlMenu extends React.Component {
     constructor(props) {
         super(props);
 
-        // FIXME: There is no event coming from the jitsi-meet iframe api to
-        // successful screenshare start or stop. So for now assume success and
-        // update state to toggle the screenshare button display. In the future,
-        // listen for updates from the iframe and update the button based on
-        // the update.
-        this.state = {
-            isScreensharing: false
-        };
-
         this._onHangUp = this._onHangUp.bind(this);
         this._onToggleAudioMute = this._onToggleAudioMute.bind(this);
         this._onToggleScreenshare = this._onToggleScreenshare.bind(this);
@@ -52,7 +44,7 @@ export default class RemoteControlMenu extends React.Component {
      * @inheritdoc
      */
     render() {
-        const { audioMuted, videoMuted } = this.props;
+        const { audioMuted, screensharing, videoMuted } = this.props;
 
         return (
             <div className = { styles.menu }>
@@ -63,7 +55,7 @@ export default class RemoteControlMenu extends React.Component {
                     isMuted = { videoMuted }
                     onClick = { this._onToggleVideoMute } />
                 <ScreenshareButton
-                    isScreensharing = { this.state.isScreensharing }
+                    isScreensharing = { screensharing }
                     onClick = { this._onToggleScreenshare } />
                 <HangupButton onClick = { this._onHangUp } />
             </div>
@@ -107,10 +99,6 @@ export default class RemoteControlMenu extends React.Component {
             this.props.targetResource,
             COMMANDS.TOGGLE_SCREENSHARE
         );
-
-        this.setState({
-            isScreensharing: !this.state.isScreensharing
-        });
     }
 
     /**

--- a/src/remote-control/xmpp.js
+++ b/src/remote-control/xmpp.js
@@ -169,8 +169,14 @@ const xmppControl = {
      * @param {*} value - Additional information about the status update.
      * @returns {void}
      */
-    sendPresence(type, value) {
-        this.updatePresence(type, value);
+    updateStatus(type, value) {
+        let valueToSend = value;
+
+        if (typeof value !== 'string') {
+            valueToSend = JSON.stringify(value);
+        }
+
+        this.updatePresence(type, valueToSend);
         this.room.sendPresence();
     },
 
@@ -182,7 +188,7 @@ const xmppControl = {
      * another participant has updated its presence.
      * @returns {void}
      */
-    addPresenceListener(callback) {
+    addStatusListener(callback) {
         presenceListeners.push(callback);
     },
 

--- a/src/views/remote-control.js
+++ b/src/views/remote-control.js
@@ -15,6 +15,7 @@ import styles from './view.css';
 const presenceToStoreAsState = new Set([
     'audioMuted',
     'isSpot',
+    'screensharing',
     'videoMuted',
     'view'
 ]);
@@ -43,13 +44,16 @@ export class RemoteControl extends React.Component {
         super(props);
 
         this.state = {
+            audioMuted: false,
             events: [],
-            view: ''
+            screensharing: false,
+            view: '',
+            videoMuted: false
         };
 
         this._onCommand = this._onCommand.bind(this);
         this._onGoToMeeting = this._onGoToMeeting.bind(this);
-        this._onPresence = this._onPresence.bind(this);
+        this._onStatusChange = this._onStatusChange.bind(this);
     }
 
     /**
@@ -69,7 +73,7 @@ export class RemoteControl extends React.Component {
             'requestCalendar'
         );
 
-        remoteControlService.addPresenceListener(this._onPresence);
+        remoteControlService.addStatusListener(this._onStatusChange);
     }
 
     /**
@@ -162,6 +166,7 @@ export class RemoteControl extends React.Component {
         return (
             <RemoteControlMenu
                 audioMuted = { this.state.audioMuted === 'true' }
+                screensharing = { this.state.screensharing === 'true' }
                 targetResource = { this._getSpotResource() }
                 videoMuted = { this.state.videoMuted === 'true' } />
         );
@@ -226,7 +231,7 @@ export class RemoteControl extends React.Component {
      * @private
      * @returns {void}
      */
-    _onPresence(data) {
+    _onStatusChange(data) {
         const { status } = data;
 
         if (status.isSpot !== 'true') {

--- a/src/views/view.js
+++ b/src/views/view.js
@@ -27,7 +27,7 @@ export default class View extends React.Component {
      */
     componentDidMount() {
         if (this.props.name) {
-            remoteControlService.sendPresence('view', this.props.name);
+            remoteControlService.updateStatus('view', this.props.name);
         }
     }
 


### PR DESCRIPTION
The iframe api has had a notification for screensharing
status change. Use that instead of keeping screensharing
state local to the remote.