### PR TITLE
fix(rcs): prevent some cases of multiple connection attempts

### DIFF
--- a/spot-client/src/common/app-state/remote-control-service/selectors.js
+++ b/spot-client/src/common/app-state/remote-control-service/selectors.js
@@ -46,6 +46,19 @@ export function isAudioMutePending(state) {
 }
 
 /**
+ * A selector which returns the whether or not {@code remoteControlService} is
+ * currently establishing a connection to a Spot-MUC.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function isConnectionPending(state) {
+    const connect = state.remoteControlService.connect;
+
+    return Boolean(connect && connect.requestState === asyncActionRequestStates.PENDING);
+}
+
+/**
  * A selector which returns the whether or not {@code remoteControlService} has
  * a valid connection to a Spot-MUC.
  *

--- a/spot-client/src/common/remote-control/remote-control-service.js
+++ b/spot-client/src/common/remote-control/remote-control-service.js
@@ -368,6 +368,16 @@ class RemoteControlService extends EventEmitter {
     }
 
     /**
+     * Returns whether or not there is a connection that is being established
+     * or is active.
+     *
+     * @returns {boolean}
+     */
+    hasConnection() {
+        return Boolean(this.xmppConnection);
+    }
+
+    /**
      * Method invoked by Spot-TV to generate a new join code for a Spot-Remote
      * to pair with it.
      *

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -20,6 +20,12 @@ import { generateRandomString } from 'common/utils';
  */
 export function createSpotTVRemoteControlConnection() {
     return (dispatch, getState) => {
+        if (remoteControlService.hasConnection()) {
+            logger.warn('Called to create connection while connection exists');
+
+            return;
+        }
+
         /**
          * Callback invoked when a connect has been successfully made with
          * {@code remoteControlService}.

--- a/spot-client/src/spot-tv/ui/loaders/SpotTVRemoteControlLoader.js
+++ b/spot-client/src/spot-tv/ui/loaders/SpotTVRemoteControlLoader.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { analytics } from 'common/analytics';
 import {
     isConnectionEstablished,
+    isConnectionPending,
     setIsSpot
 } from 'common/app-state';
 import { remoteControlService } from 'common/remote-control';
@@ -22,6 +23,7 @@ export class SpotTVRemoteControlLoader extends React.Component {
     static propTypes = {
         children: PropTypes.node,
         dispatch: PropTypes.func,
+        isAttemptingConnection: PropTypes.bool,
         isConnected: PropTypes.bool
     };
 
@@ -39,7 +41,9 @@ export class SpotTVRemoteControlLoader extends React.Component {
 
         // TODO: Add some retry logic to error handling for when the initial
         // connection fails to be established.
-        this.props.dispatch(createSpotTVRemoteControlConnection());
+        if (!this.props.isConnected && !this.props.isAttemptingConnection) {
+            this.props.dispatch(createSpotTVRemoteControlConnection());
+        }
     }
 
     /**
@@ -83,6 +87,7 @@ export class SpotTVRemoteControlLoader extends React.Component {
  */
 function mapStateToProps(state) {
     return {
+        isAttemptingConnection: isConnectionPending(state),
         isConnected: isConnectionEstablished(state)
     };
 }


### PR DESCRIPTION
Spot-TV setup no longer connects to the remote control
service, so it no longer uses the remote control loader.
This causes the loader component to mount again when
exiting setup, calling connection creation again.