### PR TITLE
ref(code-input): always a 6x1 grid

### DIFF
--- a/spot-client/src/common/css/page-layouts/join-code-view.scss
+++ b/spot-client/src/common/css/page-layouts/join-code-view.scss
@@ -28,16 +28,19 @@
             justify-content: center;
             margin: auto;
 
-            @media #{$mq-xxsmall} {
-                flex-wrap: wrap;
+            /**
+             * Override box styles to support 6x1 grid of boxes, which works
+             * around the code entry implementation of having one input and
+             * mobile browsers auto-centering on focused inputs.
+             */
+            .box {
+                @media #{$mq-xxsmall} {
+                    margin: 5px;
+                }
 
-                // Hardcode some width that force a 3x2 code entry.
-                width: 65%;
-            }
-
-            @media #{$mq-tablet} {
-                flex-wrap: nowrap;
-                width: auto;
+                @media #{$mq-tablet} {
+                    margin: 15px;
+                }
             }
         }
 


### PR DESCRIPTION
![Screen Shot 2019-05-14 at 2 22 48 PM](https://user-images.githubusercontent.com/1243084/57733214-dafeb700-7653-11e9-94e6-9848777bdc92.png)
![Screen Shot 2019-05-14 at 2 23 29 PM](https://user-images.githubusercontent.com/1243084/57733219-dd611100-7653-11e9-890b-3916177ba52d.png)
