### PR TITLE
feat(code-input): bring back react-code-input

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -3344,6 +3344,12 @@
                 }
             }
         },
+        "classnames": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+            "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+            "dev": true
+        },
         "cli-cursor": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -10968,6 +10974,17 @@
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
                 "scheduler": "^0.13.2"
+            }
+        },
+        "react-code-input": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/react-code-input/-/react-code-input-3.8.1.tgz",
+            "integrity": "sha512-pFrPqcRoJj/Aao2PFrnH9lKquSp52K7QIc+6Pft8xloEidjOvhWB4RjmJvoBmkkkiBHEuicHxu+zyFbFKt27uQ==",
+            "dev": true,
+            "requires": {
+                "classnames": "^2.2.5",
+                "react": "^16.3.2",
+                "react-dom": "^16.3.2"
             }
         },
         "react-dom": {

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -42,6 +42,7 @@
         "nosleep.js": "github:virtuacoplenny/NoSleep.js#304185436a04deb3ed3ef91e67820ed28fd352d6",
         "prop-types": "15.7.2",
         "react": "16.8.2",
+        "react-code-input": "3.8.1",
         "react-dom": "16.8.2",
         "react-redux": "6.0.0",
         "react-router-dom": "4.3.1",

--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -2,22 +2,24 @@
     outline: none;
     position: relative;
 
-    .box {
+    input {
         align-items: center;
         background-color: var(--container-bg-color);
         border: 1px solid var(--container-sub-content-font-color);
         border-radius: 5px;
         color: var(--container-content-font-color);
-        display: flex;
+        display: inline-block;
         font-size: var(--font-size-x-large);
         height: calc(var(--font-size-x-large) * 0.7);
         justify-content: center;
-        line-height:  var(--font-size-x-large);
+        line-height: normal;
         margin-top: 10px;
+        padding: 0;
+        text-align: center;
         text-transform: uppercase;
         width: calc(var(--font-size-x-large) * 0.5);
 
-        &.active {
+        &:focus {
             border: 5px solid var(--active);
         }
         &:hover {
@@ -26,23 +28,5 @@
         &:not(:last-child) {
             margin-right: 0.5em;
         }
-    }
-
-    .hidden-input {
-        background: transparent;
-        border: none;
-        bottom: 0;
-        /**
-         * Prevent auto-zooming of mobile browser by setting a font-size of
-         * at least 16px.
-         */
-        font-size: 16px;
-        height: 1;
-        left: 50%;
-        outline: none;
-        pointer-events: none;
-        position: absolute;
-        right: 50%;
-        width: 1;
     }
 }

--- a/spot-client/src/common/css/join-code-view.scss
+++ b/spot-client/src/common/css/join-code-view.scss
@@ -25,15 +25,23 @@
         justify-content: center;
 
         .code-entry {
+            // Usage of !important is needed to override the inline style
+            // set by react-code-input.
             @media #{$mq-mobile-s} {
-                display: grid;
+                display: grid !important;
 
                 grid-template-columns: 1fr 1fr 1fr;
             }
 
             @media #{$mq-tablet} {
-                display: flex;
+                display: flex !important;
             }
         }
+    }
+
+    .hidden-submit {
+        position: absolute;
+        pointer-events: none;
+        visibility: hidden;
     }
 }

--- a/spot-client/src/spot-remote/ui/components/code-input/code-input.js
+++ b/spot-client/src/spot-remote/ui/components/code-input/code-input.js
@@ -1,26 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactCodeInput from 'react-code-input';
+
+import { isAutoFocusSupported } from 'common/utils';
 
 /**
- * A ReactComponent for entering a code in a UI where each character is in
- * a separate box. This component uses a hidden input and listens for key
- * strokes to update its UI, which works around WebView issues of the keyboard
- * being dismissed automatically whenever an input is blurred.
+ * A component for entering a code, with each character in a separate box.
  *
  * @extends React.Component
  */
 export default class CodeInput extends React.Component {
-    static defaultProps = {
-        length: 6,
-        value: ''
-    };
-
     static propTypes = {
-        autoFocus: PropTypes.bool,
-        forceUppercase: PropTypes.bool,
-        length: PropTypes.number,
         onChange: PropTypes.func,
-        onSubmit: PropTypes.func,
         value: PropTypes.string
     };
 
@@ -33,17 +24,7 @@ export default class CodeInput extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            currentIndex: 0,
-            hasFocus: false
-        };
-
-        this._hiddenInputRef = React.createRef();
-
-        this._onBlur = this._onBlur.bind(this);
-        this._onKeyDown = this._onKeyDown.bind(this);
-        this._onKeyPress = this._onKeyPress.bind(this);
-        this._onTabFocus = this._onTabFocus.bind(this);
+        this._onChange = this._onChange.bind(this);
     }
 
     /**
@@ -54,232 +35,24 @@ export default class CodeInput extends React.Component {
      */
     render() {
         return (
-            <div className = 'code-entry'>
-                { this._renderBoxes() }
-                <input
-                    aria-hidden = { true }
-                    autoFocus = { this.props.autoFocus }
-                    className = 'hidden-input'
-                    onBlur = { this._onBlur }
-                    onFocus = { this._onTabFocus }
-                    onKeyDown = { this._onKeyDown }
-                    onKeyPress = { this._onKeyPress }
-                    ref = { this._hiddenInputRef }
-                    tabIndex = { -1 } />
-            </div>
+            <ReactCodeInput
+                autoFocus = { isAutoFocusSupported() }
+                className = 'code-entry'
+                fields = { 6 }
+                onChange = { this._onChange }
+                type = 'string'
+                value = { this.props.value } />
         );
     }
 
     /**
-     * Helper to replace a character in the passed in value prop, at the index
-     * set on currentIndex. The returned string will be padded to make sure the
-     * new string length matches at least the currentIndex.
+     * Callback invoked when the entered code has been changed.
      *
-     * @param {string} character - The character to use to replace the.
-     * @private
-     * @returns {string}
-     */
-    _changeCharacterAtCurrentIndex(character) {
-        const { currentIndex } = this.state;
-        const spaces = Math.max(
-            this.state.currentIndex + 1,
-            this.props.value.length
-        );
-
-        const newValue = ''.padEnd(spaces);
-        const newValueParts = newValue.split('');
-
-        return newValueParts.map((space, index) => {
-            if (index === currentIndex) {
-                return character;
-            }
-
-            return this.props.value[index] || space;
-        }).join('');
-    }
-
-    /**
-     * Callback invoked when focus is lost on the hidden input, likely because
-     * of a click outside of {@code CodeInput}.
-     *
+     * @param {string} value - The value entered in the boxes.
      * @private
      * @returns {void}
      */
-    _onBlur() {
-        this.setState({
-            hasFocus: false
-        });
-    }
-
-    /**
-     * Callback invoked when an individual code box is clicked so it can be
-     * focused on.
-     *
-     * @param {number} index - The number of the box that was clicked.
-     * @private
-     * @returns {void}
-     */
-    _onBoxClick(index) {
-        this.setState({
-            currentIndex: index,
-            hasFocus: true
-        }, () => this._hiddenInputRef.current.focus());
-    }
-
-    /**
-     * Callback invoked when a non-character key is pressed while focus is on
-     * the hidden input.
-     *
-     * @param {KeyboardEvent} event - The native event emitted on key down.
-     * @private
-     * @returns {void}
-     */
-    _onKeyDown(event) {
-        const charCode = event.keyCode || event.which;
-
-        switch (charCode) {
-
-        // Backspace should delete the character in the current box or move
-        // focus back one box.
-        case 8: {
-            const currentIndexHasCharacter
-                = this.props.value[this.state.currentIndex];
-
-            if (!currentIndexHasCharacter || !currentIndexHasCharacter.trim()) {
-                this.setState({
-                    currentIndex: Math.max(0, this.state.currentIndex - 1)
-                });
-            } else {
-                this.props.onChange(this._changeCharacterAtCurrentIndex(' '));
-            }
-
-            break;
-        }
-
-        // Tab should proceed to the next box or allow tab focus to continue
-        // forward in the dom.
-        case 9: {
-            if (event.shiftKey) {
-                if (this.state.currentIndex === 0) {
-                    return;
-                }
-
-                event.preventDefault();
-
-                this.setState({
-                    currentIndex: Math.max(0, this.state.currentIndex - 1)
-                });
-            } else {
-                const isOnLastIndex
-                    = this.state.currentIndex === (this.props.length - 1);
-
-                if (isOnLastIndex) {
-                    return;
-                }
-
-                event.preventDefault();
-
-                this.setState({
-                    currentIndex: Math.min(
-                        this.props.length - 1, this.state.currentIndex + 1)
-                });
-            }
-
-            break;
-        }
-
-        // Left arrow should move focus back one box.
-        case 37:
-            this.setState({
-                currentIndex: Math.max(0, this.state.currentIndex - 1)
-            });
-
-            break;
-
-        // Right arrow should move focus forward one box.
-        case 39:
-            this.setState({
-                currentIndex: Math.min(
-                    this.props.length - 1, this.state.currentIndex + 1)
-            });
-
-            break;
-
-        // Delete should empty the character in the current box but keep focus
-        // on the current box.
-        case 46:
-            this.props.onChange(this._changeCharacterAtCurrentIndex(' '));
-
-            break;
-        }
-    }
-
-    /**
-     * Callback invoked when a character has been entered.
-     *
-     * @param {KeyboardEvent} event - The native event emitted on key press.
-     * @private
-     * @returns {void}
-     */
-    _onKeyPress(event) {
-        const characterCode = event.keyCode || event.which;
-        const characterString = String.fromCharCode(characterCode);
-
-        if (!characterString || !characterString.trim()) {
-            return;
-        }
-
-        event.preventDefault();
-
-        this.props.onChange(
-            this._changeCharacterAtCurrentIndex(characterString));
-
-        this.setState({
-            currentIndex: Math.min(
-                this.props.length - 1, this.state.currentIndex + 1)
-        });
-    }
-
-    /**
-     * Callback invoked when the hidden input receives focus. This method exists
-     * to support autofocus.
-     *
-     * @private
-     * @returns {void}
-     */
-    _onTabFocus() {
-        if (!this.state.hasFocus) {
-            this._onBoxClick(this.state.currentIndex);
-        }
-    }
-
-    /**
-     * Creates the boxes UI to show the entered value so far and trigger
-     * value editing.
-     *
-     * @private
-     * @returns {ReactElement}
-     */
-    _renderBoxes() {
-        const { currentIndex, hasFocus } = this.state;
-        const boxes = [];
-
-        for (let i = 0; i < this.props.length; i++) {
-            const showFocused = hasFocus && currentIndex === i;
-            const classNames = `box ${showFocused ? 'active' : ''}`;
-
-            boxes.push(
-                <div
-                    className = { classNames }
-                    key = { i }
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onFocus = { () => this._onBoxClick(i) }
-                    tabIndex = { 0 }>
-                    { this.props.value[i] || '' }
-                </div>
-            );
-        }
-
-        return boxes;
+    _onChange(value) {
+        this.props.onChange(value);
     }
 }

--- a/spot-client/src/spot-remote/ui/components/nav-button/nav-button.js
+++ b/spot-client/src/spot-remote/ui/components/nav-button/nav-button.js
@@ -11,7 +11,8 @@ import { logger } from 'common/logger';
  */
 export default class NavButton extends React.Component {
     static defaultProps = {
-        className: ''
+        className: '',
+        type: 'button'
     };
 
     static propTypes = {
@@ -20,7 +21,8 @@ export default class NavButton extends React.Component {
         iconName: PropTypes.string,
         label: PropTypes.string,
         onClick: PropTypes.func,
-        qaId: PropTypes.string
+        qaId: PropTypes.string,
+        type: PropTypes.string
     };
 
     /**
@@ -47,7 +49,8 @@ export default class NavButton extends React.Component {
             className,
             iconName,
             label,
-            qaId
+            qaId,
+            type
         } = this.props;
 
         return (
@@ -56,7 +59,8 @@ export default class NavButton extends React.Component {
                     = { `nav-button ${active ? 'active' : ''} ${className}` }
                 data-qa-id = { qaId }
                 onClick = { this._onClick }
-                tabIndex = { 0 }>
+                tabIndex = { 0 }
+                type = { type }>
 
                 {
 

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -11,7 +11,6 @@ import {
 import { remoteControlService } from 'common/remote-control';
 import { ROUTES } from 'common/routing';
 import { View } from 'common/ui';
-import { isAutoFocusSupported } from 'common/utils';
 
 import { CodeInput, NavButton } from './../components';
 import { withUltrasound } from './../loaders';
@@ -124,10 +123,12 @@ export class JoinCodeEntry extends React.Component {
                             onSubmit = { this._onFormSubmit }>
                             <div data-qa-id = { 'join-code-input' }>
                                 <CodeInput
-                                    autoFocus = { isAutoFocusSupported() }
-                                    forceUppercase = { true }
                                     onChange = { this._onCodeChange }
                                     value = { this.state.enteredCode } />
+                                <input
+                                    className = 'hidden-submit'
+                                    tabIndex = { -1 }
+                                    type = 'submit' />
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
It was taken out before because iOS webview could
not support changing focus on inputs while keeping
the keyboard displayed. This seems to be fixed
after switching to react-native-webview. So bring
back react-code-input now that is can work in
all necessary environments.

Whether or not we'll keep it long term is another story but the current implementation had to change anyway because it wasn't working on android browsers due to difference in capatibility with onkeypress listening.