### PR TITLE
ref(admin): let wired screenshare selection be changeable

### DIFF
--- a/spot-client/src/common/css/temp.scss
+++ b/spot-client/src/common/css/temp.scss
@@ -208,7 +208,7 @@ body.using-mouse :focus {
   background-color: white;
   border-radius: 25px;
   height: 100%;
-  overflow: hidden;
+  overflow: scroll;
   padding: 40px;
   width: 100%;
 }

--- a/spot-client/src/spot-tv/ui/components/setup/index.js
+++ b/spot-client/src/spot-tv/ui/components/setup/index.js
@@ -1,1 +1,2 @@
+export { default as ScreenshareInput } from './screenshare-input';
 export { default as Setup } from './setup';

--- a/spot-client/src/spot-tv/ui/components/setup/screenshare-input.js
+++ b/spot-client/src/spot-tv/ui/components/setup/screenshare-input.js
@@ -83,11 +83,15 @@ class ScreenshareInput extends React.Component {
                     Select screenshare input
                 </div>
                 <div>Please ensure no device is connected to the input</div>
-                <div className = 'setup-content'>
+                <div
+                    className = 'setup-content'
+                    data-qa-id = 'screenshare-input-devices'>
                     { this._renderDeviceList() }
                 </div>
                 <div className = 'setup-buttons'>
-                    <Button onClick = { this._onSkip }>
+                    <Button
+                        data-qa-id = 'screenshare-input-skip'
+                        onClick = { this._onSkip }>
                         Skip
                     </Button>
                 </div>
@@ -131,6 +135,7 @@ class ScreenshareInput extends React.Component {
     _renderDeviceList() {
         return this.state.devices.map(device => (
             <Button
+                className = 'screenshare-input-selection'
                 key = { device.deviceId }
 
                 // eslint-disable-next-line react/jsx-no-bind

--- a/spot-client/src/spot-tv/ui/views/admin.js
+++ b/spot-client/src/spot-tv/ui/views/admin.js
@@ -7,33 +7,113 @@ import { ROUTES } from 'common/routing';
 import {
     CalendarStatus,
     InMeetingConfig,
+    ScreenshareInput,
     ScreenshareStatus
 } from './../components';
 
 /**
  * A component for providing post-setup Spot configuration.
  *
- * @returns {ReactElement}
+ * @extends React.Component
  */
-export default function AdminView() {
-    return (
-        <div className = 'container'>
-            <div className = 'admin'>
-                <CalendarStatus />
-                <ScreenshareStatus />
-                <ResetState />
-                <InMeetingConfig />
-                <div>
-                    <Link to = { ROUTES.SETUP }>
-                        <Button>Setup</Button>
-                    </Link>
-                </div>
-                <div>
-                    <Link to = { ROUTES.HOME }>
-                        <Button>Done</Button>
-                    </Link>
+export default class AdminView extends React.Component {
+    /**
+     * Initializes a new {@code AdminView} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            view: 'all'
+        };
+
+        this._onChangeScreenshareInput
+            = this._onChangeScreenshareInput.bind(this);
+        this._onShowAllOptions = this._onShowAllOptions.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <div className = 'container'>
+                <div className = 'admin'>
+                    { this._renderSubcomponent() }
                 </div>
             </div>
-        </div>
-    );
+        );
+    }
+
+    /**
+     * Returns the contents that should be displayed.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderSubcomponent() {
+        switch (this.state.view) {
+        case 'screenshare-input':
+            return <ScreenshareInput onSuccess = { this._onShowAllOptions } />;
+        case 'all':
+        default:
+            return (
+                <>
+                    <CalendarStatus />
+                    <div>
+                        <div className = 'admin-title'>Screenshare Input</div>
+                        <ScreenshareStatus />
+                        <Button
+                            data-qa-id = 'admin-change-screenshare'
+                            onClick = { this._onChangeScreenshareInput }>
+                            Change
+                        </Button>
+                    </div>
+                    <ResetState />
+                    <InMeetingConfig />
+                    <div>
+                        <div className = 'admin-title'>Setup Wizard</div>
+                        <Link to = { ROUTES.SETUP }>
+                            <Button>Start wizard</Button>
+                        </Link>
+                    </div>
+                    <div>
+                        <div className = 'admin-title'>Exit Admin Tools</div>
+                        <Link to = { ROUTES.HOME }>
+                            <Button data-qa-id = 'admin-exit'>
+                                Exit
+                            </Button>
+                        </Link>
+                    </div>
+                </>
+            );
+        }
+    }
+
+    /**
+     * Displays the view for selecting a wired screensharing input device.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onChangeScreenshareInput() {
+        this.setState({ view: 'screenshare-input' });
+    }
+
+    /**
+     * Displays the main admin view for a summary of the current Spot-TV
+     * configuration.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onShowAllOptions() {
+        this.setState({ view: 'all' });
+    }
 }


### PR DESCRIPTION
Note that there are no UI/UX designs for this section. What's there has been the placeholder designs for over a year now but I still see the admin functionality being useful. The current usage will be for the selenium tests to configure a wired screenshare dongle to get the full screensharing UX.