### PR TITLE
ref(config): avoid webpack processing

### DIFF
--- a/spot-client/config.js
+++ b/spot-client/config.js
@@ -1,13 +1,20 @@
-/* global process */
-
 /**
- * FIXME: I wanted to keep the local environment file to place overrides for
- * development while also making the config dynamically loadable. The only way
- * I could find to do this reliably was by placing the config on a global...
+ * Overrides for the default configuration for Spot. See file default-config.js
+ * for all the default values which are used.
  */
 window.JitsiMeetSpotConfig = {
+    /**
+     * Configuration object for referencing external links and applications that
+     * provide additional support for Spot.
+     */
     ADVERTISEMENT: {
-        APP_NAME: process.env.APP_NAME
+
+        /**
+         * The name of an application that enhances the functionality of Spot.
+         *
+         * @type {string}
+         */
+        APP_NAME: undefined
     },
 
     /**
@@ -22,9 +29,12 @@ window.JitsiMeetSpotConfig = {
 
             /**
              * The Google application client id to be used for interacting with
-             * a Google Calendar.
+             * a Google Calendar. Please see the docs directory for a guide on
+             * creating a calendar integration application.
+             *
+             * @type {string}
              */
-            CLIENT_ID: process.env.GOOGLE_CLIENT_ID || ''
+            CLIENT_ID: undefined
         },
 
         /**
@@ -32,33 +42,41 @@ window.JitsiMeetSpotConfig = {
          */
         OUTLOOK: {
 
-            /*
+            /**
              * The Microsoft application client id to be used for interacting
-             * with an Outlook calendar.
+             * with an Outlook calendar. Please see the docs directory for a
+             * guide on creating a calendar integration application.
+             *
+             * @type {string}
              */
-            CLIENT_ID: process.env.OUTLOOK_CLIENT_ID || ''
+            CLIENT_ID: undefined
         }
     },
 
     /**
      * The avatar image to display in the meetings list when a participant of
      * the meeting has no gravatar configured.
+     *
+     * @type {string}
      */
-    DEFAULT_AVATAR_URL: process.env.DEFAULT_AVATAR_URL
-        || 'https://meet.jit.si/images/avatar.png',
+    DEFAULT_AVATAR_URL: undefined,
 
     /**
-     * The app background image to display. An empty string will load no
-     * background image and instead display a solid color.
+     * The app background image to display. By default a solid color is
+     * displayed as the background.
+     *
+     * @type {string}
      */
-    DEFAULT_BACKGROUND_IMAGE_URL: process.env.DEFAULT_BACKGROUND_IMAGE_URL
-        || '',
+    DEFAULT_BACKGROUND_IMAGE_URL: undefined,
 
     /**
-     * The domain to proceed to when a meeting name is submitted with a base
-     * url.
+     * The domain to proceed to when a meeting name is submitted without a base
+     * url. This value should be set to the domain of a jitsi-meet deployment;
+     * for example, set it to "meet.jit.si."
+     *
+     * @type {string}
      */
-    DEFAULT_MEETING_DOMAIN: process.env.DEFAULT_MEETING_DOMAIN || 'meet.jit.si',
+    DEFAULT_MEETING_DOMAIN: undefined,
 
     /**
      * Configuration object related to printing, collecting, and reporting of
@@ -67,9 +85,12 @@ window.JitsiMeetSpotConfig = {
     LOGGING: {
 
         /**
-         * Currently logging is implemented to send logs to an endpoint.
+         * The URL to which to post client logs. Currently logging is only
+         * implemented to send logs to an endpoint as an array of objects.
+         *
+         * @type {string}
          */
-        ENDPOINT: process.env.LOGGING_ENDPOINT || ''
+        ENDPOINT: undefined
     },
 
     /**
@@ -80,14 +101,18 @@ window.JitsiMeetSpotConfig = {
         /**
          * The maximum frames per second the browser should be allowed to
          * capture during wired and wireless screensharing.
+         *
+         * @type {number}
          */
-        SS_MAX_FPS: process.env.SS_MAX_FPS,
+        SS_MAX_FPS: undefined,
 
         /**
          * The minumum frames per second the browser should capture during
          * wired and wireless screensharing.
+         *
+         * @type {number}
          */
-        SS_MIN_FPS: process.env.SS_MIN_FPS
+        SS_MIN_FPS: undefined
     },
 
     /**
@@ -96,30 +121,34 @@ window.JitsiMeetSpotConfig = {
     ULTRASOUND: {
 
         /**
-         * The location of the quiet-emscripten.js file necessary for
+         * The URL pathname of the quiet-emscripten.js file necessary for
          * lib-quiet-js to process ultrasound.
+         *
+         * @type {string}
          */
-        EMSCRIPTEN_PATH: process.env.ULTRASOUND_EMSCRIPTEN_PATH || '/dist/',
+        EMSCRIPTEN_PATH: undefined,
 
         /**
-         * The location of the quiet-emscriptem.js.mem file used by
+         * The URL pathname of the quiet-emscriptem.js.mem file used by
          * lib-quiet-js's emscripten.
+         *
+         * @type {string}
          */
-        MEM_INITIALIZER_PATH:
-            process.env.ULTRASOUND_MEM_INITIALIZER_PATH || '/dist/',
+        MEM_INITIALIZER_PATH: undefined,
 
         /**
          * A string to convert to regex which will be run against the user
          * agent to determine if a remote control should play ultrasound.
+         *
+         * @type {string}
          */
-        SUPPORTED_ENV_REGEX:
-            typeof process.env.ULTRASOUND_SUPPORT_ENV === 'undefined'
-                ? 'ipad'
-                : process.env.ULTRASOUND_SUPPORT_ENV,
+        SUPPORTED_ENV_REGEX: undefined,
 
         /**
          * The amount of time in milliseconds to wait until playing an
          * ultrasound message after a message has finished playing.
+         *
+         * @type {number}
          */
         TRANSMISSION_DELAY: undefined
     },
@@ -134,11 +163,10 @@ window.JitsiMeetSpotConfig = {
      * the jitsi UI.
      */
     XMPP_CONFIG: {
-        bosh: process.env.XMPP_BOSH || 'https://meet.jit.si/http-bind',
+        bosh:  undefined,
         hosts: {
-            domain: process.env.XMPP_HOSTS_DOMAIN || 'meet.jit.si',
-            muc: process.env.XMPP_HOSTS_MUC_URL
-                || 'conference.meet.jit.si'
+            domain: undefined,
+            muc: undefined
         }
     }
 };

--- a/spot-client/config.js
+++ b/spot-client/config.js
@@ -163,7 +163,7 @@ window.JitsiMeetSpotConfig = {
      * the jitsi UI.
      */
     XMPP_CONFIG: {
-        bosh:  undefined,
+        bosh: undefined,
         hosts: {
             domain: undefined,
             muc: undefined

--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -9240,6 +9240,12 @@
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
             "dev": true
         },
+        "lodash.merge": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+            "dev": true
+        },
         "lodash.mergewith": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -37,6 +37,7 @@
         "jsrsasign": "8.0.12",
         "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
         "lodash.debounce": "4.0.8",
+        "lodash.merge": "4.6.1",
         "lodash.throttle": "4.1.1",
         "md5": "2.2.1",
         "moment": "2.24.0",

--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -1,0 +1,55 @@
+/* global process */
+
+/**
+ * A version of the configuration with default values set. The dotenv plugin
+ * is used here so that during development values can be overridden easily
+ * using a .env file.
+ */
+export default {
+    ADVERTISEMENT: {
+        APP_NAME: process.env.APP_NAME || ''
+    },
+
+    CALENDARS: {
+        GOOGLE: {
+            CLIENT_ID: process.env.GOOGLE_CLIENT_ID || ''
+        },
+        OUTLOOK: {
+            CLIENT_ID: process.env.OUTLOOK_CLIENT_ID || ''
+        }
+    },
+
+    DEFAULT_AVATAR_URL: process.env.DEFAULT_AVATAR_URL
+        || 'https://meet.jit.si/images/avatar.png',
+
+    DEFAULT_BACKGROUND_IMAGE_URL: process.env.DEFAULT_BACKGROUND_IMAGE_URL
+        || '',
+
+    DEFAULT_MEETING_DOMAIN: process.env.DEFAULT_MEETING_DOMAIN || 'meet.jit.si',
+
+    LOGGING: {
+        ENDPOINT: process.env.LOGGING_ENDPOINT || ''
+    },
+
+    MEDIA: {
+        SS_MAX_FPS: process.env.SS_MAX_FPS || 60,
+        SS_MIN_FPS: process.env.SS_MIN_FPS || 5
+    },
+
+    ULTRASOUND: {
+        EMSCRIPTEN_PATH: process.env.ULTRASOUND_EMSCRIPTEN_PATH || '/dist/',
+        MEM_INITIALIZER_PATH:
+            process.env.ULTRASOUND_MEM_INITIALIZER_PATH || '/dist/',
+        SUPPORTED_ENV_REGEX: process.env.ULTRASOUND_SUPPORT_ENV || 'ipad',
+        TRANSMISSION_DELAY: undefined
+    },
+
+    XMPP_CONFIG: {
+        bosh: process.env.XMPP_BOSH || 'https://meet.jit.si/http-bind',
+        hosts: {
+            domain: process.env.XMPP_HOSTS_DOMAIN || 'meet.jit.si',
+            muc: process.env.XMPP_HOSTS_MUC_URL
+                || 'conference.meet.jit.si'
+        }
+    }
+};

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -61,8 +61,8 @@ export function getDefaultMeetingDomain(state) {
  */
 export function getDesktopSharingFramerate(state) {
     return {
-        max: state.config.MEDIA.SS_MAX_FPS || 60,
-        min: state.config.MEDIA.SS_MIN_FPS || 5
+        max: state.config.MEDIA.SS_MAX_FPS,
+        min: state.config.MEDIA.SS_MIN_FPS
     };
 }
 

--- a/spot-client/src/common/app-state/config/set-default-values.js
+++ b/spot-client/src/common/app-state/config/set-default-values.js
@@ -1,0 +1,15 @@
+import merge from 'lodash.merge';
+
+import defaultConfig from './default-config';
+
+/**
+ * Creates a new config object with the {@code defaultConfig} as a base, with
+ * values overridden by the passed in {@code config}.
+ *
+ * @param {Object} config - The config which should override the default config.
+ * @returns {Object} A new version of {@code defaultConfig} but with overrides
+ * set.
+ */
+export function setDefaultValues(config) {
+    return merge({}, defaultConfig, config);
+}

--- a/spot-client/src/common/app-state/index.js
+++ b/spot-client/src/common/app-state/index.js
@@ -30,3 +30,5 @@ export * from './notifications/selectors';
 export * from './setup/selectors';
 export * from './spot-tv/selectors';
 export * from './wired-screenshare/selectors';
+
+export * from './config/set-default-values';

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -9,7 +9,8 @@ import { globalDebugger } from 'common/debugging';
 import { LoggingService } from 'common/logger';
 import reducers, {
     getDesktopSharingFramerate,
-    getLoggingEndpoint
+    getLoggingEndpoint,
+    setDefaultValues
 } from 'common/app-state';
 import {
     RemoteControlServiceSubscriber,
@@ -29,7 +30,7 @@ const store = createStore(
     reducers,
     {
         config: {
-            ...window.JitsiMeetSpotConfig
+            ...setDefaultValues(window.JitsiMeetSpotConfig)
         },
         ...getPersistedState()
 

--- a/spot-client/webpack.config.js
+++ b/spot-client/webpack.config.js
@@ -10,7 +10,7 @@ const webpack = require('webpack');
 const mode = process.env.NODE_ENV === 'production'
     ? 'production' : 'development';
 
-const app = {
+module.exports = {
     devServer: {
         compress: true,
         contentBase: path.join(__dirname, '/'),
@@ -74,10 +74,17 @@ const app = {
             {
                 from: './static',
                 to: '.'
+            },
+            {
+                from: './config.js',
+                to: './config'
             }
         ]),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+        }),
+        new Dotenv({
+            systemvars: true // Respect existing environment variables
         }),
         new WriteFilePlugin()
     ],
@@ -92,20 +99,3 @@ const app = {
         ]
     }
 };
-
-const config = {
-    entry: './config',
-    mode,
-    output: {
-        filename: 'config.js',
-        path: path.resolve(__dirname, 'dist/config')
-    },
-    plugins: [
-        new Dotenv({
-            systemvars: true // Respect existing environment variables
-        }),
-        new WriteFilePlugin()
-    ]
-};
-
-module.exports = [ app, config ];


### PR DESCRIPTION
config used to be part of the main spot-client
app but was moved out for easier overriding
during deployment--better mirroring jitsi-meet's
deployment assumptions. Processing config
through webpack to support dotenv makes the
config output file harder to read. So, convert
config.js to an overrides file and put all
defaults and overrides into spot-client.