### PR TITLE
fix(code-entry): work around android backspace moving focus forward

### DIFF
--- a/spot-client/src/common/ui/components/code-input/code-input.js
+++ b/spot-client/src/common/ui/components/code-input/code-input.js
@@ -133,7 +133,14 @@ export default class CodeInput extends React.Component {
             inputValues: this._replaceEnteredValue(index, value[0])
         }, () => {
             this._notifyOfChange();
-            this._focusOnNextInputBox(index);
+
+            // The Android software keyboard does not necessarily behave like
+            // a hardware keyboard and can instead set an empty string as the
+            // value when backspace is pressed. In that case do not bother going
+            // forward.
+            if (value) {
+                this._focusOnNextInputBox(index);
+            }
         });
     }
 
@@ -148,6 +155,10 @@ export default class CodeInput extends React.Component {
      * @returns {void}
      */
     _onKeyDown(index, event) {
+        // FIXME: Android software keyboards may not send the proper key code
+        // for various possible reasons such as supporting swiping to type. See
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=118639
+
         switch (event.keyCode) {
         case keyCodes.BACKSPACE_KEY:
             event.preventDefault();

--- a/spot-client/src/common/ui/components/code-input/input-box.js
+++ b/spot-client/src/common/ui/components/code-input/input-box.js
@@ -74,6 +74,7 @@ export default class InputBox extends React.Component {
                 autoComplete = 'off'
                 autoFocus = { this.props.autoFocus }
                 className = 'box'
+                maxLength = { 1 }
                 onChange = { this._onChange }
                 onFocus = { this._onFocus }
                 onInput = { this._onInput }


### PR DESCRIPTION
Note: this is entirely a workaround and only a partial patch to the UX on android.