### PR TITLE
ref(code-input): rewrite with one input approach

### DIFF
--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -2,6 +2,7 @@
 @import './variables.scss';
 
 .code-entry {
+    cursor: pointer;
     display: flex;
     outline: none;
     position: relative;
@@ -38,13 +39,13 @@
              */
             -webkit-appearance: none;
         }
-        &:hover {
-            cursor: pointer;
-        }
     }
 
     input {
+        font-size: $font-size-x-large;
+        height: 100%;
         left: 0;
+        letter-spacing: 2em;
 
         /**
          * Use opacity and pointer-events to effectively make the input
@@ -53,6 +54,6 @@
         opacity: 0;
         pointer-events: none;
         position: absolute;
-        top: 50%;
+        width: 100%;
     }
 }

--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -44,13 +44,14 @@
     input {
         background: transparent;
         border: 0;
+        bottom: 0;
         caret-color: transparent;
         color: transparent;
         font-size: $font-size-x-large;
-        left: 0;
         letter-spacing: 2em;
         pointer-events: none;
         position: absolute;
+        top: 0;
         width: 100%;
         z-index: 0;
 

--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -43,17 +43,23 @@
 
     input {
         font-size: $font-size-x-large;
-        height: 100%;
-        left: 0;
-        letter-spacing: 2em;
 
-        /**
-         * Use opacity and pointer-events to effectively make the input
-         * invisible but still responsive to keyboard events.
-         */
-        opacity: 0;
+        border: none;
+        caret-color: transparent;
+        color: transparent;
+        left: 0;
+        top: 50%;
+        letter-spacing: 2em;
+        background: transparent;
+        border: 0;
+
         pointer-events: none;
         position: absolute;
         width: 100%;
+        z-index: 0;
+
+        &:focus {
+            outline: none;
+        }
     }
 }

--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -42,17 +42,13 @@
     }
 
     input {
-        font-size: $font-size-x-large;
-
-        border: none;
-        caret-color: transparent;
-        color: transparent;
-        left: 0;
-        top: 50%;
-        letter-spacing: 2em;
         background: transparent;
         border: 0;
-
+        caret-color: transparent;
+        color: transparent;
+        font-size: $font-size-x-large;
+        left: 0;
+        letter-spacing: 2em;
         pointer-events: none;
         position: absolute;
         width: 100%;
@@ -60,6 +56,10 @@
 
         &:focus {
             outline: none;
+        }
+
+        &::selection {
+            background: transparent;
         }
     }
 }

--- a/spot-client/src/common/css/code-entry.scss
+++ b/spot-client/src/common/css/code-entry.scss
@@ -2,6 +2,7 @@
 @import './variables.scss';
 
 .code-entry {
+    display: flex;
     outline: none;
     position: relative;
 
@@ -18,7 +19,6 @@
         border: 1px solid var(--container-sub-content-font-color);
         border-radius: 5px;
         color: var(--container-content-font-color);
-        display: inline-block;
         font-size: $font-size-x-large;
         height: calc(#{$font-size-x-large} * 0.7);
         line-height: normal;
@@ -28,7 +28,7 @@
         text-transform: uppercase;
         width: calc(#{$font-size-x-large} * 0.5);
 
-        &:focus {
+        &.focused {
             border-color: var(--active);
             box-shadow: 0px 0px 0px 5px var(--active);
 
@@ -41,5 +41,18 @@
         &:hover {
             cursor: pointer;
         }
+    }
+
+    input {
+        left: 0;
+
+        /**
+         * Use opacity and pointer-events to effectively make the input
+         * invisible but still responsive to keyboard events.
+         */
+        opacity: 0;
+        pointer-events: none;
+        position: absolute;
+        top: 50%;
     }
 }

--- a/spot-client/src/common/ui/components/code-input/code-input.js
+++ b/spot-client/src/common/ui/components/code-input/code-input.js
@@ -181,7 +181,9 @@ export default class CodeInput extends React.Component {
     _renderHiddenInput() {
         return (
             <input
+                autoCapitalize = 'off'
                 autoComplete = 'off'
+                autoCorrect = 'off'
                 autoFocus = { this._isAutoFocusSupported }
                 maxLength = { this.props.length }
                 onBlur = { this._onBlur }
@@ -189,8 +191,7 @@ export default class CodeInput extends React.Component {
                 onFocus = { this._onFocus }
                 onKeyDown = { this._onKeyDown }
                 ref = { this._inputRef }
-                spellCheck = 'false'
-                type = 'text'
+                spellCheck = { false }
                 value = { this.state.value } />
         );
     }

--- a/spot-client/src/common/ui/components/code-input/code-input.js
+++ b/spot-client/src/common/ui/components/code-input/code-input.js
@@ -103,9 +103,11 @@ export default class CodeInput extends React.Component {
     _onFocus() {
         // Prevent selection of the entire value when tabbed to focus
         if (this._inputRef.current) {
-            this._inputRef.current.selectionStart
-                = this._inputRef.current.selectionEnd
-                = this.state.value.length;
+            setTimeout(() => {
+                this._inputRef.current.selectionStart
+                    = this._inputRef.current.selectionEnd
+                    = this.state.value.length;
+            });
         }
 
         this.setState({ isFocused: true });

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -56,7 +56,6 @@ export class JoinCodeEntry extends React.Component {
         this._isShareModeEnabled = this._isInShareModeEnv();
 
         this._onCodeChange = this._onCodeChange.bind(this);
-        this._onEntryComplete = this._onEntryComplete.bind(this);
         this._onFormSubmit = this._onFormSubmit.bind(this);
         this._onSubmit = this._onSubmit.bind(this);
     }
@@ -135,9 +134,7 @@ export class JoinCodeEntry extends React.Component {
                         <form
                             onSubmit = { this._onFormSubmit }>
                             <div data-qa-id = { 'join-code-input' }>
-                                <CodeInput
-                                    onChange = { this._onCodeChange }
-                                    onEntryComplete = { this._onEntryComplete } />
+                                <CodeInput onChange = { this._onCodeChange } />
                                 {
 
                                     /**
@@ -174,19 +171,11 @@ export class JoinCodeEntry extends React.Component {
      * @returns {void}
      */
     _onCodeChange(enteredCode) {
-        this.setState({ enteredCode });
-    }
-
-    /**
-     * Callback invoked when the last character of the join code entry has
-     * been filled. Submits the join code for verification.
-     *
-     * @param {string} enteredCode - The entered code so far.
-     * @private
-     * @returns {void}
-     */
-    _onEntryComplete(enteredCode) {
-        this.setState({ enteredCode }, this._onSubmit);
+        this.setState({ enteredCode }, () => {
+            if (enteredCode.length === 6) {
+                this._onSubmit();
+            }
+        });
     }
 
     /**

--- a/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
+++ b/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
@@ -25,7 +25,7 @@ export class SyncWithBackend extends React.Component {
     constructor(props) {
         super(props);
 
-        this._onEntryComplete = this._onEntryComplete.bind(this);
+        this._onChange = this._onChange.bind(this);
     }
 
     /**
@@ -46,7 +46,7 @@ export class SyncWithBackend extends React.Component {
                     </div>
                 </div>
                 <div className = 'code-input'>
-                    <CodeInput onEntryComplete = { this._onEntryComplete } />
+                    <CodeInput onChange = { this._onChange } />
                 </div>
             </div>
         );
@@ -55,11 +55,14 @@ export class SyncWithBackend extends React.Component {
     /**
      * Attempts validation of the entered code.
      *
+     * @param {string} value - The entered code.
      * @private
      * @returns {void}
      */
-    _onEntryComplete() {
-        this.props.onSuccess();
+    _onChange(value) {
+        if (value.length === 6) {
+            this.props.onSuccess();
+        }
     }
 }
 


### PR DESCRIPTION
Instead of using 6 input elements, use one, which
will allow backspace to work on Android browser.

![android](https://user-images.githubusercontent.com/1243084/57733754-1cdc2d00-7655-11e9-9094-64e1ab5e486f.gif)
