### PR TITLE
fix(deps): remove extra package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Probably snuck in from an npm install done in
the wrong directory.