### PR TITLE
fix(nav): change flex stylings for safari not rendering

### DIFF
--- a/spot-client/src/common/css/temp.scss
+++ b/spot-client/src/common/css/temp.scss
@@ -292,12 +292,18 @@ body.using-mouse :focus {
 * view acts as the main wrapper each individual route. By default put the
 * content of view in the center of the screen.
 */
-.view,
+.view {
+  background-size: cover;
+  height: 100%;
+  min-height: 100%;
+  width: 100%;
+}
+
 .view-gradient {
   align-items: center;
   background-size: cover;
   display: flex;
-  flex-direction: column;
+  height: 100%;
   min-height: 100%;
   justify-content: center;
   width: 100%;


### PR DESCRIPTION
On safari, the nav icons would not display the circle border
or the label. Somehow the nested flex wrappers and the
flex direction were causing problems. Admittedly the
problem is not understood but removing stylings fixes
it.