### PR TITLE
fix(layout): use vh to cover viewport in firefox

### DIFF
--- a/spot-client/src/common/css/mixins.scss
+++ b/spot-client/src/common/css/mixins.scss
@@ -27,7 +27,7 @@
 @mixin spot-remote-view-layout {
     display: flex;
     flex-direction: column;
-    min-height: 100%;
+    min-height: 100vh;
     width: 100%;
 
     .view-header {

--- a/spot-client/src/common/css/page-layouts/spot-tv/meeting-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/meeting-view.scss
@@ -2,7 +2,7 @@
 
 .meeting-view {
     height: 100%;
-    min-height: 100%;
+    min-height: 100vh;
     width: 100%;
 
     .feedback-hider-overlay,

--- a/spot-client/src/common/css/reset.scss
+++ b/spot-client/src/common/css/reset.scss
@@ -72,7 +72,7 @@ body {
 
 body,
 body > div {
-    min-height: 100%;
+    min-height: 100vh;
     width: 100%;
 }
 /**

--- a/spot-client/src/common/css/temp.scss
+++ b/spot-client/src/common/css/temp.scss
@@ -129,7 +129,7 @@ body.using-mouse :focus {
 .loading {
     @include centered-content;
 
-    min-height: 100%;
+    min-height: 100vh;
     width: 100%;
 }
 
@@ -143,7 +143,7 @@ body.using-mouse :focus {
 */
 .view {
   background-size: cover;
-  min-height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 
@@ -151,8 +151,7 @@ body.using-mouse :focus {
   align-items: center;
   background-size: cover;
   display: flex;
-  min-height: 100%;
-  min-height: 100%;
+  min-height: 100vh;
   justify-content: center;
   width: 100%;
 }
@@ -163,5 +162,5 @@ body.using-mouse :focus {
 }
 
 .app {
-  min-height: 100%;
+  min-height: 100vh;
 }


### PR DESCRIPTION
Firefox's min-height 100% is not working like other
browsers.