### PR TITLE
fix(buttons): add focus style

### DIFF
--- a/spot-client/src/common/css/button.scss
+++ b/spot-client/src/common/css/button.scss
@@ -7,6 +7,14 @@
     font-size: $font-size-small;
     padding: 8px 32px;
 
+    &:focus {
+        /**
+         * Be explicit about outline because material-ui hides outline by
+         * default.
+         */
+        outline: auto;
+    }
+
     &.primary {
         background-color: var(--button-color);
         border: 1px solid var(--button-color);


### PR DESCRIPTION
material-ui sets outline to none by default, which
makes it not possible to see when the button is
being focused on when using keyboard navigation.

Example with focus on the second Join Now button:
<img width="1467" alt="Screen Shot 2019-04-25 at 5 17 34 PM" src="https://user-images.githubusercontent.com/1243084/56775977-8e276f00-677e-11e9-8ab3-30984ea6a63a.png">
