### PR TITLE
feat: enable TURN

### DIFF
--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -449,6 +449,11 @@ class RemoteControlService {
                 this._wirelessScreensharingConfiguration || {},
 
             /**
+             * The {@code JitsiConnection} instance will be used to fetch TURN credentials.
+             */
+            jitsiConnection: this.xmppConnection.getJitsiConnection(),
+
+            /**
              * Callback invoked when the connection has been closed
              * automatically. Triggers cleanup of {@code ScreenshareService}.
              *

--- a/spot-client/src/common/remote-control/screenshare-connection.js
+++ b/spot-client/src/common/remote-control/screenshare-connection.js
@@ -10,6 +10,8 @@ export default class ScreenshareConnection {
      * Initializes a new {@code ScreenshareConnection} instance.
      *
      * @param {Object} options - Configuration to initialize with.
+     * @param {JitsiConnection} options.jitsiConnection - The JitsiConnection instance which will be
+     * used to fetch TURN credentials.
      * @param {Object} options.mediaConfiguration - Describes how the desktop
      * sharing source should be captured.
      * @param {Object} options.mediaConfiguration.desktopSharingFrameRate - The
@@ -44,6 +46,7 @@ export default class ScreenshareConnection {
 
         this._proxyConnectionService
             = new JitsiMeetJS.ProxyConnectionService({
+                jitsiConnection: options.jitsiConnection,
                 onConnectionClosed: () => this.options.onConnectionClosed(),
                 onSendMessage: (to, data) => this.options.sendMessage(to, data),
                 onRemoteStream() { /** no-op */ }

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -68,6 +68,9 @@ export default class XmppConnection {
             null,
             null,
             {
+                p2p: {
+                    useStunTurn: true
+                },
                 ...this.options.configuration,
                 bosh:
                     `${this.options.configuration.bosh}?room=${roomName}`
@@ -354,6 +357,15 @@ export default class XmppConnection {
         this.room.connection.send(ack);
 
         return true;
+    }
+
+    /**
+     * Returns the underlying {@link JitsiConnection} instance.
+     *
+     * @returns {JitsiMeetJS.JitsiConnection}
+     */
+    getJitsiConnection() {
+        return this.xmppConnection;
     }
 
     /**


### PR DESCRIPTION
Will pass JitsiConnection to the ProxyConnectionService, so that it can use it to fetch the TURN credentials from Prosody. Those will be used in the P2P screensharing connection.