### PR TITLE
fix(meeting): do not disable screenshare

### DIFF
--- a/spot-client/src/features/meeting-frame/meeting-frame.js
+++ b/spot-client/src/features/meeting-frame/meeting-frame.js
@@ -69,8 +69,7 @@ export default class MeetingFrame extends React.Component {
 
         this._jitsiApi = new JitsiMeetExternalAPI(`${host}${path}`, {
             configOverwrite: {
-                _desktopSharingSourceDevice: this.props.screenshareDevice,
-                desktopSharingChromeDisabled: !screensharingEnabled
+                _desktopSharingSourceDevice: this.props.screenshareDevice
             },
             interfaceConfigOverwrite: {
                 DEFAULT_LOCAL_DISPLAY_NAME: '',


### PR DESCRIPTION
If no screenshare connector is setup, wired screensharing
should be disabled. However, disabling screenshare
though the iframe aoi would prevent wireless screensharing
from work. So rely on hiding the screenshare button only
and don't actually disable it.