### PR TITLE
fix(in-room-controller): re-disable zoom

### DIFF
--- a/in-room-controller/src/remote-control.js
+++ b/in-room-controller/src/remote-control.js
@@ -22,7 +22,7 @@ export default class RemoteControl extends React.PureComponent {
     _preventWebViewZoomScript = `
         var metaTag = document.getElementsByName('viewport')[0];
         if (metaTag) {
-            metaTag.setAttribute('content', 'initial-scale=1');
+            metaTag.setAttribute('content', 'initial-scale=1,user-scalable=no');
         }
 
         true;


### PR DESCRIPTION
It was enabled while attempting to fix
the join code page jumping around after
the iOS 12.2 issue. The fix for iOS 12.2
had to do with box-sizing, not zoom.
See commit d3ed9b.