### PR TITLE
fix(meeting): hide spot-tv's meeting view while it loads

### DIFF
--- a/spot-client/src/common/css/temp.scss
+++ b/spot-client/src/common/css/temp.scss
@@ -225,6 +225,12 @@ body.using-mouse :focus {
   }
 }
 
+.loading-curtain {
+    height: 100%;
+    position: absolute;
+    width: 100%;
+}
+
 .meetingMouseHider {
   pointer-events: none;
   position: absolute;

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -13,6 +13,7 @@ import {
 import { logger } from 'common/logger';
 import { isValidMeetingName, isValidMeetingUrl } from 'common/utils';
 import { ROUTES } from 'common/routing';
+import { Loading } from 'common/ui';
 
 import { MeetingFrame } from './../components';
 
@@ -44,6 +45,10 @@ export class Meeting extends React.Component {
         super(props);
 
         this._queryParams = this._getQueryParams();
+
+        this.state = {
+            meetingLoaded: false
+        };
 
         this._onMeetingLeave = this._onMeetingLeave.bind(this);
         this._onMeetingStart = this._onMeetingStart.bind(this);
@@ -97,6 +102,12 @@ export class Meeting extends React.Component {
                     screenshareDevice = { this.props.screenshareDevice }
                     showMeetingToolbar = { this.props.showMeetingToolbar }
                     startWithScreenshare = { screenshare } />
+                {
+                    !this.state.meetingLoaded
+                        && <div className = 'loading-curtain'>
+                            <Loading />
+                        </div>
+                }
                 {
 
                     /**
@@ -175,6 +186,10 @@ export class Meeting extends React.Component {
      */
     _onMeetingStart(meetingApi) {
         this.props.dispatch(setMeetingApi(meetingApi));
+
+        this.setState({
+            meetingLoaded: true
+        });
     }
 }
 


### PR DESCRIPTION
This should hide any flashes of gum permission that
display and any erroneously entered web pages. In
the future it can be used to hide the password prompt.