### PR TITLE
fix(remote): bring back sleep prevention

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -9981,9 +9981,8 @@
             }
         },
         "nosleep.js": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/nosleep.js/-/nosleep.js-0.9.0.tgz",
-            "integrity": "sha512-qLOl2MmuGOPZY7Exi0kYJSCr2e9IcAtOykOo7hXUGAoaMC1Iqj0m+Aj2REuay68mDkhbc5CoA4ccUvcZI175Kw==",
+            "version": "github:virtuacoplenny/NoSleep.js#304185436a04deb3ed3ef91e67820ed28fd352d6",
+            "from": "github:virtuacoplenny/NoSleep.js#304185436a04deb3ed3ef91e67820ed28fd352d6",
             "dev": true
         },
         "npm-run-path": {

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -39,7 +39,7 @@
         "md5": "2.2.1",
         "moment": "2.24.0",
         "node-sass": "4.11.0",
-        "nosleep.js": "0.9.0",
+        "nosleep.js": "github:virtuacoplenny/NoSleep.js#304185436a04deb3ed3ef91e67820ed28fd352d6",
         "prop-types": "15.7.2",
         "react": "16.8.2",
         "react-dom": "16.8.2",

--- a/spot-client/src/spot-remote/no-sleep/no-sleep.js
+++ b/spot-client/src/spot-remote/no-sleep/no-sleep.js
@@ -56,6 +56,6 @@ export default class NoSleep extends React.Component {
     _enableNoSleep() {
         document.removeEventListener('click', this._enableNoSleep, false);
 
-        // this._noSleepJS.enable();
+        this._noSleepJS.enable();
     }
 }

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -10,6 +10,8 @@ import {
 } from 'common/reducers';
 import { LoadingIcon, View } from 'common/ui';
 
+import { NoSleep } from './../../no-sleep';
+
 import { withRemoteControl, withUltrasound } from './../loaders';
 
 import { Feedback, InCall, WaitingForCall } from './remote-views';
@@ -76,9 +78,11 @@ export class RemoteControl extends React.PureComponent {
      */
     render() {
         return (
-            <View name = 'remoteControl'>
-                { this._getView() }
-            </View>
+            <NoSleep>
+                <View name = 'remoteControl'>
+                    { this._getView() }
+                </View>
+            </NoSleep>
         );
     }
 


### PR DESCRIPTION
NoSleep can make Google Chrome Helper user over
100% CPU. A PR is up on the NoSleep repo to use
a longer video file to reduce CPU usage. The
fork drops CPU usage to around 6% whereas without
any NoSleep CPU usage is around 1%.

The exact conditions for when NoSleep should be
triggered is left for consideration but for now
bring back the functionality.