### PR TITLE
fix(remote): allow scroll and zoom for input centering

### DIFF
--- a/in-room-controller/src/remote-control.js
+++ b/in-room-controller/src/remote-control.js
@@ -17,14 +17,12 @@ export default class RemoteControl extends React.PureComponent {
         url: PropTypes.string
     };
 
+    // Override the meta tag with values that are known not allow this app to
+    // be native-app like but not break functionality like input centering.
     _preventWebViewZoomScript = `
         var metaTag = document.getElementsByName('viewport')[0];
         if (metaTag) {
-            var content = metaTag.getAttribute('content') || '';
-            var preventZoom = 'maximum-scale=1.0';
-            if (!content.includes(preventZoom))
-            metaTag.setAttribute(
-                'content', content + ',' + preventZoom);
+            metaTag.setAttribute('content', 'initial-scale=1');
         }
 
         true;
@@ -42,16 +40,30 @@ export default class RemoteControl extends React.PureComponent {
                 <WebView
                     allowsInlineMediaPlayback = { true }
                     allowsLinkPreview = { false }
+
+                    // Prevents moving the webview up and down.
                     bounces = { false }
+
+                    // Do not cache so any reloads can pick up the latest.
+                    cacheEnabled = { false }
+
+                    directionalLockEnabled = { true }
+
                     injectedJavaScript = { this._preventWebViewZoomScript }
+
+                    // Allow immediate playing of any media, like ultrasound.
                     mediaPlaybackRequiresUserAction = { false }
-                    scrollEnabled = { false }
+
+                    // The default is true but being explicit to point out
+                    // scrolling is necessary for iOS (starting on 12.2) to
+                    // properly center focus on inputs.
+                    scrollEnabled = { true }
+
+                    // In general the WebView should not need to scroll.
                     showsHorizontalScrollIndicator = { false }
                     showsVerticalScrollIndicator = { false }
-                    source = {{ uri: this.props.url }}
-                    style = {{
-                        ...StyleSheet.absoluteFillObject
-                    }} />
+
+                    source = {{ uri: this.props.url }} />
             </View>
         );
     }


### PR DESCRIPTION
Scroll needs to be enabled to allow iOS to center
inputs on screen. Zoom has to be enabled to support
iPad Pro centering.