### PR TITLE
ios: fix build error Library not found for -lDoubleConversion

### DIFF
--- a/in-room-controller/ios/spot-controller.xcodeproj/project.pbxproj
+++ b/in-room-controller/ios/spot-controller.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
-			remoteInfo = spot-controller;
+			remoteInfo = "spot-controller";
 		};
 		0E56D48F22178B44003DEFA2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -191,17 +191,17 @@
 		00E356F21AD99517003FC87E /* spot-controllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "spot-controllerTests.m"; sourceTree = "<group>"; };
 		0E349904220149EC00EF3A15 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
 		0E56D48B22178B44003DEFA2 /* RNCWebView.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCWebView.xcodeproj; path = "../node_modules/react-native-webview/ios/RNCWebView.xcodeproj"; sourceTree = "<group>"; };
-		0E934677222F35F50005B4A5 /* spot-controller.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = spot-controller.entitlements; path = spot-controller/spot-controller.entitlements; sourceTree = "<group>"; };
+		0E934677222F35F50005B4A5 /* spot-controller.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "spot-controller.entitlements"; path = "spot-controller/spot-controller.entitlements"; sourceTree = "<group>"; };
 		0EFFC488221C7E4F00D2DC0F /* libPods-spot-controller.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libPods-spot-controller.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* spot-controller.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "spot-controller.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = spot-controller/AppDelegate.h; sourceTree = "<group>"; };
-		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = spot-controller/AppDelegate.m; sourceTree = "<group>"; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = "spot-controller/AppDelegate.h"; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = "spot-controller/AppDelegate.m"; sourceTree = "<group>"; };
 		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = spot-controller/Images.xcassets; sourceTree = "<group>"; };
-		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = spot-controller/Info.plist; sourceTree = "<group>"; };
-		13B07FB71A68108700A75B9A /* spot-controller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = spot-controller/main.m; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "spot-controller/Images.xcassets"; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "spot-controller/Info.plist"; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "spot-controller/main.m"; sourceTree = "<group>"; };
 		174179B42ECEE49A5C946190 /* libPods-spot-controllerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-spot-controllerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D16E6891FA4F8E400B85C8A /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A9F086B1A2993CE0468D9EB /* libPods-spot-controller.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-spot-controller.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -455,7 +455,7 @@
 				00E356F51AD99517003FC87E /* PBXTargetDependency */,
 			);
 			name = "spot-controllerTests";
-			productName = spot-controllerTests;
+			productName = "spot-controllerTests";
 			productReference = 00E356EE1AD99517003FC87E /* spot-controllerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -842,7 +842,7 @@
 				13B07FB21A68108700A75B9A /* Base */,
 			);
 			name = LaunchScreen.xib;
-			path = spot-controller;
+			path = "spot-controller";
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -854,7 +854,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = P8STL8J997;
-				INFOPLIST_FILE = spot-controllerTests/Info.plist;
+				INFOPLIST_FILE = "spot-controllerTests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -876,9 +876,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = FC967L3QRG;
-				INFOPLIST_FILE = spot-controller/Info.plist;
+				INFOPLIST_FILE = "spot-controller/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -993,9 +994,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = FC967L3QRG;
-				INFOPLIST_FILE = spot-controller/Info.plist;
+				INFOPLIST_FILE = "spot-controller/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1015,7 +1017,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = P8STL8J997;
-				INFOPLIST_FILE = spot-controllerTests/Info.plist;
+				INFOPLIST_FILE = "spot-controllerTests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
Set "yes" to "build active architecture only" for debug

This commit also contains other details adjusted by xcode, but they are not related. Pushing them to avoid ping pong.