### PR TITLE
fix(calendar): reset state on re-initialization

### DIFF
--- a/spot-client/src/spot-tv/calendars/calendarService.js
+++ b/spot-client/src/spot-tv/calendars/calendarService.js
@@ -51,6 +51,9 @@ export class CalendarService extends EventEmitter {
 
         this._calendarIntegration = calendarIntegrations[type];
 
+        this._calendarEvents = [];
+        this._hasFetchedEvents = false;
+
         return this._calendarIntegration.initialize(this.config[type]);
     }
 


### PR DESCRIPTION
This fixes the bug where setup is re-run with the same
calendar selected or a calendar with the same events
selected, and initial event of calendar events having
been fetched doesn't fire because the cached events
is the same.