### PR TITLE
 feat(detection): add ability to check for volume control support

### DIFF
--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -67,5 +67,5 @@ export function isConnectedToSpot(state) {
  * @returns {boolean}
  */
 export function isVolumeControlSupported(state) {
-    return Boolean(state.spotTv.supportsOSFunctionality);
+    return Boolean(state.spotTv.electron);
 }

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -58,3 +58,14 @@ export function getRemoteSpotTVRoomName(state) {
 export function isConnectedToSpot(state) {
     return Boolean(state.spotTv.spotId);
 }
+
+/**
+ * A selector which returns whether or not the Spot-TV has volume control
+ * support.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function isVolumeControlSupported(state) {
+    return Boolean(state.spotTv.supportsOSFunctionality);
+}

--- a/spot-client/src/common/utils/detection.js
+++ b/spot-client/src/common/utils/detection.js
@@ -35,7 +35,7 @@ export function isDesktopBrowser() {
  * @returns {boolean}
  */
 export function isElectron() {
-    return window && window.process && window.process.emit;
+    return Boolean(window && window.process && window.process.emit);
 }
 
 /**

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -40,7 +40,7 @@ const store = createStore(
         spotTv: {
 
             // Will get overridden on Spot-Remote by Spot-TV updates.
-            supportsOSFunctionality: isElectron()
+            electron: isElectron()
         },
         ...getPersistedState()
     },

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -24,6 +24,7 @@ import {
 import {
     getDeviceId,
     getPersistedState,
+    isElectron,
     setPersistedState
 } from 'common/utils';
 
@@ -35,6 +36,11 @@ const store = createStore(
     {
         config: {
             ...setDefaultValues(window.JitsiMeetSpotConfig)
+        },
+        spotTv: {
+
+            // Will get overridden on Spot-Remote by Spot-TV updates.
+            supportsOSFunctionality: isElectron()
         },
         ...getPersistedState()
     },

--- a/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
+++ b/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
@@ -26,6 +26,7 @@ import { getRoomInfo } from './../../app-state';
 const presenceToStoreAsBoolean = new Set([
     'audioMuted',
     'screensharing',
+    'supportsOSFunctionality',
     'tileView',
     'videoMuted',
     'wiredScreensharingEnabled'

--- a/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
+++ b/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
@@ -25,8 +25,8 @@ import { getRoomInfo } from './../../app-state';
  */
 const presenceToStoreAsBoolean = new Set([
     'audioMuted',
+    'electron',
     'screensharing',
-    'supportsOSFunctionality',
     'tileView',
     'videoMuted',
     'wiredScreensharingEnabled'

--- a/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
+
+import { isVolumeControlSupported } from 'common/app-state';
 
 import { VolumeUp } from 'common/icons';
 import { NavButton, TileViewButton } from '../../components';
@@ -9,10 +12,11 @@ import VolumeModal from './volume-modal';
 /**
  * Implements a modal to show some more buttons that are probably less often used as the main ones on the screen.
  */
-export default class MoreModal extends React.Component {
+export class MoreModal extends React.Component {
     static propTypes = {
-        onClose: PropTypes.func
-    }
+        onClose: PropTypes.func,
+        supportsVolumeControl: PropTypes.bool
+    };
 
     /**
      * Instantiates a new {@code Component}.
@@ -57,11 +61,15 @@ export default class MoreModal extends React.Component {
                     </button>
                     <div className = 'more-modal'>
                         <TileViewButton />
-                        <NavButton
-                            label = 'Volume control'
-                            onClick = { this._onToggleVolumeModal }>
-                            <VolumeUp />
-                        </NavButton>
+                        {
+                            this.props.supportsVolumeControl && (
+                                <NavButton
+                                    label = 'Volume control'
+                                    onClick = { this._onToggleVolumeModal }>
+                                    <VolumeUp />
+                                </NavButton>
+                            )
+                        }
                     </div>
                 </div>
             </div>
@@ -79,3 +87,19 @@ export default class MoreModal extends React.Component {
         });
     }
 }
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code MoreModal}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        supportsVolumeControl: isVolumeControlSupported(state)
+    };
+}
+
+export default connect(mapStateToProps)(MoreModal);


### PR DESCRIPTION
Re-opening of #309. These changes didn't make it in before volume control so they're being applied after volume control has been merged. The volume control button simply won't display.

We'll need to figure out the UI/UX for this case a big better. But at least for now we're not gonna show the volume buttons when they won't do anything.
![Screen Shot 2019-05-22 at 12 43 15 PM](https://user-images.githubusercontent.com/1243084/58203551-3271d800-7c8f-11e9-8bb4-b5c76aef7ef6.png)
