### PR TITLE
feat(nav): move tile view toggle into more menu

### DIFF
--- a/spot-client/src/common/css/page-layouts/more-modal.scss
+++ b/spot-client/src/common/css/page-layouts/more-modal.scss
@@ -1,9 +1,11 @@
+@import './../mixins.scss';
 @import './../variables.scss';
 
 .more-modal {
+    @include centered-content;
+
     background-color: var(--container-bg-color);
     display: flex;
-    flex: 1;
-    flex-direction: column;
     padding: 50px;
+    justify-content: space-around;
 }

--- a/spot-client/src/common/icons/index.js
+++ b/spot-client/src/common/icons/index.js
@@ -19,7 +19,8 @@ export {
     Star,
     StarBorder,
     Videocam,
-    VideocamOff
+    VideocamOff,
+    VolumeUp
 } from '@material-ui/icons';
 export { default as WiredScreenshare } from './wired-screenshare-icon';
 export { default as WirelessScreenshare } from './wireless-screenshare-icon';

--- a/spot-client/src/spot-remote/ui/components/nav/index.js
+++ b/spot-client/src/spot-remote/ui/components/nav/index.js
@@ -1,2 +1,3 @@
+export * from './buttons';
 export { default as NavButton } from './nav-button';
 export { default as NavContainer } from './nav-container';

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -16,7 +16,6 @@ import { isWirelessScreenshareSupported, parseMeetingUrl } from 'common/utils';
 import { NavButton, NavContainer } from '../../components';
 import {
     AudioMuteButton,
-    TileViewButton,
     VideoMuteButton
 } from './../../components/nav/buttons';
 
@@ -114,10 +113,10 @@ export class InCall extends React.Component {
                         subIcon = { this._renderScreenshareSubIcon() }>
                         <ScreenShare />
                     </NavButton>
-                    <TileViewButton />
                     <NavButton
                         label = 'More'
-                        onClick = { this._onToggleMore }>
+                        onClick = { this._onToggleMore }
+                        qaId = 'more'>
                         <MoreVert />
                     </NavButton>
                     <NavButton

--- a/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { MenuButton } from '../../components/remote-control-menu';
+import { VolumeUp } from 'common/icons';
+import { NavButton, TileViewButton } from '../../components';
 
 import VolumeModal from './volume-modal';
 
@@ -43,7 +44,9 @@ export default class MoreModal extends React.Component {
         }
 
         return (
-            <div className = 'modal'>
+            <div
+                className = 'modal'
+                data-qa-id = 'more-modal'>
                 <div className = 'modal-shroud' />
                 <div className = 'modal-content'>
                     <button
@@ -53,9 +56,12 @@ export default class MoreModal extends React.Component {
                         x
                     </button>
                     <div className = 'more-modal'>
-                        <MenuButton
+                        <TileViewButton />
+                        <NavButton
                             label = 'Volume control'
-                            onClick = { this._onToggleVolumeModal } />
+                            onClick = { this._onToggleVolumeModal }>
+                            <VolumeUp />
+                        </NavButton>
                     </div>
                 </div>
             </div>

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -4,6 +4,8 @@ const ScreensharePicker = require('./screenshare-picker');
 
 const AUDIO_MUTE_BUTTON = '[data-qa-id=mute-audio]';
 const AUDIO_UNMUTE_BUTTON = '[data-qa-id=unmute-audio]';
+const MORE_BUTTON = '[data-qa-id=more]';
+const MORE_MODAL = '[data-qa-id=more-modal]';
 const REMOTE_CONTROL = '[data-qa-id=remoteControl-view]';
 const START_SHARE_BUTTON = '[data-qa-id=start-share]';
 const STOP_SHARE_BUTTON = '[data-qa-id=stop-share]';
@@ -53,6 +55,21 @@ class SpotRemoteInMeetingPage extends PageObject {
     }
 
     /**
+     * Displays the modal holder other nav buttons.
+     *
+     * @returns {void}
+     */
+    openMoreMenu() {
+        this.waitForElementDisplayed(MORE_BUTTON);
+
+        if (!this.select(MORE_MODAL).isExisting()) {
+            this.select(MORE_BUTTON).click();
+        }
+
+        this.waitForElementDisplayed(MORE_MODAL);
+    }
+
+    /**
      * Enables or disable tile view layout.
      *
      * @param {boolean} enabled - Whether tile view should be enabled or
@@ -60,6 +77,8 @@ class SpotRemoteInMeetingPage extends PageObject {
      * @returns {void}
      */
     setTileView(enabled) {
+        this.openMoreMenu();
+
         const buttonToClick = enabled
             ? TILE_VIEW_ENABLE_BUTTON
             : TILE_VIEW_DISABLE_BUTTON;


### PR DESCRIPTION
The tile view button was always meant to be put
into the dumphole that will be the more menu.
    
Updated the volume button to look like the other
nav button. The previous volume button looked
inconsistent next to the tile view button.
![Screen Shot 2019-05-22 at 10 30 58 AM](https://user-images.githubusercontent.com/1243084/58196302-d8691680-7c7e-11e9-90b6-174b5dce84f5.png)
