### PR TITLE
fix(home): hide settings button on load

### DIFF
--- a/src/features/admin/settings-button.js
+++ b/src/features/admin/settings-button.js
@@ -24,7 +24,7 @@ class SettingsButton extends React.Component {
 
     state = {
         hovered: false,
-        isCursorIdle: false
+        isCursorIdle: true
     };
 
     /**

--- a/src/features/idle-cursor-detector/idle-cursor-detector.js
+++ b/src/features/idle-cursor-detector/idle-cursor-detector.js
@@ -29,7 +29,7 @@ export class IdleCursorDetector extends React.Component {
         super(props);
 
         this._hideTimeout = null;
-        this._mouseIsIdle = false;
+        this._mouseIsIdle = true;
 
         this._onCursorMove = throttle(
             this._onCursorMove.bind(this),


### PR DESCRIPTION
Instead of waiting for cursor idle and then hiding
the settings button, assume cursor idle to start.