### PR TITLE
fix(screenshare): prevent max fps being set to 5

### DIFF
--- a/spot-client/config.js
+++ b/spot-client/config.js
@@ -69,6 +69,18 @@ window.JitsiMeetSpotConfig = {
     },
 
     /**
+     * Configuration related to audio/video capturing and playback.
+     */
+    MEDIA: {
+
+        /**
+         * The maximum frames per second the browser should be allowed to
+         * capture during wireless screensharing.
+         */
+        WIRELESS_SS_MAX_FPS: process.env.WIRELESS_SS_MAX_FPS || 60
+    },
+
+    /**
      * Configuration object for loading the ultrasound library.
      */
     ULTRASOUND: {

--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -25,6 +25,20 @@ class RemoteControlService {
     }
 
     /**
+     * Configures the wireless screensharing service with options for
+     * screenshare source capturing.
+     *
+     * @param {Object} configuration - A configuration file for how the wireless
+     * screensharing should be captured.
+     * @param {Object} configuration.maxFps - The maximum number of frame per
+     * second which should be captured from the sharer's device.
+     * @returns {void}
+     */
+    configureWirelessScreensharing(configuration = {}) {
+        this._wirelessScreensharingConfiguration = configuration;
+    }
+
+    /**
      * Creates a connection to the remote control service.
      *
      * @param {Object} options - Information necessary for creating the MUC.
@@ -298,6 +312,8 @@ class RemoteControlService {
     setWirelessScreensharing(enable) {
         if (enable) {
             const connection = new ScreenshareService({
+                mediaConfiguration:
+                    this._wirelessScreensharingConfiguration || {},
 
                 /**
                  * Callback invoked when the connection has been closed

--- a/spot-client/src/common/remote-control/screenshare-connection.js
+++ b/spot-client/src/common/remote-control/screenshare-connection.js
@@ -10,6 +10,11 @@ export default class ScreenshareConnection {
      * Initializes a new {@code ScreenshareConnection} instance.
      *
      * @param {Object} options - Configuration to initialize with.
+     * @param {Object} options.mediaConfiguration - Describes how the desktop
+     * sharing source should be captured.
+     * @param {Object} options.mediaConfiguration.desktopSharingFrameRate - The
+     * frames per second which should be captured from the desktop sharing
+     * source. Can include a "max" and "min" key, both being numbers.
      * @param {Function} options.sendMessage - Callback invoked when the
      * {@code ProxyConnectionService} needs to send a message out to Jitsi-Meet.
      * @param {Function} options.onConnectionClosed - Callback to invoke when a
@@ -81,7 +86,10 @@ export default class ScreenshareConnection {
 
         const JitsiMeetJS = JitsiMeetJSProvider.get();
 
-        return JitsiMeetJS.createLocalTracks({ devices: [ 'desktop' ] })
+        return JitsiMeetJS.createLocalTracks({
+            ...this.options.mediaConfiguration,
+            devices: [ 'desktop' ]
+        })
             .then(jitsiLocalTracks => {
                 logger.log('screenshareConnection created desktop track');
 

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -67,6 +67,11 @@ if (process.env.NODE_ENV !== 'production') {
 
 const history = createHashHistory();
 
+remoteControlService.configureWirelessScreensharing({
+    desktopSharingFrameRate: {
+        max: window.JitsiMeetSpotConfig.MEDIA.WIRELESS_SS_MAX_FPS
+    }
+});
 remoteControlService.setDelegate(new ProcessUpdateDelegate(store, history));
 
 render(


### PR DESCRIPTION
By default lib-jitsi-meet sets the max to 5
unless a value is provided. By default the
max fps will be 60 but it will be configurable
in order to react to perf issues.