### PR TITLE
fix(ci): lint spot-electron

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -15,6 +15,10 @@ cd ../spot-webdriver
 npm install
 npm run lint
 
+cd ../spot-electron
+npm install
+npm run lint
+
 pid=""
 
 # if [ -z "$TEST_SERVER_URL" ]; then


### PR DESCRIPTION
There must be a better way...

until that's done, I'm gonna stay dumb. I tried looking up how it would be done in a mono-repo. There could be a root eslint file but I always wanted the root to be pretty clean, with the assumption we'd have non-js projects in here too...and that assumption might just be wrong.