### PR TITLE
fix(meeting): center mute icons

### DIFF
--- a/spot-client/src/common/css/page-layouts/spot-tv/meeting-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/meeting-view.scss
@@ -48,15 +48,19 @@
 
     .meeting-status {
         bottom: 50px;
-        left: 25px;
+        left: 50%;
         position: absolute;
+        transform: translate(-50%, -50%);
 
         .status-icon {
             background: rgba(0, 0, 0, 0.3);
             border-radius: 50%;
             display: inline-block;
-            margin-right: 1em;
             padding: 1em;
+
+            &:not(:last-child) {
+                margin-right: 1em;
+            }
 
             svg {
                 font-size: $font-size-x-large;


### PR DESCRIPTION
So that they do not overlap notifications.

![Screen Shot 2019-05-17 at 2 36 52 PM](https://user-images.githubusercontent.com/1243084/57957503-5a3cf680-78b1-11e9-8886-11545fcc51f6.png)
