### PR TITLE
fix(calendar): notify remotes of events after calendar change

### DIFF
--- a/spot-client/src/common/reducers/calendars.js
+++ b/spot-client/src/common/reducers/calendars.js
@@ -22,10 +22,11 @@ const calendar = (state = DEFAULT_STATE, action) => {
     case CALENDAR_SET_ACCOUNT:
         return {
             ...state,
+            calendarType: action.calendarType,
             displayName: action.displayName,
             email: action.email,
             events: [],
-            calendarType: action.calendarType
+            hasSetEvents: false
         };
 
     case CALENDAR_SET_EVENTS:

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -176,7 +176,7 @@ export class Home extends React.Component {
                 } = this.props;
 
                 if (!hasFetchedEvents
-                        || hasUpdatedEvents(previousEvents, events)) {
+                    || hasUpdatedEvents(previousEvents, events)) {
                     dispatch(setCalendarEvents(events));
                     remoteControlService.notifyCalendarStatus(events);
                 }


### PR DESCRIPTION
The edge case is being connected to a calendar with events,
going into setup, changing calendars to one without any
events. No notification of the new events would be sent
out to remotes, leaving them to show events from the
previous calendar. This is because the known events
for the new calendar had not changed (going from empty
to empty) and a calendar fetch had been completed
for the old calendar. The fix is clearing the fetch
flag with the calendar change.