### PR TITLE
fix(screenshare): stop relying on screensharing boolean

### DIFF
--- a/spot-client/src/common/app-state/spot-tv/reducer.js
+++ b/spot-client/src/common/app-state/spot-tv/reducer.js
@@ -8,8 +8,7 @@ const DEFAULT_STATE = {
     audioMuted: true,
     inMeeting: undefined,
     joinCode: null,
-    screensharing: false,
-    screensharingType: '',
+    screensharingType: undefined,
     spotId: null,
     videoMuted: true,
     view: null

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -18,7 +18,6 @@ export function getInMeetingStatus(state) {
     return {
         audioMuted: state.spotTv.audioMuted,
         inMeeting: state.spotTv.inMeeting,
-        screensharing: state.spotTv.screensharing,
         screensharingType: state.spotTv.screensharingType,
         videoMuted: state.spotTv.videoMuted,
         wiredScreensharingEnabled:

--- a/spot-client/src/spot-remote/ui/components/remote-control-menu/remote-control-menu.js
+++ b/spot-client/src/spot-remote/ui/components/remote-control-menu/remote-control-menu.js
@@ -13,7 +13,6 @@ export default class RemoteControlMenu extends React.Component {
         audioMuted: PropTypes.bool,
         onToggleScreenshare: PropTypes.func,
         remoteControlService: PropTypes.object,
-        screensharing: PropTypes.bool,
         screensharingEnabled: PropTypes.bool,
         videoMuted: PropTypes.bool
     };

--- a/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
+++ b/spot-client/src/spot-remote/ui/components/remote-control-menu/screenshare-picker.js
@@ -19,14 +19,6 @@ export class ScreensharePicker extends React.Component {
         onStartWiredScreenshare: PropTypes.func,
         onStartWirelessScreenshare: PropTypes.func,
         onStopScreensharing: PropTypes.func,
-
-        /**
-         * Generally if screensharingType is defined, then screensharing should
-         * be true. However, screensharing may be true while there is not type
-         * (currently due to jitsi-meet changes not being deployed). So rely on
-         * both to show the proper view.
-         */
-        screensharing: PropTypes.bool,
         screensharingType: PropTypes.string,
         wiredScreenshareEnabled: PropTypes.bool,
         wirelessScreenshareEnabled: PropTypes.bool
@@ -39,7 +31,7 @@ export class ScreensharePicker extends React.Component {
      * @inheritdoc
      */
     static getDerivedStateFromProps(props) {
-        if (props.screensharingType || props.screensharing) {
+        if (props.screensharingType) {
             return {
                 displayWirelessInstructions: false,
                 displayWiredInstructions: false
@@ -122,7 +114,7 @@ export class ScreensharePicker extends React.Component {
      */
     _renderContent() {
         // If screensharing is enabled, show a stop screensharing view.
-        if (this.props.screensharingType || this.props.screensharing) {
+        if (this.props.screensharingType) {
             return this._renderStopShare();
         }
 

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -23,7 +23,6 @@ export class InCall extends React.Component {
         dispatch: PropTypes.func,
         inMeeting: PropTypes.string,
         remoteControlService: PropTypes.object,
-        screensharing: PropTypes.bool,
         screensharingType: PropTypes.string,
         videoMuted: PropTypes.bool,
         wiredScreensharingEnabled: PropTypes.bool
@@ -78,7 +77,6 @@ export class InCall extends React.Component {
         const {
             audioMuted,
             inMeeting,
-            screensharing,
             screensharingType,
             videoMuted,
             wiredScreensharingEnabled
@@ -113,7 +111,7 @@ export class InCall extends React.Component {
                         label = 'Share Content'
                         onClick = { this._onToggleScreenshare }
                         qaId = {
-                            screensharing ? 'stop-share' : 'start-share'
+                            screensharingType ? 'stop-share' : 'start-share'
                         }
                         subIcon = { this._renderScreenshareSubIcon() } />
                     <NavButton
@@ -131,7 +129,6 @@ export class InCall extends React.Component {
                             = { this._onStartWirelessScreenshare }
                         onStopScreensharing
                             = { this._onStopScreenshare }
-                        screensharing = { screensharing }
                         screensharingType = { screensharingType }
                         wiredScreenshareEnabled
                             = { wiredScreensharingEnabled }
@@ -185,7 +182,7 @@ export class InCall extends React.Component {
         // screenshare occurring, then start the wireless screensharing flow.
         if (this._isWirelessScreenshareSupported
             && !this.props.wiredScreensharingEnabled
-            && !this.props.screensharing) {
+            && !this.props.screensharingType) {
             this.props.remoteControlService.setWirelessScreensharing(true);
 
             return;
@@ -252,7 +249,7 @@ export class InCall extends React.Component {
      * @returns {ReactElement | null}
      */
     _renderScreenshareSubIcon() {
-        return this.props.screensharing
+        return this.props.screensharingType
             ? <div className = 'on-indicator' />
             : null;
     }

--- a/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
@@ -14,7 +14,6 @@ export class ScreenshareModal extends React.Component {
         onStartWiredScreenshare: PropTypes.func,
         onStartWirelessScreenshare: PropTypes.func,
         onStopScreensharing: PropTypes.func,
-        screensharing: PropTypes.bool,
         screensharingType: PropTypes.string,
         wiredScreenshareEnabled: PropTypes.bool,
         wirelessScreenshareEnabled: PropTypes.bool
@@ -45,7 +44,6 @@ export class ScreenshareModal extends React.Component {
                                 = { this.props.onStartWirelessScreenshare }
                             onStopScreensharing
                                 = { this.props.onStopScreensharing }
-                            screensharing = { this.props.screensharing }
                             screensharingType = { this.props.screensharingType }
                             wiredScreenshareEnabled
                                 = { this.props.wiredScreenshareEnabled }

--- a/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
@@ -29,7 +29,6 @@ class WaitingForCallView extends React.Component {
         events: PropTypes.array,
         onGoToMeeting: PropTypes.func,
         remoteControlService: PropTypes.object,
-        screensharing: PropTypes.bool,
         wiredScreensharingEnabled: PropTypes.bool
     };
 

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -171,7 +171,7 @@ export class MeetingFrame extends React.Component {
 
         this.props.updateSpotTvState({
             audioMuted: false,
-            screensharing: false,
+            screensharingType: undefined,
             videoMuted: false
         });
     }
@@ -440,9 +440,9 @@ export class MeetingFrame extends React.Component {
         this._maybeToggleFilmstripVisibility();
 
         this.props.updateSpotTvState({
-            screensharing: this._isScreensharing,
             screensharingType: this._isScreensharing
-                ? details.sourceType : ''
+                ? details.sourceType || 'other'
+                : undefined
         });
     }
 


### PR DESCRIPTION
There was a transitionary time when jitsi-meet only said
if screensharing was on or off and not the type of screensharing
that is currently enabled. During this time both the boolean
and screenshare type were used to determine the current spot
screenshare status. With the jitsi-meet changes deployed,
just rely on the screenshare type to know screenshare is on.