### PR TITLE
fix(xmpp): do not throttle presence updates

### DIFF
--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -280,19 +280,19 @@ class RemoteControlService {
      * @returns {void}
      */
     notifyJoinCodeUpdate(joinCode) {
-        this.xmppConnection.updateStatus('joinCode', joinCode);
+        this.updateStatus({ joinCode });
     }
 
     /**
      * Notifies all Spot-Remotes about the the current availability of wired
      * screensharing on a Spot-TV.
      *
-     * @param {boolean} isEnabled - Whether or not screensharing is possible.
+     * @param {boolean} wiredScreensharingEnabled - Whether or not screensharing
+     * is possible.
      * @returns {void}
      */
-    notifyWiredScreenshareEnabled(isEnabled) {
-        this.xmppConnection.updateStatus(
-            'wiredScreensharingEnabled', isEnabled);
+    notifyWiredScreenshareEnabled(wiredScreensharingEnabled) {
+        this.updateStatus({ wiredScreensharingEnabled });
     }
 
     /**
@@ -419,21 +419,18 @@ class RemoteControlService {
     /**
      * To be called by Spot-TV to update self presence.
      *
-     * @param {Object} newState - The presence values to be updated. The
-     * key-values will override existing presence key-values and will not
-     * override the complete presence.
+     * @param {Object} newStatus - The new presence object that should be merged
+     * with existing presence.
      * @returns {void}
      */
-    updateStatus(newState = {}) {
+    updateStatus(newStatus = {}) {
         // FIXME: these truthy checks also fix a condition where updateStatus
         // is fired when the redux store is initialized.
         if (!this.xmppConnection || !this._isSpot) {
             return;
         }
 
-        Object.keys(newState).forEach(key => {
-            this.xmppConnection.updateStatus(key, newState[key]);
-        });
+        this.xmppConnection.updateStatus(newStatus);
     }
 
     /**

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -1,4 +1,3 @@
-import throttle from 'lodash.throttle';
 import { $iq } from 'strophe.js';
 
 import { logger } from 'common/logger';
@@ -35,8 +34,6 @@ export default class XmppConnection {
         this.options = options;
 
         this.initPromise = null;
-
-        this._sendPresence = throttle(this._sendPresence.bind(this), 100);
 
         this._onCommand = this._onCommand.bind(this);
         this._onMessage = this._onMessage.bind(this);
@@ -249,18 +246,21 @@ export default class XmppConnection {
      * Updates the current muc participant's status, which should notify other
      * participants of the update. This is a fire and forget call with no ack.
      *
-     * @param {string} type - The status type to send.
-     * @param {*} value - Additional information about the status update.
+     * @param {Object} newStatus - The presence values to be updated. The
+     * key-values will override existing presence key-values and will not
+     * override the complete presence.
      * @returns {void}
      */
-    updateStatus(type, value) {
-        let valueToSend = value;
+    updateStatus(newStatus = {}) {
+        Object.keys(newStatus).forEach(key => {
+            let valueToSend = newStatus[key];
 
-        if (typeof value !== 'string') {
-            valueToSend = JSON.stringify(value);
-        }
+            if (typeof valueToSend !== 'string') {
+                valueToSend = JSON.stringify(valueToSend);
+            }
 
-        this.updatePresence(type, valueToSend);
+            this.updatePresence(key, valueToSend);
+        });
 
         this._sendPresence();
     }


### PR DESCRIPTION
Presence updates were throttled in case many calls
to update presence were being made in a short time
span (100ms) to reduce the number of network requests
fired. However, that introduces the 100ms delay,
which adds to the already existing delays of dealing
with prodosy presence updates.