### PR TITLE
fix(screenshare): placeholder icons for wired vs wireless

### DIFF
--- a/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
+++ b/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
@@ -28,12 +28,12 @@ export default class ScreensharePicker extends React.Component {
                 <div className = 'options'>
                     <NavButton
                         className = 'screenshare'
-                        iconName = 'screen_share'
+                        iconName = 'wifi'
                         label = 'Wireless Screensharing'
                         onClick = { this.props.onStartWirelessScreenshare } />
                     <NavButton
                         className = 'screenshare'
-                        iconName = 'screen_share'
+                        iconName = 'settings_input_hdmi'
                         label = 'HDMI Screensharing'
                         onClick = { this.props.onStartWiredScreenshare } />
                 </div>


### PR DESCRIPTION
There are a lot of unknowns around screensharing UI and UX, one being what icons to show and when to show them. The icons from the designs maybe were not provided (can't tell if they're accessible somewhere but was never told where) so use a couple approximations for now.