### PR TITLE
ref(bootstrap): import history

### DIFF
--- a/spot-client/src/common/history/index.js
+++ b/spot-client/src/common/history/index.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export const history = createBrowserHistory();

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { createStore } from 'redux';
 import thunk from 'redux-thunk';
 
 import 'common/css';
 import { AmplitudeHandler, analytics } from 'common/analytics';
 import { globalDebugger } from 'common/debugging';
+import { history } from 'common/history';
 import { LoggingService } from 'common/logger';
 import reducers, {
     getAnalyticsAppKey,
@@ -77,9 +78,9 @@ remoteControlService.configureWirelessScreensharing({
 
 render(
     <Provider store = { store }>
-        <BrowserRouter>
+        <Router history = { history }>
             <App />
-        </BrowserRouter>
+        </Router>
     </Provider>,
     document.getElementById('root')
 );

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -1,5 +1,6 @@
 import { getSpotServicesConfig } from 'common/app-state';
 import { remoteControlService } from 'common/remote-control';
+import { history } from 'common/history';
 
 import {
     SPOT_REMOTE_EXIT_SHARE_MODE,
@@ -48,10 +49,9 @@ export function connectToSpotTV(joinCode, shareMode) {
 /**
  * Exits the special share mode.
  *
- * @param {Object} history - The history object user for navigating the browser.
  * @returns {Function}
  */
-export function exitShareMode(history) {
+export function exitShareMode() {
     return dispatch => {
         dispatch({
             type: SPOT_REMOTE_EXIT_SHARE_MODE

--- a/spot-client/src/spot-remote/ui/views/share/share.js
+++ b/spot-client/src/spot-remote/ui/views/share/share.js
@@ -116,7 +116,7 @@ export class Share extends React.PureComponent {
      * @returns {void}
      */
     _onGoToSpotRemoteView() {
-        this.props.dispatch(exitShareMode(this.props.history));
+        this.props.dispatch(exitShareMode());
     }
 
     /**


### PR DESCRIPTION
This way history can be used outside of components
by being imported as a module.