### PR TITLE
fix(ios): re-add a default build script

### DIFF
--- a/in-room-controller/ios/mobile.xcodeproj/project.pbxproj
+++ b/in-room-controller/ios/mobile.xcodeproj/project.pbxproj
@@ -655,8 +655,8 @@
 				0E3E4F19221C82BF00760E9E /* Run React packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
-				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1122,12 +1122,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "
-";
+			shellScript = "export NODE_BINARY=node\npwd\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		0E3E4F19221C82BF00760E9E /* Run React packager */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (
@@ -1141,7 +1140,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "pwd\n./scripts/run-packager.sh\n\n";
+			shellScript = "./scripts/run-packager.sh\n\n";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
While moving over deps to pod, a build script was removed,
as it was not being included in jitsi-meet's build phases.
Looks like it's needed for building on real devices.