### PR TITLE
fix(reconnect): ensure calendar events are emitted

### DIFF
--- a/spot-client/src/common/remote-control/remote-control-service-subscriber.js
+++ b/spot-client/src/common/remote-control/remote-control-service-subscriber.js
@@ -10,6 +10,7 @@ export default class RemoteControlServiceSubscriber {
      */
     constructor() {
         this._previousSpotTvState = {};
+        this._previousCalendarEvents = [];
     }
 
     /**
@@ -23,12 +24,17 @@ export default class RemoteControlServiceSubscriber {
      */
     onUpdate(store) {
         const newSpotTvState = store.getState().spotTv;
+        const newCalendarEvents = store.getState().calendars.events || [];
 
-        if (newSpotTvState === this._previousSpotTvState) {
+        if (newSpotTvState === this._previousSpotTvState
+            && newCalendarEvents === this._previousCalendarEvents) {
             return;
         }
 
-        remoteControlService.updateStatus(newSpotTvState);
+        remoteControlService.updateStatus({
+            ...newSpotTvState,
+            calendar: newCalendarEvents
+        });
 
         if (this._previousSpotTvState.inMeeting !== newSpotTvState.inMeeting
             && newSpotTvState.inMeeting) {
@@ -36,5 +42,6 @@ export default class RemoteControlServiceSubscriber {
         }
 
         this._previousSpotTvState = newSpotTvState;
+        this._previousCalendarEvents = newCalendarEvents;
     }
 }

--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -273,16 +273,6 @@ class RemoteControlService {
     }
 
     /**
-     * Notifies all Spot-Remotes about a change in known calendar events.
-     *
-     * @param {Array<Object>} events - The calendar events for Spot-TV.
-     * @returns {void}
-     */
-    notifyCalendarStatus(events) {
-        this.xmppConnection.updateStatus('calendar', events);
-    }
-
-    /**
      * Notifies all Spot-Remotes of the current join code for a Spot-TV.
      *
      * @param {string} joinCode - The join code necessary for a user to connect

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -231,14 +231,12 @@ export class Home extends React.Component {
                 const {
                     dispatch,
                     events: previousEvents,
-                    hasFetchedEvents,
-                    remoteControlService
+                    hasFetchedEvents
                 } = this.props;
 
                 if (!hasFetchedEvents
                     || hasUpdatedEvents(previousEvents, events)) {
                     dispatch(setCalendarEvents(events));
-                    remoteControlService.notifyCalendarStatus(events);
                 }
             });
     }


### PR DESCRIPTION
When reconnecting, Spot-TV creates a new XMPP
connection and sets a new join code. The setting
of a join code triggers a redux update, which
updates presence through a redux subscriber.
This ensure the new connection has the updated
presence. Use this mechanism to enusre the
new connection has updated events as well.

Note for the future: probably all notifications for presence should happen through Spot-TV subscriber instead of any component calling directly into remoteControlService to set a status update.