### PR TITLE
ref(css): start using mixins

### DIFF
--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -1,9 +1,12 @@
+@import './mixins.scss';
+
 .code-entry {
     outline: none;
     position: relative;
 
     input {
-        align-items: center;
+        @include  centered-content;
+
         background-color: var(--container-bg-color);
         border: 1px solid var(--container-sub-content-font-color);
         border-radius: 5px;
@@ -11,7 +14,6 @@
         display: inline-block;
         font-size: var(--font-size-x-large);
         height: calc(var(--font-size-x-large) * 0.7);
-        justify-content: center;
         line-height: normal;
         margin-top: 10px;
         padding: 0;

--- a/spot-client/src/common/css/dial-pad.scss
+++ b/spot-client/src/common/css/dial-pad.scss
@@ -1,15 +1,15 @@
+@import './mixins';
+
 .number-entry-view {
-    display: flex;
-    justify-content: center;
+    @include centered-content;
 }
 
 .dial-pad {
-    align-items: center;
+    @include centered-content;
+
     background-color: var(--container-bg-color);
     border-radius: 4px;
-    display: flex;
     flex-direction: column;
-    justify-content: center;
     padding: 20px;
 
     .dial-pad-buttons {
@@ -42,21 +42,19 @@
                 content: '.';
                 visibility: hidden;
             }
+
+            &.active,
+            &:active,
+            &:active .sub {
+                @include active;
+            }
         }
     }
 
     .call-button {
-        background-color: var(--button-color);
-        border: 0;
-        border-radius: 5px;
-        color: var(--container-content-font-color);
-        cursor: pointer;
-        font-size: var(--font-size-small);
-        padding: 0.5em 1em;
+        @include styled-button;
 
-        &:active {
-            background-color: var(--button-active-color);
-        }
+        font-size: var(--font-size-small);
     }
 
     .input-container,
@@ -69,30 +67,11 @@
     }
 
     .number-input {
-        /**
-        * Explicitly override default input element styles.
-        */
-        &:focus {
-            outline: none;
-        }
-        &::placeholder {
-            color: var(--container-sub-content-font-color);
-        }
-        background-color: transparent;
-        color: var(--container-content-font-color);
+        @include styled-input;
+
         font: inherit;
         text-align: center;
-        width: 100%;
 
-        /**
-        * Set each border attribute separately for mobile safari to
-        * support border-image.
-        */
-        border-bottom: 2px;
-        border-left: 0;
-        border-right: 0;
-        border-style: solid;
-        border-top: 0;
         border-image:
             linear-gradient(
                 to right,

--- a/spot-client/src/common/css/join-code-view.scss
+++ b/spot-client/src/common/css/join-code-view.scss
@@ -1,4 +1,5 @@
 @import './media-queries';
+@import './mixins';
 
 .join-code-view {
     display: grid;
@@ -20,9 +21,7 @@
     }
 
     .code-entry-wrapper {
-        align-items: center;
-        display: flex;
-        justify-content: center;
+        @include centered-content;
 
         .code-entry {
             // Usage of !important is needed to override the inline style

--- a/spot-client/src/common/css/meeting-name-entry.scss
+++ b/spot-client/src/common/css/meeting-name-entry.scss
@@ -1,4 +1,5 @@
 @import './media-queries';
+@import './mixins';
 
 .meeting-name-entry {
     background-color: var(--container-content-bg-color);
@@ -19,30 +20,9 @@
         flex: 1;
 
         .input {
-            /**
-            * Explicitly override default input element styles.
-            */
-            &:focus {
-                outline: none;
-            }
-            &::placeholder {
-                color: var(--container-sub-content-font-color);
-            }
-            background-color: transparent;
-            color: var(--container-content-font-color);
-            font-size: var(--font-size-small);
-            padding-bottom: 16px;
-            width: 100%;
+            @include styled-input;
 
-            /**
-            * Set each border attribute separately for mobile safari to
-            * support border-image.
-            */
-            border-bottom: 2px;
-            border-left: 0;
-            border-right: 0;
-            border-style: solid;
-            border-top: 0;
+            padding-bottom: 16px;
             border-image:
                 linear-gradient(
                     to right,
@@ -62,22 +42,14 @@
 
 
     .submit-wrapper {
-        align-items: center;
-        display: flex;
+        @include centered-content;
+
         margin-left: 2em;
 
         .submit-button {
-            background-color: var(--button-color);
-            border: 0;
-            border-radius: 5px;
-            color: var(--container-content-font-color);
-            cursor: pointer;
-            font-size: var(--font-size-medium);
-            padding: 0.5em 1em;
+            @include styled-button;
 
-            &:active {
-                background-color: var(--button-active-color);
-            }
+            font-size: var(--font-size-medium);
         }
     }
 }

--- a/spot-client/src/common/css/mixins.scss
+++ b/spot-client/src/common/css/mixins.scss
@@ -1,0 +1,50 @@
+@mixin active {
+    border-color: var(--active);
+    color: var(--active);
+}
+
+@mixin centered-content {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+}
+
+@mixin styled-button {
+    background-color: var(--button-color);
+    border: 0;
+    border-radius: 5px;
+    color: var(--container-content-font-color);
+    cursor: pointer;
+    padding: 0.5em 1em;
+
+    &:active {
+        background-color: var(--button-active-color);
+    }
+}
+
+@mixin styled-input {
+    /**
+    * Explicitly override default input element styles.
+    */
+    &:focus {
+      outline: none;
+    }
+    &::placeholder {
+        color: var(--container-sub-content-font-color);
+    }
+
+    background-color: transparent;
+    color: var(--container-content-font-color);
+    font-size: var(--font-size-small);
+    width: 100%;
+
+    /**
+    * Set each border attribute separately for mobile safari to
+    * support border-image.
+    */
+    border-bottom: 2px;
+    border-left: 0;
+    border-right: 0;
+    border-top: 0;
+    border-style: solid;
+}

--- a/spot-client/src/common/css/nav.scss
+++ b/spot-client/src/common/css/nav.scss
@@ -1,4 +1,5 @@
 @import './media-queries';
+@import './mixins';
 
 .nav {
     flex-wrap: wrap;
@@ -57,12 +58,9 @@
         }
 
         &.active,
-        &:active {
-            color: var(--active);
-
-            .nav-icon {
-                border-color: var(--active);
-            }
+        &:active,
+        &:active .nav-icon {
+            @include active;
         }
 
         &:hover:not(.active) {

--- a/spot-client/src/common/css/temp.scss
+++ b/spot-client/src/common/css/temp.scss
@@ -3,6 +3,7 @@
  * be used on the final product should be included here.
  */
 @import './media-queries';
+@import './mixins';
 
 .idleCursor {
   cursor: none;
@@ -246,11 +247,10 @@ body.using-mouse :focus {
 }
 
 .loading {
-  align-items: center;
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  width: 100%;
+    @include centered-content;
+
+    height: 100%;
+    width: 100%;
 }
 
 .settings_cog {


### PR DESCRIPTION
To reduce css duplication, use mixins. The intent
is to use mixins like a toolbox of css without
having to modify the jsx to add classes.