### PR TITLE
ref(wired-screenshare): add the detector to the global

### DIFF
--- a/spot-client/src/common/debugging/global-debugger.js
+++ b/spot-client/src/common/debugging/global-debugger.js
@@ -1,0 +1,14 @@
+/**
+ * Spots may experience states that are difficult to debug from logs alone. As
+ * such features are allowed to expose globals for the sake of debugging through
+ * the browser console.
+ */
+
+// All debugging is available within the "spot" namespace.
+window.spot = {};
+
+export default {
+    register(name, debugObject) {
+        window.spot[name] = debugObject;
+    }
+};

--- a/spot-client/src/common/debugging/index.js
+++ b/spot-client/src/common/debugging/index.js
@@ -1,0 +1,1 @@
+export { default as globalDebugger } from './global-debugger';

--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -1,3 +1,4 @@
+import { globalDebugger } from 'common/debugging';
 import { logger } from 'common/logger';
 
 import { COMMANDS, MESSAGES } from './constants';
@@ -463,4 +464,8 @@ class RemoteControlService {
     }
 }
 
-export default new RemoteControlService();
+const remoteControlService = new RemoteControlService();
+
+globalDebugger.register('remoteControlService', remoteControlService);
+
+export default remoteControlService;

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -6,6 +6,7 @@ import { HashRouter } from 'react-router-dom';
 import { createHashHistory } from 'history';
 
 import 'common/css';
+import { globalDebugger } from 'common/debugging';
 import { LoggingService } from 'common/logger';
 import reducers, { getLoggingEndpoint } from 'common/app-state';
 import {
@@ -33,6 +34,8 @@ const store = createStore(
     }
 );
 
+globalDebugger.register('store', store);
+
 store.subscribe(() => {
     setPersistedState(store);
 });
@@ -55,14 +58,6 @@ if (loggingEndpoint) {
     );
 
     loggingService.start();
-}
-
-// eslint-disable-next-line no-undef
-if (process.env.NODE_ENV !== 'production') {
-    window.spot = {
-        remoteControlService,
-        store
-    };
 }
 
 const history = createHashHistory();

--- a/spot-client/src/spot-tv/wired-screenshare-service/wired-screenshare-service.js
+++ b/spot-client/src/spot-tv/wired-screenshare-service/wired-screenshare-service.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash.debounce';
 
+import { globalDebugger } from 'common/debugging';
 import { logger } from 'common/logger';
 import { JitsiMeetJSProvider } from 'common/vendor';
 
@@ -208,4 +209,8 @@ export class WiredScreenshareService {
     }
 }
 
-export default new WiredScreenshareService();
+const wiredScreenshareService = new WiredScreenshareService();
+
+globalDebugger.register('wiredScreenshareService', wiredScreenshareService);
+
+export default wiredScreenshareService;


### PR DESCRIPTION
This way when issues happen the video element used for
detecting can be examined.