### PR TITLE
fix(vendor): init lib-jitsi-meet only for webrtc calls 

### DIFF
--- a/spot-client/src/common/media/av-utils.js
+++ b/spot-client/src/common/media/av-utils.js
@@ -1,0 +1,161 @@
+import { JitsiMeetJSProvider } from 'common/vendor';
+
+/**
+ * Encapsulates all media and media-devices related calls into one object.
+ */
+export default {
+    /**
+     * Whether or not JitsiMeetJS has had initialized called on it. Used to
+     * prevent multiple initialization calls.
+     */
+    _initialized: false,
+
+    /**
+     * Creates a new {@code JitsiLocalTrack} for a specified microphone.
+     *
+     * @param {string} micDeviceId - The device ID of the microphone which
+     * should be used to capture audio.
+     * @returns {Promise<JitsiLocalTrack>}
+     */
+    createLocalAudioTrack(micDeviceId) {
+        return this._createTracks({
+            micDeviceId,
+            devices: [ 'audio' ]
+        })
+        .then(jitsiLocalTracks => jitsiLocalTracks[0]);
+    },
+
+    /**
+     * Creates a new {@code JitsiLocalTrack} for a desktop stream with the
+     * provided media configuration.
+     *
+     * @param {Object} mediaConfiguration - Configuration for how the desktop
+     * stream should be constrained.
+     * @param {Object} mediaConfiguration.desktopSharingFrameRate - The
+     * frames per second which should be captured from the desktop sharing
+     * source. Can include a "max" and "min" key, both being numbers.
+     * @returns {Promise<JitsiLocalTrack>}
+     */
+    createLocalDesktopTrack(mediaConfiguration) {
+        return this._createTracks({
+            ...mediaConfiguration,
+            devices: [ 'desktop' ]
+        })
+        .then(jitsiLocalTracks => jitsiLocalTracks[0]);
+    },
+
+    /**
+     * Creates a new {@code JitsiLocalTrack} for audio and video.
+     *
+     * @returns {Promise<Array<JitsiLocalTrack>>}
+     */
+    createLocalTracks() {
+        return this._createTracks({ devices: [ 'audio', 'video' ] });
+    },
+
+    /**
+     * Creates a new {@code JitsiLocalTrack} for a specified camera.
+     *
+     * @param {string} cameraDeviceId - The device ID of the camera which
+     * should be used to capture video.
+     * @returns {Promise<JitsiLocalTrack>}
+     */
+    createLocalVideoTrack(cameraDeviceId) {
+        return this._createTracks({
+            cameraDeviceId,
+            devices: [ 'video' ]
+        })
+        .then(jitsiLocalTracks => jitsiLocalTracks[0]);
+    },
+
+    /**
+     * Returns a list of WebRTC-capable devices.
+     *
+     * @returns {Promise<Array>}
+     */
+    enumerateDevices() {
+        this._initializeWebRTC();
+
+        return new Promise(resolve =>
+            JitsiMeetJSProvider.get().mediaDevices.enumerateDevices(resolve));
+    },
+
+    /**
+     * Returns the enumeration of error events a {@code JitsiLocalTrack} may
+     * fire.
+     *
+     * @returns {Object}
+     */
+    getTrackErrorEvents() {
+        return JitsiMeetJSProvider.get().errors.track;
+    },
+
+    /**
+     * Returns the enumeration of events a {@code JitsiLocalTrack} may fire.
+     *
+     * @returns {Object}
+     */
+    getTrackEvents() {
+        return JitsiMeetJSProvider.get().events.track;
+    },
+
+    /**
+     * Adds a listener for when the list of connected WebRTC capable devices has
+     * changed.
+     *
+     * @param {Function} callback - Invoked when the list of connected WebRTC
+     * capable devices has changed. The list of devices will be passed in.
+     * @returns {void}
+     */
+    listenForDeviceListChanged(callback) {
+        JitsiMeetJSProvider.get().mediaDevices.addEventListener(
+            JitsiMeetJSProvider.get().events.mediaDevices.DEVICE_LIST_CHANGED,
+            callback);
+    },
+
+    /**
+     * Removes a listener for when the list of connected WebRTC capable devices
+     * has changed.
+     *
+     * @param {Function} callback - The listener which should no longer receive
+     * updates.
+     * @returns {void}
+     */
+    stopListeningForDeviceListChanged(callback) {
+        JitsiMeetJSProvider.get().mediaDevices.removeEventListener(
+            JitsiMeetJSProvider.get().events.mediaDevices.DEVICE_LIST_CHANGED,
+            callback
+        );
+    },
+
+    /**
+     * Ensures {@code JitsiMeetJS} is initialized for WebRTC related activity
+     * and calls to create a {@code JitsiLocalTrack}.
+     *
+     * @param {Object} options - The details of the how to create the track.
+     * @private
+     * @returns {void}
+     */
+    _createTracks(options) {
+        this._initializeWebRTC();
+
+        return JitsiMeetJSProvider.get().createLocalTracks(options);
+    },
+
+    /**
+     * Ensures {@code JitsiMeetJS} has been initialized so it can use WebRTC
+     * related methods.
+     *
+     * @private
+     * @returns {void}
+     */
+    _initializeWebRTC() {
+        if (this._initialized) {
+            return;
+        }
+
+        JitsiMeetJSProvider.get().init({});
+
+        this._initialized = true;
+    }
+};

--- a/spot-client/src/common/media/index.js
+++ b/spot-client/src/common/media/index.js
@@ -1,0 +1,1 @@
+export { default as avUtils } from './av-utils';

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -77,12 +77,14 @@ export default class XmppConnection {
             }
         );
 
+        const connectionEvents = JitsiMeetJS.events.connection;
+
         const connectionPromise = new Promise((resolve, reject) => {
             this.xmppConnection.addEventListener(
-                JitsiMeetJS.events.connection.CONNECTION_ESTABLISHED,
+                connectionEvents.CONNECTION_ESTABLISHED,
                 () => {
                     this.xmppConnection.addEventListener(
-                        JitsiMeetJS.events.connection.CONNECTION_FAILED,
+                        connectionEvents.CONNECTION_FAILED,
                         onDisconnect);
 
                     resolve();
@@ -90,7 +92,7 @@ export default class XmppConnection {
             );
 
             this.xmppConnection.addEventListener(
-                JitsiMeetJS.events.connection.CONNECTION_FAILED,
+                connectionEvents.CONNECTION_FAILED,
                 reject
             );
         });

--- a/spot-client/src/common/utils/detection.js
+++ b/spot-client/src/common/utils/detection.js
@@ -1,5 +1,7 @@
 import Bowser from 'bowser';
 
+import { JitsiMeetJSProvider } from 'common/vendor';
+
 const browser = Bowser.getParser(window.navigator.userAgent);
 
 /**
@@ -23,4 +25,20 @@ export function isAutoFocusSupported() {
  */
 export function isDesktopBrowser() {
     return browser.getPlatformType() === 'desktop';
+}
+
+/**
+ * Returns whether or not the current environment supports wirelessly screensharing into a Spot.
+ * Currently only Chrome works and the underlying implementation assumes getDisplayMedia is
+ * available.
+ *
+ * @private
+ * @returns {boolean}
+ */
+export function isWirelessScreenshareSupported() {
+    const jitsiBrowserDetection = JitsiMeetJSProvider.get().util.browser;
+
+    return (jitsiBrowserDetection.isChrome()
+        && jitsiBrowserDetection.supportsGetDisplayMedia())
+        || jitsiBrowserDetection.isElectron();
 }

--- a/spot-client/src/common/vendor/jitsi-meet-js-provider.js
+++ b/spot-client/src/common/vendor/jitsi-meet-js-provider.js
@@ -1,35 +1,15 @@
 /* global JitsiMeetJS */
 
 /**
+ * Prevent JitsiMeetJS from spamming the console.
+ */
+JitsiMeetJS.setLogLevel('error');
+
+/**
  * A wrapper around the global JitsiMeetJS, as loaded by lib-jitsi-meet.
  */
 export default {
     get() {
-        if (this._jitsiMeetJS) {
-            return this._jitsiMeetJS;
-        }
-
-        JitsiMeetJS.init({});
-        JitsiMeetJS.setLogLevel('error');
-
-        this._jitsiMeetJS = window.JitsiMeetJS;
-
-        return this._jitsiMeetJS;
-    },
-
-    /**
-     * Returns whether or not the current environment supports wirelessly screensharing into a Spot.
-     * Currently only Chrome works and the underlying implementation assumes getDisplayMedia is
-     * available.
-     *
-     * @private
-     * @returns {boolean}
-     */
-    isWirelessScreenshareSupported() {
-        const JitsiMeetJS = this.get();
-
-        return (JitsiMeetJS.util.browser.isChrome()
-            && JitsiMeetJS.util.browser.supportsGetDisplayMedia())
-            || JitsiMeetJS.util.browser.isElectron();
+        return window.JitsiMeetJS;
     }
 };

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -4,12 +4,11 @@ import { connect } from 'react-redux';
 
 import { getInMeetingStatus } from 'common/app-state';
 import { LoadingIcon } from 'common/ui';
-import { parseMeetingUrl } from 'common/utils';
+import { isWirelessScreenshareSupported, parseMeetingUrl } from 'common/utils';
 
 import { NavButton, NavContainer } from '../../components';
 
 import ScreenshareModal from './screenshare-modal';
-import { JitsiMeetJSProvider } from 'common/vendor';
 
 /**
  * A view for displaying ways to interact with the Spot while Spot is in a
@@ -41,9 +40,7 @@ export class InCall extends React.Component {
             showScreenshareModal: false
         };
 
-        this._isWirelessScreenshareSupported
-            = JitsiMeetJSProvider.isWirelessScreenshareSupported();
-
+        this._isWirelessScreenshareSupported = isWirelessScreenshareSupported();
         this._onCloseScreenshareModal
             = this._onCloseScreenshareModal.bind(this);
         this._onHangUp = this._onHangUp.bind(this);

--- a/spot-client/src/spot-tv/ui/components/setup/select-media/camera-preview.js
+++ b/spot-client/src/spot-tv/ui/components/setup/select-media/camera-preview.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { JitsiMeetJSProvider } from 'common/vendor';
+import { avUtils } from 'common/media';
 
 /**
  * Displays a video element previewing the selected video input device.
@@ -79,21 +79,18 @@ export default class CameraPreview extends React.PureComponent {
 
         const description = this.props.devices.find(device =>
             device.label === this.props.label);
-        const JitsiMeetJS = JitsiMeetJSProvider.get();
 
         if (!description) {
             return;
         }
 
-        JitsiMeetJS.createLocalTracks({
-            cameraDeviceId: description.deviceId,
-            devices: [ 'video' ]
-        }).then(jitsiLocalTracks => {
-            this._previewTrack = jitsiLocalTracks[0];
+        avUtils.createLocalVideoTrack(description.deviceId)
+            .then(jitsiLocalTrack => {
+                this._previewTrack = jitsiLocalTrack;
 
-            this._ref.current.srcObject
-                = this._previewTrack.getOriginalStream();
-        });
+                this._ref.current.srcObject
+                    = this._previewTrack.getOriginalStream();
+            });
     }
 
     /**

--- a/spot-client/src/spot-tv/ui/components/setup/select-media/mic-preview.js
+++ b/spot-client/src/spot-tv/ui/components/setup/select-media/mic-preview.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { JitsiMeetJSProvider } from 'common/vendor';
+import { avUtils } from 'common/media';
 
 /**
  * Displays a volume meter for previewing the selected audio input device.
@@ -98,19 +98,15 @@ export default class MicPreview extends React.PureComponent {
             return;
         }
 
-        const JitsiMeetJS = JitsiMeetJSProvider.get();
+        avUtils.createLocalAudioTrack(description.deviceId)
+            .then(jitsiLocalTrack => {
+                this._previewTrack = jitsiLocalTrack;
 
-        JitsiMeetJS.createLocalTracks({
-            micDeviceId: description.deviceId,
-            devices: [ 'audio' ]
-        }).then(jitsiLocalTracks => {
-            this._previewTrack = jitsiLocalTracks[0];
-
-            this._previewTrack.on(
-                JitsiMeetJS.events.track.TRACK_AUDIO_LEVEL_CHANGED,
-                this._updateAudioLevel
-            );
-        });
+                this._previewTrack.on(
+                    avUtils.getTrackEvents().TRACK_AUDIO_LEVEL_CHANGED,
+                    this._updateAudioLevel
+                );
+            });
     }
 
     /**
@@ -121,10 +117,8 @@ export default class MicPreview extends React.PureComponent {
      */
     _destroyPreviewTrack() {
         if (this._previewTrack) {
-            const JitsiMeetJS = JitsiMeetJSProvider.get();
-
             this._previewTrack.off(
-                JitsiMeetJS.events.track.TRACK_AUDIO_LEVEL_CHANGED,
+                avUtils.getTrackEvents().TRACK_AUDIO_LEVEL_CHANGED,
                 this._updateAudioLevel
             );
             this._previewTrack.dispose();

--- a/spot-client/src/spot-tv/ui/components/setup/select-media/select-media.js
+++ b/spot-client/src/spot-tv/ui/components/setup/select-media/select-media.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { Button } from 'common/ui';
-import { JitsiMeetJSProvider } from 'common/vendor';
+import { avUtils } from 'common/media';
 
 import CameraPreview from './camera-preview';
 import MicPreview from './mic-preview';
@@ -52,12 +52,7 @@ class SelectMedia extends React.Component {
      * @inheritdoc
      */
     componentDidMount() {
-        const JitsiMeetJS = JitsiMeetJSProvider.get();
-
-        JitsiMeetJS.mediaDevices.addEventListener(
-            JitsiMeetJS.events.mediaDevices.DEVICE_LIST_CHANGED,
-            this._onDeviceListChange
-        );
+        avUtils.listenForDeviceListChanged(this._onDeviceListChange);
 
         this._getDevices();
     }
@@ -68,12 +63,7 @@ class SelectMedia extends React.Component {
      * @inheritdoc
      */
     componentWillUnmount() {
-        const JitsiMeetJS = JitsiMeetJSProvider.get();
-
-        JitsiMeetJS.mediaDevices.removeEventListener(
-            JitsiMeetJS.events.mediaDevices.DEVICE_LIST_CHANGED,
-            this._onDeviceListChange
-        );
+        avUtils.stopListeningForDeviceListChanged(this._onDeviceListChange);
     }
 
     /**
@@ -200,13 +190,9 @@ class SelectMedia extends React.Component {
      * @returns {void}
      */
     _getDevices() {
-        const JitsiMeetJS = JitsiMeetJSProvider.get();
-
-        JitsiMeetJS.createLocalTracks({ devices: [ 'audio', 'video' ] })
+        avUtils.createLocalTracks()
             .then(tracks => tracks.forEach(track => track.dispose()))
-            .then(() => new Promise(
-                resolve => JitsiMeetJS.mediaDevices.enumerateDevices(resolve)
-            ))
+            .then(() => avUtils.enumerateDevices())
             .then(devices => {
                 this._onDeviceListChange(devices);
             });


### PR DESCRIPTION
Spot mainly uses lib-jitsi-meet for its MUC handling
and its ProxyPeerConnection. While Spot-TV uses
some of its WebRTC logic, Spot-Remotes does not.
Spot-Remote may be loaded on environments that do
not have full WebRTC support, such as old android
browsers, and preventing app load due to a lack
of WebRTC is unnecessary.