### PR TITLE
ref(deps): replace jsrsasign with jwt-decode

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -9110,12 +9110,6 @@
                 "verror": "1.10.0"
             }
         },
-        "jsrsasign": {
-            "version": "8.0.12",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.12.tgz",
-            "integrity": "sha1-Iqu5ZW00owuVMENnIINeicLlwxY=",
-            "dev": true
-        },
         "jss": {
             "version": "9.8.7",
             "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
@@ -9202,6 +9196,12 @@
             "requires": {
                 "array-includes": "^3.0.3"
             }
+        },
+        "jwt-decode": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+            "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=",
+            "dev": true
         },
         "killable": {
             "version": "1.0.1",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -42,7 +42,7 @@
         "jquery": "3.4.0",
         "js-utils": "github:jitsi/js-utils#73a67a7a60d52f8e895f50939c8fcbd1f20fe7b5",
         "jsdoc": "3.5.5",
-        "jsrsasign": "8.0.12",
+        "jwt-decode": "2.2.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#86e3badd5c04e1df72435205d28a58c8a64e343a",
         "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
         "lodash.debounce": "4.0.8",

--- a/spot-client/src/spot-tv/calendars/microsoft-client-api/api.js
+++ b/spot-client/src/spot-tv/calendars/microsoft-client-api/api.js
@@ -1,5 +1,5 @@
 import { Client } from '@microsoft/microsoft-graph-client';
-import rs from 'jsrsasign';
+import jwtDecode from 'jwt-decode';
 
 import { generateGuid, persistence } from 'common/utils';
 
@@ -299,8 +299,7 @@ function getValidatedTokenParts(tokenInfo, guids, appId) {
         return null;
     }
 
-    const payload
-         = rs.KJUR.jws.JWS.readSafeJSONString(rs.b64utoutf8(tokenParts[1]));
+    const payload = jwtDecode(idToken);
 
     if (payload.nonce !== guids.authNonce
         || payload.aud !== appId


### PR DESCRIPTION
jsrsasign is used for validating the Outlook
jwt and is used because it is the library
references in the Outlook API docs. The
same functionality can be done with jwt-decode
at a 2kb footprint versus 225kb.