### PR TITLE
fix(home): temporarily hide join info footer

### DIFF
--- a/spot-client/src/common/css/home-view.scss
+++ b/spot-client/src/common/css/home-view.scss
@@ -60,4 +60,8 @@
             font-size: var(--font-size-large);
         }
     }
+
+    ~ .info-footer {
+        display: none;
+    }
 }

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -105,7 +105,7 @@ export class Home extends React.Component {
                                 className = 'join-info'
                                 data-qa-id = 'join-info'
                                 onClick = { this._onOpenRemote }>
-                                Sharing key { joinCode }
+                                Connect at { windowHandler.getBaseUrl() } | Sharing key { joinCode }
                             </div> }
                     </div>
                     <div className = 'settings_cog'>
@@ -219,7 +219,10 @@ export class Home extends React.Component {
                 <h1>Welcome to Spot!</h1>
                 <div className = 'setup-instructions'>
                     <div>You're almost set</div>
-                    <div>Pair your remote and connect your calendar.</div>
+                    <div>
+                        Pair your remote and connect your calendar at
+                        <div>{ windowHandler.getBaseUrl() }</div>
+                    </div>
                 </div>
                 {
                     this.props.joinCode


### PR DESCRIPTION
These changes are temporary. Will wait on design for
final UI/UX, which should include the remote control
url.