### PR TITLE
fix(error): use error boundary as class component

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -103,11 +103,12 @@ export class App extends React.Component {
             = `app ${this.state.hideCursor ? 'idleCursor' : ''}`;
 
         return (
-            <IdleCursorDetector
-                onCursorIdleChange = { this._onCursorIdleChange }>
-                <div className = { rootClassName }>
-                    <Notifications />
-                    <ErrorBoundary errorComponent = { FatalError }>
+            <ErrorBoundary errorComponent = { FatalError }>
+                <IdleCursorDetector
+                    onCursorIdleChange = { this._onCursorIdleChange }>
+                    <div className = { rootClassName }>
+
+                        <Notifications />
                         <Switch>
                             {
 
@@ -138,9 +139,9 @@ export class App extends React.Component {
                                 path = { ROUTES.REMOTE_CONTROL } />
                             <Route component = { JoinCodeEntry } />
                         </Switch>
-                    </ErrorBoundary>
-                </div>
-            </IdleCursorDetector>
+                    </div>
+                </IdleCursorDetector>
+            </ErrorBoundary>
         );
     }
 

--- a/spot-client/src/common/ui/components/error-boundary/error-boundary.js
+++ b/spot-client/src/common/ui/components/error-boundary/error-boundary.js
@@ -40,8 +40,16 @@ export default class ErrorBoundary extends React.Component {
      * @inheritdoc
      */
     render() {
-        return this.state.error
-            ? this.props.errorComponent(this.state.error, this.state.info)
-            : this.props.children;
+        if (!this.state.error) {
+            return this.props.children;
+        }
+
+        const ErrorComponent = this.props.errorComponent;
+
+        return (
+            <ErrorComponent
+                error = { this.state.error }
+                info = { this.state.info } />
+        );
     }
 }

--- a/spot-client/src/common/ui/components/index.js
+++ b/spot-client/src/common/ui/components/index.js
@@ -5,4 +5,5 @@ export * from './idle-cursor-detector';
 export * from './input';
 export * from './loading-icon';
 export * from './notifications';
+export * from './reset';
 export * from './scheduled-meetings';

--- a/spot-client/src/common/ui/components/reset/index.js
+++ b/spot-client/src/common/ui/components/reset/index.js
@@ -1,0 +1,1 @@
+export { default as ResetState } from './reset';

--- a/spot-client/src/common/ui/components/reset/reset.js
+++ b/spot-client/src/common/ui/components/reset/reset.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { Button } from 'common/ui';
+import { Button } from './../button';
 import { persistence } from 'common/utils';
 
 /**
  * Displays a menu option, with confirmation, to clear all saved Spot state,
- * including its setup.
+ * including any spot-tv setup.
  *
  * @extends React.Component
  */

--- a/spot-client/src/common/ui/views/fatal-error.js
+++ b/spot-client/src/common/ui/views/fatal-error.js
@@ -1,11 +1,7 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
 
-import { isSpot } from './../../reducers';
-import { Button } from './../components';
+import { Button, ResetState } from './../components';
 
-// TODO: Add back reset state feature.
 import View from './view';
 
 /**
@@ -14,13 +10,7 @@ import View from './view';
  *
  * @returns {ReactElement}
  */
-export class FatalError extends React.Component {
-    static propTypes = {
-        error: PropTypes.string,
-        info: PropTypes.string,
-        isSpot: PropTypes.bool
-    };
-
+export default class FatalError extends React.Component {
     /**
      * Initializes a new {@code App} instance.
      *
@@ -50,6 +40,7 @@ export class FatalError extends React.Component {
                         <Button onClick = { this._onReloadToHome }>
                             Reload
                         </Button>
+                        <ResetState />
                     </div>
                 </div>
             </View>
@@ -66,19 +57,3 @@ export class FatalError extends React.Component {
         window.location.reload();
     }
 }
-
-/**
- * Selects parts of the Redux state to pass in with the props of
- * {@code FatalError}.
- *
- * @param {Object} state - The Redux state.
- * @private
- * @returns {Object}
- */
-function mapStateToProps(state) {
-    return {
-        isSpot: isSpot(state)
-    };
-}
-
-export default connect(mapStateToProps)(FatalError);

--- a/spot-client/src/spot-tv/ui/components/admin/index.js
+++ b/spot-client/src/spot-tv/ui/components/admin/index.js
@@ -1,5 +1,4 @@
 export { default as CalendarStatus } from './calendar-status';
 export { default as InMeetingConfig } from './in-meeting-config';
-export { default as ResetState } from './reset';
 export { default as ScreenshareStatus } from './screenshare-status';
 export { default as SettingsButton } from './settings-button';

--- a/spot-client/src/spot-tv/ui/views/admin.js
+++ b/spot-client/src/spot-tv/ui/views/admin.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { Button } from 'common/ui';
+import { Button, ResetState } from 'common/ui';
 import { ROUTES } from 'common/routing';
 
 import {
     CalendarStatus,
     InMeetingConfig,
-    ResetState,
     ScreenshareStatus
 } from './../components';
 


### PR DESCRIPTION
At some point FatalError was changed from a functional
component to a class component. The error boundary
was still expecting a functional component.

While fixint this also brought back the reset state
feature to FatalError and made ErrorBoundary wrap
the entire app.