### PR TITLE
fix(logging): prevent double json stringification

### DIFF
--- a/spot-client/src/common/logger/logger.js
+++ b/spot-client/src/common/logger/logger.js
@@ -9,14 +9,21 @@ const jitsiLogger = getLogger(null, null, { disableCallerInfo: true });
  *
  * @param {string} level - The severity level of the log.
  * @param {string} message - The message to be logged.
+ * @param {Object} context - Additional information to be logged.
  * @returns {string} The log object, which includes metadata, as a string.
  */
-function formatMessage(level, message) {
-    return JSON.stringify({
+function formatMessage(level, message, context) {
+    const formattedMessage = {
         level,
         timestamp: Date.now(),
         message
-    });
+    };
+
+    if (context) {
+        formattedMessage.context = context;
+    }
+
+    return formattedMessage;
 }
 
 /**
@@ -27,32 +34,36 @@ export default {
     /**
      * Logs an error level message. Should be used for critical errors.
      *
-     * @param {string} message - The information to be logged as an error.
+     * @param {string} message - The main string to be logged as an error.
+     * @param {Object} context - Additional information to be logged.
      * @returns {void}
      */
-    error(message) {
-        jitsiLogger.error(formatMessage('error', message));
+    error(message, context) {
+        jitsiLogger.error(formatMessage('error', message, context));
     },
 
     /**
      * Logs a normal level message. Should be used for recording normal app
      * behavior.
      *
-     * @param {string} message - The information to be logged.
+     * @param {string} message - The main string to be logged as essentially an
+     * information level log.
+     * @param {Object} context - Additional information to be logged.
      * @returns {void}
      */
-    log(message) {
-        jitsiLogger.log(formatMessage('log', message));
+    log(message, context) {
+        jitsiLogger.log(formatMessage('log', message, context));
     },
 
     /**
      * Logs a warning message. Should be used for recoverable errors or to
      * indicate recovery from errors.
      *
-     * @param {string} message - The information to be logged.
+     * @param {string} message - The main string to be logged a warning.
+     * @param {Object} context - Additional information to be logged.
      * @returns {void}
      */
-    warn(message) {
-        jitsiLogger.warn(formatMessage('warn', message));
+    warn(message, context) {
+        jitsiLogger.warn(formatMessage('warn', message, context));
     }
 };

--- a/spot-client/src/common/logger/logging-service.js
+++ b/spot-client/src/common/logger/logging-service.js
@@ -21,7 +21,8 @@ export default class LoggingService {
                 storeLogs: this.storeLogs.bind(this)
             },
             {
-                storeInterval: 1000
+                storeInterval: 1000,
+                stringifyObjects: true
             }
         );
 

--- a/spot-client/src/common/remote-control/process-update-delegate.js
+++ b/spot-client/src/common/remote-control/process-update-delegate.js
@@ -303,8 +303,7 @@ export default class ProcessUpdateDelegate {
             this.stopScreenshare();
         }
 
-        logger.log(`processUpdateDelegate new spot state ${
-            JSON.stringify(newState)}`);
+        logger.log('processUpdateDelegate new spot state', { ...newState });
 
         this._store.dispatch(updateSpotState(newState));
 


### PR DESCRIPTION
Objects in logs were being logged as strings,
instead of key-accessible objects. The behavior
was intentional because of how jitsi-meet-logger
concatenates logs as one string, and converting
back to JSON could cause errors. However, this
produces the undesireable log format, so introduce
a context argument object for logging additional
details.