### PR TITLE
fix(calendar): gray out meetings without urls

### DIFF
--- a/spot-client/src/common/css/meeting.scss
+++ b/spot-client/src/common/css/meeting.scss
@@ -21,7 +21,7 @@
         flex-direction: row;
     }
 
-    &:active {
+    &:active:not(.no-url) {
         background-color: var(--container-content-highlight-bg-color);
     }
 

--- a/spot-client/src/common/css/page-layouts/waiting-view.scss
+++ b/spot-client/src/common/css/page-layouts/waiting-view.scss
@@ -25,6 +25,11 @@
             @media #{$mq-laptop-l} {
                 width: 60%;
             }
+
+            &.no-url {
+                background-color: rgba(105, 105, 105, 0.7);
+                cursor: initial;
+            }
         }
 
         .meeting:first-child {

--- a/spot-client/src/common/ui/components/scheduled-meetings/scheduled-meeting.js
+++ b/spot-client/src/common/ui/components/scheduled-meetings/scheduled-meeting.js
@@ -41,12 +41,11 @@ export default class ScheduledMeeting extends React.Component {
             title
         } = this.props.event;
         const startTime = new Date(start);
-        const joinNowClasses
-            = `meeting-join ${this._hasMeetingToJoin() ? '' : 'hidden'}`;
+        const hasMeetingToJoin = this._hasMeetingToJoin();
 
         return (
             <div
-                className = 'meeting'
+                className = { `meeting ${hasMeetingToJoin ? '' : 'no-url'} ` }
                 onClick = { this._onMeetingClick }>
                 <div className = 'meeting-info-container'>
                     <div className = 'time-info'>
@@ -66,7 +65,7 @@ export default class ScheduledMeeting extends React.Component {
                         </div>
                     </div>
                 </div>
-                <div className = { joinNowClasses }>
+                <div className = { `meeting-join ${hasMeetingToJoin ? '' : 'hidden'}` }>
                     <button className = 'join-cta'>Join Now</button>
                 </div>
             </div>


### PR DESCRIPTION
Design said for events without meeting URLs to either make a plus button like jitsi-meet's home page to add an event or gray out the event, whichever is easier.