### PR TITLE
feat(tests): basic wireless screensharing flows

### DIFF
--- a/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
+++ b/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
@@ -174,7 +174,8 @@ export class ScreensharePicker extends React.Component {
                         className = 'screenshare'
                         iconName = 'wireless_screen_share'
                         label = 'Wireless Screensharing'
-                        onClick = { this._onShowStartWireless } />
+                        onClick = { this._onShowStartWireless }
+                        qaId = 'start-wireless-screenshare' />
                     { this.props.wiredScreenshareEnabled
                         && (
                             <NavButton

--- a/spot-client/src/spot-tv/ui/components/admin/settings-button.js
+++ b/spot-client/src/spot-tv/ui/components/admin/settings-button.js
@@ -16,7 +16,11 @@ class SettingsButton extends React.Component {
         return (
             <div className = 'cog'>
                 <Link to = { ROUTES.ADMIN } >
-                    <i className = 'material-icons'>settings</i>
+                    <i
+                        className = 'material-icons'
+                        data-qa-id = 'admin-settings'>
+                        settings
+                    </i>
                 </Link>
             </div>
         );

--- a/spot-webdriver/constants/index.js
+++ b/spot-webdriver/constants/index.js
@@ -1,6 +1,16 @@
 const TEST_SERVER_URL = process.env.TEST_SERVER_URL || 'http://localhost:8000';
 
 module.exports = {
+    /**
+     * The name of the video file which should be used by Chrome as the video
+     * to display while using a fake camera.
+     */
+    FAKE_SCREENSHARE_FILE_NAME: 'static-image.y4m',
+
+    /**
+     * The direct URL to visit to start the flow for becoming a Spot-Remote for
+     * a Spot-TV.
+     */
     JOIN_CODE_ENTRY_URL: TEST_SERVER_URL,
 
     /**
@@ -15,5 +25,13 @@ module.exports = {
      */
     REMOTE_COMMAND_WAIT: 5000,
 
-    SPOT_URL: `${TEST_SERVER_URL}/spot`
+    /**
+     * The direct URL to visit to for a browser to act as a Spot-TV.
+     */
+    SPOT_URL: `${TEST_SERVER_URL}/spot`,
+
+    /**
+     * The direct URL to visit to display the configuration for Spot-TV.
+     */
+    SPOT_TV_ADMIN_URL: `${TEST_SERVER_URL}/admin`
 };

--- a/spot-webdriver/page-objects/admin-page.js
+++ b/spot-webdriver/page-objects/admin-page.js
@@ -1,0 +1,72 @@
+const constants = require('../constants');
+const PageObject = require('./page-object');
+
+const ADMIN_VIEW = '[data-qa-id=admin-view]';
+const CHANGE_SCREENSHARE_BUTTON = '[data-qa-id=admin-change-screenshare]';
+const EXIT_BUTTON = '[data-qa-id=admin-exit]';
+const SCREENSHARE_DEVICE_LIST = '[data-qa-id=screenshare-input-devices]';
+const SCREENSHARE_DEVICE_SKIP = '[data-qa-id=screenshare-input-skip]';
+
+/**
+ * A page object for interacting with the admin configuration view of a Spot-TV.
+ */
+class AdminPage extends PageObject {
+    /**
+     * Initializes a new {@code AdminPage} instance.
+     *
+     * @inheritdoc
+     */
+    constructor(driver) {
+        super(driver);
+
+        this.rootSelector = ADMIN_VIEW;
+    }
+
+    /**
+     * Uses the UI to leave the admin view, thereby avoiding a page reload.
+     *
+     * @returns {void}
+     */
+    exit() {
+        const exitButton = this.waitForElementDisplayed(EXIT_BUTTON);
+
+        exitButton.click();
+    }
+
+    /**
+     * Interacts with the admin view to configure Spot-TV to use a specified
+     * device as a wired screensharing input.
+     *
+     * @param {string} deviceLabel - The name of the device. The name is matched
+     * on a partial, so a partial device label may be passed. If undefined is
+     * passed then any configured screensharing input will be unset.
+     * @returns {void}
+     */
+    setScreenshareInput(deviceLabel) {
+        const changeScreenshareButton
+            = this.waitForElementDisplayed(CHANGE_SCREENSHARE_BUTTON);
+
+        changeScreenshareButton.click();
+
+        this.waitForElementDisplayed(SCREENSHARE_DEVICE_LIST);
+
+        const screenshareInputButtonSelector = deviceLabel
+            ? `button*=${deviceLabel}` : SCREENSHARE_DEVICE_SKIP;
+        const button = this.driver.$(screenshareInputButtonSelector);
+
+        button.waitForDisplayed();
+        button.click();
+    }
+
+    /**
+     * Proceeds directly to the admin view of a Spot-TV.
+     *
+     * @returns {void}
+     */
+    visit() {
+        this.driver.url(constants.SPOT_TV_ADMIN_URL);
+        this.waitForVisible();
+    }
+}
+
+module.exports = AdminPage;

--- a/spot-webdriver/page-objects/calendar-page.js
+++ b/spot-webdriver/page-objects/calendar-page.js
@@ -2,11 +2,12 @@ const constants = require('../constants');
 const MeetingInput = require('./meeting-input');
 const PageObject = require('./page-object');
 
+const ADMIN_SETTINGS_BUTTON = '[data-qa-id=admin-settings]';
 const CALENDAR_VIEW = '[data-qa-id=home-view]';
 const JOIN_CODE = '[data-qa-id=join-info]';
 
 /**
- * A page object for interacting with the calendar view of Spot.
+ * A page object for interacting with the calendar view of Spot-TV.
  */
 class CalendarPage extends PageObject {
     /**
@@ -22,7 +23,7 @@ class CalendarPage extends PageObject {
     }
 
     /**
-     * Scrapes the join code necessary for a remote control to connect to Spot.
+     * Scrapes the join code necessary for a Spot-Remote to connect to Spot-TV.
      *
      * @returns {string}
      */
@@ -35,28 +36,27 @@ class CalendarPage extends PageObject {
     }
 
     /**
-     * Proceeds directly to the calendar view of Spot.
+     * Interacts with the UI to visit the admin configuration view of Spot-TV.
+     *
+     * @returns {void}
+     */
+    goToAdminPage() {
+        const adminSettingsButtons = this.driver.$(ADMIN_SETTINGS_BUTTON);
+
+        adminSettingsButtons.waitForExist();
+        adminSettingsButtons.moveTo();
+        adminSettingsButtons.waitForDisplayed();
+        adminSettingsButtons.click();
+    }
+
+    /**
+     * Proceeds directly to the calendar view of Spot-TV.
      *
      * @returns {void}
      */
     visit() {
         this.driver.url(constants.SPOT_URL);
         this.waitForVisible();
-    }
-
-    /**
-     * Compares the currently opened tab ids with an array of tab ids and
-     * returns the difference.
-     *
-     * @param {Array<string>} previousTabIds - The old tab ids to compare
-     * against to calculate which of the current tabs are new.
-     * @private
-     * @returns {Array<string>}
-     */
-    _getNewTabIds(previousTabIds) {
-        const currentTabIds = this.driver.getTabIds();
-
-        return currentTabIds.filter(id => !previousTabIds.includes(id));
     }
 }
 

--- a/spot-webdriver/page-objects/remote-control-page.js
+++ b/spot-webdriver/page-objects/remote-control-page.js
@@ -1,5 +1,6 @@
 const MeetingInput = require('./meeting-input');
 const PageObject = require('./page-object');
+const ScreensharePicker = require('./screenshare-picker');
 
 const MEET_NOW_BUTTON = '[data-qa-id=meet-now]';
 const REMOTE_CONTROL = '[data-qa-id=remoteControl-view]';
@@ -18,6 +19,8 @@ class RemoteControlPage extends PageObject {
         super(driver);
 
         this.meetingInput = new MeetingInput(this.driver);
+        this.screensharePicker = new ScreensharePicker(this.driver);
+
         this.rootSelector = REMOTE_CONTROL;
     }
 
@@ -35,12 +38,24 @@ class RemoteControlPage extends PageObject {
     }
 
     /**
+     * Begins the wireless screensharing flow for when there is both wireless
+     * and wired screensharing enabled.
+     *
+     * @returns {void}
+     */
+    startWirelessScreenshareWithPicker() {
+        this.startWirelessScreenshareWithoutPicker();
+
+        this.screensharePicker.startWirelessScreenshare();
+    }
+
+    /**
      * Begins the wireless screensharing flow for when there is only wireless
      * screensharing enabled.
      *
      * @returns {void}
      */
-    startWirelessScreenshare() {
+    startWirelessScreenshareWithoutPicker() {
         const shareContentButton = this.waitForElementDisplayed(SHARE_CONTENT_BUTTON);
 
         shareContentButton.click(SHARE_CONTENT_BUTTON);

--- a/spot-webdriver/page-objects/screenshare-picker.js
+++ b/spot-webdriver/page-objects/screenshare-picker.js
@@ -1,0 +1,49 @@
+const PageObject = require('./page-object');
+
+const SCREENSHARE_PICKER = '[data-qa-id=screenshare-picker]';
+const START_WIRELESS_SCREENSHARE = '[data-qa-id=start-wireless-screenshare]';
+const STOP_SHARE_CONFIRM = '[data-qa-id=stop-share-button]';
+
+/**
+ * A page object for interacting with the UI for starting wired or wireless
+ * screensharing.
+ */
+class ScreensharePicker extends PageObject {
+    /**
+     * Initializes a new {@code ScreensharePicker} instance.
+     *
+     * @inheritdoc
+     */
+    constructor(driver) {
+        super(driver);
+
+        this.rootSelector = SCREENSHARE_PICKER;
+    }
+
+    /**
+     * Clicks the button to show the desktop picker for starting a wireless
+     * screenshare.
+     *
+     * @returns {void}
+     */
+    startWirelessScreenshare() {
+        const startWirelessScreenshareButton
+            = this.waitForElementDisplayed(START_WIRELESS_SCREENSHARE);
+
+        startWirelessScreenshareButton.click();
+    }
+
+    /**
+     * Clicks the button to stop any screenshare in progress.
+     *
+     * @returns {void}
+     */
+    stopScreensharing() {
+        const stopShareButton
+            = this.waitForElementDisplayed(STOP_SHARE_CONFIRM);
+
+        stopShareButton.click();
+    }
+}
+
+module.exports = ScreensharePicker;

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -1,15 +1,15 @@
 const constants = require('../constants');
 const PageObject = require('./page-object');
+const ScreensharePicker = require('./screenshare-picker');
 
 const AUDIO_MUTE_BUTTON = '[data-qa-id=mute-audio]';
 const AUDIO_UNMUTE_BUTTON = '[data-qa-id=unmute-audio]';
 const REMOTE_CONTROL = '[data-qa-id=remoteControl-view]';
-const SHARE_PICKER = '[data-qa-id=screenshare-picker]';
 const START_SHARE_BUTTON = '[data-qa-id=start-share]';
 const STOP_SHARE_BUTTON = '[data-qa-id=stop-share]';
-const STOP_SHARE_CONFIRM = '[data-qa-id=stop-share-button]';
 const VIDEO_MUTE_BUTTON = '[data-qa-id=mute-video]';
 const VIDEO_UNMUTE_BUTTON = '[data-qa-id=unmute-video]';
+
 
 /**
  * A page object for interacting with the in meeting view of Spot-Remote.
@@ -22,6 +22,8 @@ class SpotRemoteInMeetingPage extends PageObject {
      */
     constructor(driver) {
         super(driver);
+
+        this.screensharePicker = new ScreensharePicker(this.driver);
 
         this.rootSelector = REMOTE_CONTROL;
     }
@@ -48,6 +50,29 @@ class SpotRemoteInMeetingPage extends PageObject {
         this.select(VIDEO_MUTE_BUTTON).click();
     }
 
+    /*
+     * Begins the wireless screensharing flow for when there is both wireless
+     * and wired screensharing enabled.
+     *
+     * @returns {void}
+     */
+    startWirelessScreenshareWithPicker() {
+        this.startWirelessScreenshareWithoutPicker();
+        this.screensharePicker.startWirelessScreenshare();
+    }
+
+    /**
+     * Begins the wireless screensharing flow for when there is only wireless
+     * screensharing enabled.
+     *
+     * @returns {void}
+     */
+    startWirelessScreenshareWithoutPicker() {
+        this.waitForScreensharingStateToBe(false);
+
+        this.select(START_SHARE_BUTTON).click();
+    }
+
     /**
      * Turns off the current screenshare.
      *
@@ -58,9 +83,7 @@ class SpotRemoteInMeetingPage extends PageObject {
 
         this.select(STOP_SHARE_BUTTON).click();
 
-        this.waitForSharePicker();
-
-        this.select(STOP_SHARE_CONFIRM).click();
+        this.screensharePicker.stopScreensharing();
     }
 
     /**

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -50,7 +50,7 @@ class SpotRemoteInMeetingPage extends PageObject {
         this.select(VIDEO_MUTE_BUTTON).click();
     }
 
-    /*
+    /**
      * Begins the wireless screensharing flow for when there is both wireless
      * and wired screensharing enabled.
      *
@@ -142,16 +142,6 @@ class SpotRemoteInMeetingPage extends PageObject {
                 waitTime: constants.REMOTE_COMMAND_WAIT
 
             });
-    }
-
-    /**
-     * Waits for the component for screenshare interaction confirmation to be
-     * displayed.
-     *
-     * @returns {void}
-     */
-    waitForSharePicker() {
-        this.waitForElementDisplayed(SHARE_PICKER);
     }
 
     /**

--- a/spot-webdriver/specs/helpers/global-after-each.js
+++ b/spot-webdriver/specs/helpers/global-after-each.js
@@ -1,0 +1,4 @@
+afterEach(() => {
+    // Delete all persisted app state.
+    browser.deleteLocalStorageItem('spot');
+});

--- a/spot-webdriver/specs/wireless-screenshare.spec.js
+++ b/spot-webdriver/specs/wireless-screenshare.spec.js
@@ -1,3 +1,5 @@
+const constants = require('../constants');
+
 const SpotSession = require('../user/spot-session');
 
 describe('A Spot-Remote can screenshare wirelessly', () => {
@@ -6,28 +8,101 @@ describe('A Spot-Remote can screenshare wirelessly', () => {
     const spotRemote = userFactory.getSpotRemote();
     const spotSession = new SpotSession(spotTV, spotRemote);
 
+    /**
+     * Goes through the flow for starting a wireless screenshare session
+     * starting from the Spot-Remote Waiting-For-Call view.
+     *
+     * @param {boolean} isPickerExpected - Whether or not a screenshare picker
+     * will display when starting wireless screensharing.
+     * @private
+     * @returns {void}
+     */
+    function startScreenshareFromHome(isPickerExpected) {
+        const remoteControlPage = spotRemote.getRemoteControlPage();
+
+        remoteControlPage.waitForVisible();
+
+        if (isPickerExpected) {
+            remoteControlPage.startWirelessScreenshareWithPicker();
+        } else {
+            remoteControlPage.startWirelessScreenshareWithoutPicker();
+        }
+
+        const meetingPage = spotTV.getMeetingPage();
+
+        meetingPage.waitForVisible();
+        meetingPage.waitForMeetingJoined();
+
+        const inMeetingPage = spotRemote.getInMeetingPage();
+
+        inMeetingPage.waitForScreensharingStateToBe(true);
+        inMeetingPage.stopScreensharing();
+        inMeetingPage.waitForScreensharingStateToBe(false);
+    }
+
+    /**
+     * Goes through the flow for starting a wireless screenshare session
+     * starting from the Spot-Remote in the call view.
+     *
+     * @param {boolean} isPickerExpected - Whether or not a screenshare picker
+     * will display when starting wireless screensharing.
+     * @private
+     * @returns {void}
+     */
+    function startScreenshareFromMeeting(isPickerExpected) {
+        const remoteControlPage = spotRemote.getRemoteControlPage();
+        const meetingInput = remoteControlPage.getMeetingInput();
+
+        meetingInput.submitMeetingName();
+
+        const meetingPage = spotTV.getMeetingPage();
+
+        meetingPage.waitForVisible();
+
+        const inMeetingPage = spotRemote.getInMeetingPage();
+
+        if (isPickerExpected) {
+            inMeetingPage.startWirelessScreenshareWithPicker();
+        } else {
+            inMeetingPage.startWirelessScreenshareWithoutPicker();
+        }
+
+        inMeetingPage.waitForScreensharingStateToBe(true);
+    }
+
     beforeEach(() => {
         spotSession.connectRemoteToTV();
     });
 
     describe('with no wired screenshare setup', () => {
         it('from the waiting screen', () => {
-            const remoteControlPage = spotRemote.getRemoteControlPage();
+            startScreenshareFromHome(false);
+        });
 
-            remoteControlPage.waitForVisible();
+        it('from in a call', () => {
+            startScreenshareFromMeeting(false);
+        });
+    });
 
-            remoteControlPage.startWirelessScreenshare();
+    describe('with wired screenshare set up', () => {
+        beforeEach(() => {
+            // Ensure wired screensharing is set up.
+            const calendarPage = spotTV.getCalendarPage();
 
-            const meetingPage = spotTV.getMeetingPage();
+            calendarPage.goToAdminPage();
 
-            meetingPage.waitForVisible();
-            meetingPage.waitForMeetingJoined();
+            const adminPage = spotTV.getAdminPage();
 
-            const inMeetingPage = spotRemote.getInMeetingPage();
+            adminPage.setScreenshareInput(constants.FAKE_SCREENSHARE_FILE_NAME);
+            adminPage.exit();
+        });
 
-            inMeetingPage.waitForScreensharingStateToBe(true);
-            inMeetingPage.stopScreensharing();
-            inMeetingPage.waitForScreensharingStateToBe(false);
+        it('from the waiting screen', () => {
+            startScreenshareFromHome(true);
+        });
+
+        it('from in a call', () => {
+            startScreenshareFromMeeting(true);
         });
     });
 });

--- a/spot-webdriver/user/spot-tv-user.js
+++ b/spot-webdriver/user/spot-tv-user.js
@@ -41,8 +41,8 @@ class SpotTV {
     }
 
     /**
-     * Waits for the meeting page to be displayed and obtains the name of the meeting that this Spot
-     * TV instance is currently in.
+     * Waits for the meeting page to be displayed and obtains the name of the
+     * meeting that this Spot-TV instance is currently in.
      *
      * @returns {string}
      */

--- a/spot-webdriver/user/spot-tv-user.js
+++ b/spot-webdriver/user/spot-tv-user.js
@@ -1,3 +1,4 @@
+const AdminPage = require('../page-objects/admin-page');
 const CalendarPage = require('../page-objects/calendar-page');
 const MeetingPage = require('../page-objects/meeting-page');
 
@@ -14,13 +15,24 @@ class SpotTV {
     constructor(driver) {
         this.driver = driver;
 
+        this.adminPage = new AdminPage(this.driver);
         this.calendarPage = new CalendarPage(this.driver);
         this.meetingPage = new MeetingPage(this.driver);
     }
 
     /**
+     * Returns an instance of {@code Admin} which wraps interactions with
+     * the admin view in Spot-TV.
+     *
+     * @returns {CalendarPage}
+     */
+    getAdminPage() {
+        return this.adminPage;
+    }
+
+    /**
      * Returns an instance of {@code CalendarPage} which wraps interactions with
-     * the calendar view in Spot.
+     * the calendar view in Spot-TV.
      *
      * @returns {CalendarPage}
      */
@@ -44,7 +56,7 @@ class SpotTV {
 
     /**
      * Returns an instance of {@code MeetingPage} which wraps interactions with
-     * the in-meeting view in Spot.
+     * the in-meeting view in Spot-TV.
      *
      * @returns {MeetingPage}
      */

--- a/spot-webdriver/wdio.conf.js
+++ b/spot-webdriver/wdio.conf.js
@@ -3,12 +3,14 @@
 const path = require('path');
 const screen = require('screen-info');
 
+const constants = require('./constants');
+
 const DESKTOP_SOURCE_NAME
     = screen.all().length > 1 ? 'Screen 1' : 'Entire screen';
 
 const LOG_LEVEL = process.env.LOG_LEVEL || 'warn';
 const PATH_TO_FAKE_VIDEO
-    = path.resolve(__dirname, 'resources/static-image.y4m');
+    = path.resolve(__dirname, 'resources', constants.FAKE_SCREENSHARE_FILE_NAME);
 
 exports.config = {
     // How many fails should trigger stopping the tests. Zero skips stopping.
@@ -49,7 +51,10 @@ exports.config = {
     // Use selenium-standalone to automatically download and launch selenium.
     services: [ 'selenium-standalone' ],
 
-    specs: [ path.resolve(__dirname, 'specs/*.spec.js') ],
+    specs: [
+        path.resolve(__dirname, 'specs', 'helpers', '**/*.js'),
+        path.resolve(__dirname, 'specs', '**/*.spec.js')
+    ],
 
     // Default wait time for all webdriverio wait-related functions.
     waitforTimeout: 10000,


### PR DESCRIPTION
- Check wireless screensharing can be started in meeting and
  out of meeting, both with wired enabled and not enabled.
- Add a global afterEach to clear persisted app state between
  tests.