### PR TITLE
fix(screenshare): notify when screenshare input no longer set

### DIFF
--- a/spot-client/src/common/app-state/spot-tv/reducer.js
+++ b/spot-client/src/common/app-state/spot-tv/reducer.js
@@ -11,11 +11,8 @@ const DEFAULT_STATE = {
     screensharingType: undefined,
     spotId: null,
     videoMuted: true,
-    view: null
-
-    // FIXME: setting the default prevents wired screensharing from being
-    // set to true.
-    // wiredScreensharingEnabled: false
+    view: null,
+    wiredScreensharingEnabled: false
 };
 
 /**


### PR DESCRIPTION
The edge case is a Spot-TV that has been set up with a screenshare
dongle and goes through setup again without selecting a dongle. In
that case the Spot-Remotes will continue to believe the Spot-TV has
a dongle connected. So instead update state when the dongle is
no longer set.