### PR TITLE
feat: add a help icon to the join code entry page

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -10,7 +10,7 @@ import {
     IdleCursorDetector,
     Notifications
 } from 'common/ui';
-import { JoinCodeEntry, RemoteControl, ShareView } from 'spot-remote/ui';
+import { Help, JoinCodeEntry, RemoteControl, ShareView } from 'spot-remote/ui';
 import {
     Admin,
     Home,
@@ -146,6 +146,9 @@ export class App extends React.Component {
                                  * Spot-Remote specific routes.
                                  */
                             }
+                            <Route
+                                component = { Help }
+                                path = { ROUTES.HELP } />
                             <Route
                                 component = { ShareView }
                                 path = { ROUTES.SHARE } />

--- a/spot-client/src/common/css/help-view.scss
+++ b/spot-client/src/common/css/help-view.scss
@@ -1,0 +1,62 @@
+@import './media-queries';
+@import './mixins';
+@import './variables.scss';
+
+.help-view {
+  @include spot-remote-view-layout;
+
+  .title {
+    padding: 1.5em;
+    text-align: center;
+    font-size: $font-size-x-large;
+  }
+
+  .help-dialog {
+    @include centered-content;
+    display: block;
+
+    background-color: var(--container-bg-color);
+    border-radius: 5px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 32px 16px;
+    text-align: center;
+
+    @media #{$mq-xxsmall} {
+      width: 95%;
+    }
+
+    @media #{$mq-tablet} {
+      width: 60%;
+    }
+
+    .help-message {
+      font-size: $font-size-medium-plus;
+
+      .spot-home-link {
+        text-decoration: none;
+
+        &:link {
+          color: white;
+        }
+
+        &:visited {
+          color: white;
+        }
+
+        &:hover {
+          color: gray;
+          cursor: pointer;
+        }
+
+        &:active {
+          color: darkgray;
+        }
+      }
+    }
+
+    .ok-button {
+      margin-top: 32px;
+    }
+  }
+}

--- a/spot-client/src/common/css/index.js
+++ b/spot-client/src/common/css/index.js
@@ -20,6 +20,7 @@ import './clock.scss';
 import './code-entry.scss';
 import './desktop-picker.scss';
 import './dial-pad.scss';
+import './help-view.scss';
 import './home-view.scss';
 import './idle-cursor.scss';
 import './input.scss';

--- a/spot-client/src/common/css/page-layouts/join-code-view.scss
+++ b/spot-client/src/common/css/page-layouts/join-code-view.scss
@@ -6,6 +6,7 @@
     @include spot-remote-view-layout;
 
     justify-content: space-between;
+    position: relative;
 
     .cta {
         padding: 2.5em;
@@ -48,6 +49,20 @@
             position: absolute;
             pointer-events: none;
             visibility: hidden;
+        }
+    }
+
+    .help-icon {
+        bottom: 5px;
+        position: absolute;
+        right: 5px;
+
+        @media #{$mq-xxsmall} {
+            font-size: 3.5em;
+        }
+
+        @media #{$mq-laptop} {
+            font-size: 2em;
         }
     }
 }

--- a/spot-client/src/common/icons/index.js
+++ b/spot-client/src/common/icons/index.js
@@ -6,6 +6,7 @@ export {
     CallEnd,
     Fullscreen,
     FullscreenExit,
+    HelpOutline,
     Mic,
     MicOff,
     ScreenShare,

--- a/spot-client/src/common/routing/constants.js
+++ b/spot-client/src/common/routing/constants.js
@@ -4,6 +4,7 @@
 export const ROUTES = {
     ADMIN: '/admin',
     CODE: '/',
+    HELP: '/help',
     HOME: '/spot',
     LOADING: '/loading',
     MEETING: '/meeting',

--- a/spot-client/src/spot-remote/ui/views/help.js
+++ b/spot-client/src/spot-remote/ui/views/help.js
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { ROUTES } from 'common/routing';
+import { Button, View } from 'common/ui';
+import { windowHandler } from 'common/utils';
+
+/**
+ * Displays a view with basic usage instructions for Spot Remote.
+ *
+ * @extends React.Component
+ */
+class Help extends React.Component {
+    static propTypes = {
+        history: PropTypes.object
+    };
+
+    /**
+     * Gets the URL which point to the join code entry page.
+     *
+     * @returns {string}
+     * @private
+     */
+    static _getSpotTvUrl() {
+        return `${windowHandler.getBaseUrl()}${ROUTES.HOME}`;
+    }
+
+    /**
+     * Initializes a new {@code Help} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._onOkButtonClicked = this._onOkButtonClicked.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const spotTvHomeUrl = Help._getSpotTvUrl();
+
+        return (
+            <View name = 'help'>
+                <div className = 'help-view'>
+                    <div className = 'title'>
+                        Welcome to Spot!
+                    </div>
+                    <div className = 'help-dialog'>
+                        <div className = 'help-message'>
+                            This app is a remote controller for a conference room.
+                            <div>
+                                Open&nbsp;
+                                <a
+                                    className = 'spot-home-link'
+                                    href = { spotTvHomeUrl } >
+                                    { spotTvHomeUrl }
+                                </a>
+                                &nbsp;in a browser to setup your conference room and obtain a share key.
+                            </div>
+                        </div>
+                        <Button
+                            className = 'ok-button'
+                            onClick = { this._onOkButtonClicked } >
+                            OK
+                        </Button>
+                    </div>
+                </div>
+            </View>
+        );
+    }
+
+    /**
+     * Takes the user to the join code entry page.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onOkButtonClicked() {
+        this.props.history.push(ROUTES.CODE);
+    }
+}
+
+export default Help;

--- a/spot-client/src/spot-remote/ui/views/index.js
+++ b/spot-client/src/spot-remote/ui/views/index.js
@@ -1,3 +1,4 @@
+export { default as Help } from './help';
 export { default as JoinCodeEntry } from './join-code-entry';
 export { default as RemoteControl } from './remote-control';
 export * from './share';

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -9,7 +9,7 @@ import {
     isConnectedToSpot,
     setJoinCode
 } from 'common/app-state';
-import { ArrowForward } from 'common/icons';
+import { ArrowForward, HelpOutline } from 'common/icons';
 import { logger } from 'common/logger';
 import { remoteControlService } from 'common/remote-control';
 import { ROUTES } from 'common/routing';
@@ -56,6 +56,7 @@ export class JoinCodeEntry extends React.Component {
         this._isShareModeEnabled = this._isInShareModeEnv();
 
         this._onCodeChange = this._onCodeChange.bind(this);
+        this._onHelpIconClicked = this._onHelpIconClicked.bind(this);
         this._onFormSubmit = this._onFormSubmit.bind(this);
         this._onSubmit = this._onSubmit.bind(this);
     }
@@ -158,9 +159,22 @@ export class JoinCodeEntry extends React.Component {
                             <ArrowForward />
                         </NavButton>
                     </NavContainer>
+                    <HelpOutline
+                        className = 'help-icon'
+                        onClick = { this._onHelpIconClicked } />
                 </div>
             </View>
         );
+    }
+
+    /**
+     * Redirects the user to the help page.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onHelpIconClicked() {
+        this.props.history.push(ROUTES.HELP);
     }
 
     /**


### PR DESCRIPTION
Clicking on the help icon takes user to the help page.

![Image from iOS (1)](https://user-images.githubusercontent.com/2965063/57883143-0071f900-77eb-11e9-863e-a0b6027cb04c.png)
![Image from iOS](https://user-images.githubusercontent.com/2965063/57883145-023bbc80-77eb-11e9-9fcd-e59fdf82b1f3.png)
<img width="1433" alt="Screenshot 2019-05-16 14 52 41" src="https://user-images.githubusercontent.com/2965063/57883157-07990700-77eb-11e9-8651-fc9f0eee90b4.png">
<img width="1330" alt="Screenshot 2019-05-16 14 54 02" src="https://user-images.githubusercontent.com/2965063/57883160-09fb6100-77eb-11e9-8d47-f68d61ab71d5.png">



