### PR TITLE
feat(modal): add a manager

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -8,6 +8,7 @@ import {
     ErrorBoundary,
     FatalError,
     IdleCursorDetector,
+    ModalManager,
     Notifications
 } from 'common/ui';
 import { Help, JoinCodeEntry, RemoteControl, ShareView } from 'spot-remote/ui';
@@ -164,6 +165,7 @@ export class App extends React.Component {
                             <Route component = { JoinCodeEntry } />
                         </Switch>
                     </div>
+                    <ModalManager />
                 </IdleCursorDetector>
             </ErrorBoundary>
         );

--- a/spot-client/src/common/app-state/index.js
+++ b/spot-client/src/common/app-state/index.js
@@ -1,5 +1,6 @@
 import calendars from './calendars/reducer';
 import config from './config/reducer';
+import modal from './modal/reducer';
 import notifications from './notifications/reducer';
 import remoteControlService from './remote-control-service/reducer';
 import setup from './setup/reducer';
@@ -9,6 +10,7 @@ import wiredScreenshare from './wired-screenshare/reducer';
 const reducers = {
     calendars,
     config,
+    modal,
     notifications,
     remoteControlService,
     setup,
@@ -19,6 +21,7 @@ const reducers = {
 export default reducers;
 
 export * from './calendars/actions';
+export * from './modal/actions';
 export * from './notifications/actions';
 export * from './remote-control-service/actions';
 export * from './setup/actions';
@@ -33,6 +36,7 @@ export * from './calendars/selectors';
 export * from './config/selectors';
 export * from './notifications/selectors';
 export * from './remote-control-service/selectors';
+export * from './modal/selectors';
 export * from './setup/selectors';
 export * from './spot-tv/selectors';
 export * from './wired-screenshare/selectors';

--- a/spot-client/src/common/app-state/modal/actionTypes.js
+++ b/spot-client/src/common/app-state/modal/actionTypes.js
@@ -1,0 +1,3 @@
+export const MODAL_HIDE = 'MODAL_HIDE';
+
+export const MODAL_SHOW = 'MODAL_SHOW';

--- a/spot-client/src/common/app-state/modal/actions.js
+++ b/spot-client/src/common/app-state/modal/actions.js
@@ -1,0 +1,27 @@
+import { MODAL_HIDE, MODAL_SHOW } from './actionTypes';
+
+/**
+ * Display a given modal component.
+ *
+ * @param {Object} modal - The modal component to be displayed.
+ * @param {Object} modalProps - Props to pass into the modal component.
+ * @returns {Object}
+ */
+export function showModal(modal, modalProps = {}) {
+    return {
+        type: MODAL_SHOW,
+        modal,
+        modalProps
+    };
+}
+
+/**
+ * Stops showing the currently displayed modal.
+ *
+ * @returns {Object}
+ */
+export function hideModal() {
+    return {
+        type: MODAL_HIDE
+    };
+}

--- a/spot-client/src/common/app-state/modal/reducer.js
+++ b/spot-client/src/common/app-state/modal/reducer.js
@@ -1,0 +1,32 @@
+import { MODAL_HIDE, MODAL_SHOW } from './actionTypes';
+
+const DEFAULT_STATE = {
+    modal: null,
+    modalProps: null
+};
+
+/**
+ * A {@code Reducer} to update the current Redux state for the 'modal' feature,
+ * which controls the display of a modal over all other UI.
+ *
+ * @param {Object} state - The current Redux state for the 'modal' feature.
+ * @param {Object} action - The Redux state update payload.
+ * @returns {Object} The new redux state for the feature 'modal'.
+ */
+const modal = (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+    case MODAL_HIDE:
+        return DEFAULT_STATE;
+
+    case MODAL_SHOW:
+        return {
+            modal: action.modal,
+            modalProps: action.modalProps
+        };
+
+    default:
+        return state;
+    }
+};
+
+export default modal;

--- a/spot-client/src/common/app-state/modal/selectors.js
+++ b/spot-client/src/common/app-state/modal/selectors.js
@@ -1,0 +1,25 @@
+/**
+ * A selector which returns the current modal, if any, which should be
+ * displayed.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {Object}
+ */
+export function getCurrentModal(state) {
+    return {
+        modal: state.modal.modal,
+        modalProps: state.modal.modalProps
+    };
+}
+
+/**
+ * A selector which returns if the currently displayed modal, if any, matches
+ * the provided component.
+ *
+ * @param {Object} state - The Redux state.
+ * @param {Object} modal - The modal component to check if is displayed.
+ * @returns {boolean}
+ */
+export function isModalOpen(state, modal) {
+    return state.modal.modal === modal;
+}

--- a/spot-client/src/common/css/_desktop-picker.scss
+++ b/spot-client/src/common/css/_desktop-picker.scss
@@ -1,4 +1,6 @@
 .electron-desktop-picker-modal {
+    z-index: 11;
+
     .modal-shroud {
         background-color: black;
         opacity: 0.7;

--- a/spot-client/src/common/ui/components/index.js
+++ b/spot-client/src/common/ui/components/index.js
@@ -5,6 +5,7 @@ export * from './error-boundary';
 export * from './idle-cursor-detector';
 export * from './input';
 export * from './loading-icon';
+export * from './modal';
 export * from './notifications';
 export * from './reset';
 export * from './room-name';

--- a/spot-client/src/common/ui/components/modal/Modal.js
+++ b/spot-client/src/common/ui/components/modal/Modal.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Yeah.
+ *
+ * @extends React.Component
+ */
+export default class Modal extends React.PureComponent {
+    static propTypes = {
+        children: PropTypes.node,
+        onClose: PropTypes.func,
+        qaId: PropTypes.string
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <div
+                className = 'modal'
+                data-qa-id = { this.props.qaId }>
+                <div className = 'modal-shroud' />
+                <div className = 'modal-content'>
+                    <button
+                        className = 'close'
+                        onClick = { this.props.onClose }
+                        type = 'button'>
+                        x
+                    </button>
+                    { this.props.children }
+                </div>
+            </div>
+        );
+    }
+}

--- a/spot-client/src/common/ui/components/modal/Modal.js
+++ b/spot-client/src/common/ui/components/modal/Modal.js
@@ -10,7 +10,8 @@ export default class Modal extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
         onClose: PropTypes.func,
-        qaId: PropTypes.string
+        qaId: PropTypes.string,
+        rootClassName: PropTypes.string
     };
 
     /**
@@ -22,7 +23,7 @@ export default class Modal extends React.PureComponent {
     render() {
         return (
             <div
-                className = 'modal'
+                className = { `modal ${this.props.rootClassName || ''}` }
                 data-qa-id = { this.props.qaId }>
                 <div className = 'modal-shroud' />
                 <div className = 'modal-content'>

--- a/spot-client/src/common/ui/components/modal/Modal.js
+++ b/spot-client/src/common/ui/components/modal/Modal.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
- * Yeah.
+ * Displays a modal dialog in the middle of the screen, above other UI elemnts.
  *
  * @extends React.Component
  */

--- a/spot-client/src/common/ui/components/modal/ModalManager.js
+++ b/spot-client/src/common/ui/components/modal/ModalManager.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { getCurrentModal } from 'common/app-state';
+
+/**
+ * Displays a modal component stored in Redux.
+ *
+ * @extends React.PureComponent
+ */
+export class ModalManager extends React.PureComponent {
+    static defaultProps = {
+        modalProps: {}
+    };
+
+    static propTypes = {
+        modal: PropTypes.func,
+        modalProps: PropTypes.object
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     */
+    render() {
+        if (!this.props.modal) {
+            return null;
+        }
+
+        const Modal = this.props.modal;
+
+        return <Modal { ...this.props.modalProps } />;
+    }
+}
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code ModalManager}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        ...getCurrentModal(state)
+    };
+}
+
+export default connect(mapStateToProps)(ModalManager);

--- a/spot-client/src/common/ui/components/modal/index.js
+++ b/spot-client/src/common/ui/components/modal/index.js
@@ -1,0 +1,1 @@
+export { default as ModalManager } from './ModalManager';

--- a/spot-client/src/common/ui/components/modal/index.js
+++ b/spot-client/src/common/ui/components/modal/index.js
@@ -1,1 +1,2 @@
+export { default as Modal } from './Modal';
 export { default as ModalManager } from './ModalManager';

--- a/spot-client/src/spot-remote/ui/components/electron-desktop-picker/electron-desktop-picker-modal.js
+++ b/spot-client/src/spot-remote/ui/components/electron-desktop-picker/electron-desktop-picker-modal.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Modal } from 'common/ui';
+
 import DesktopPicker from './desktop-picker';
 
 /**
@@ -59,18 +61,11 @@ export default class ElectronDesktopPickerModal extends React.Component {
         }
 
         return (
-            <div className = 'modal electron-desktop-picker-modal'>
-                <div className = 'modal-shroud' />
-                <div className = 'modal-content'>
-                    <button
-                        className = 'close'
-                        onClick = { this._onClose }
-                        type = 'button'>
-                        x
-                    </button>
-                    <DesktopPicker onSelect = { this._onClose } />
-                </div>
-            </div>
+            <Modal
+                onClose = { this._onClose }
+                rootClassName = 'electron-desktop-picker-modal'>
+                <DesktopPicker onSelect = { this._onClose } />
+            </Modal>
         );
     }
 

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -176,6 +176,8 @@ export class InCall extends React.Component {
     _onToggleScreenshare() {
         if (this.props.isScreenshareModalOpen) {
             this.props.hideModal();
+
+            return;
         }
 
         // If only wireless sceensharing is available and there is no

--- a/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { hideModal, isVolumeControlSupported } from 'common/app-state';
 
 import { VolumeUp } from 'common/icons';
+import { Modal } from 'common/ui';
 import { NavButton, TileViewButton } from '../../components';
 
 import VolumeModal from './volume-modal';
@@ -48,31 +49,22 @@ export class MoreModal extends React.Component {
         }
 
         return (
-            <div
-                className = 'modal'
-                data-qa-id = 'more-modal'>
-                <div className = 'modal-shroud' />
-                <div className = 'modal-content'>
-                    <button
-                        className = 'close'
-                        onClick = { this.props.onClose }
-                        type = 'button'>
-                        x
-                    </button>
-                    <div className = 'more-modal'>
-                        <TileViewButton />
-                        {
-                            this.props.supportsVolumeControl && (
-                                <NavButton
-                                    label = 'Volume control'
-                                    onClick = { this._onToggleVolumeModal }>
-                                    <VolumeUp />
-                                </NavButton>
-                            )
-                        }
-                    </div>
+            <Modal
+                onClose = { this.props.onClose }
+                qaId = 'more-modal'>
+                <div className = 'more-modal'>
+                    <TileViewButton />
+                    {
+                        this.props.supportsVolumeControl && (
+                            <NavButton
+                                label = 'Volume control'
+                                onClick = { this._onToggleVolumeModal }>
+                                <VolumeUp />
+                            </NavButton>
+                        )
+                    }
                 </div>
-            </div>
+            </Modal>
         );
     }
 

--- a/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/more-modal.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { isVolumeControlSupported } from 'common/app-state';
+import { hideModal, isVolumeControlSupported } from 'common/app-state';
 
 import { VolumeUp } from 'common/icons';
 import { NavButton, TileViewButton } from '../../components';
@@ -102,4 +102,24 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(MoreModal);
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        /**
+         * Stop showing the {@code MoreModal}.
+         *
+         * @returns {void}
+         */
+        onClose() {
+            dispatch(hideModal());
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoreModal);

--- a/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
@@ -1,5 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
+
+import {
+    getInMeetingStatus,
+    hideModal,
+    startWiredScreensharing,
+    startWirelessScreensharing,
+    stopScreenshare
+} from 'common/app-state';
+import { isWirelessScreenshareSupported } from 'common/utils';
 
 import { ScreensharePicker } from './../../components';
 
@@ -10,14 +20,26 @@ import { ScreensharePicker } from './../../components';
  */
 export class ScreenshareModal extends React.Component {
     static propTypes = {
-        onClose: PropTypes.func,
+        onHideModal: PropTypes.func,
         onStartWiredScreenshare: PropTypes.func,
         onStartWirelessScreenshare: PropTypes.func,
         onStopScreensharing: PropTypes.func,
         screensharingType: PropTypes.string,
-        wiredScreenshareEnabled: PropTypes.bool,
-        wirelessScreenshareEnabled: PropTypes.bool
+        wiredScreensharingEnabled: PropTypes.bool
     };
+
+    /**
+     * Initializes a new {@code ScreenshareModal} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._onStopScreenshare = this._onStopScreenshare.bind(this);
+        this._isWirelessScreenshareSupported = isWirelessScreenshareSupported();
+    }
 
     /**
      * Implements React's {@link Component#render()}.
@@ -32,7 +54,7 @@ export class ScreenshareModal extends React.Component {
                 <div className = 'modal-content'>
                     <button
                         className = 'close'
-                        onClick = { this.props.onClose }
+                        onClick = { this.props.onHideModal }
                         type = 'button'>
                         x
                     </button>
@@ -43,17 +65,102 @@ export class ScreenshareModal extends React.Component {
                             onStartWirelessScreenshare
                                 = { this.props.onStartWirelessScreenshare }
                             onStopScreensharing
-                                = { this.props.onStopScreensharing }
+                                = { this._onStopScreenshare }
                             screensharingType = { this.props.screensharingType }
                             wiredScreenshareEnabled
-                                = { this.props.wiredScreenshareEnabled }
+                                = { this.props.wiredScreensharingEnabled }
                             wirelessScreenshareEnabled
-                                = { this.props.wirelessScreenshareEnabled } />
+                                = { this._isWirelessScreenshareSupported } />
                     </div>
                 </div>
             </div>
         );
     }
+
+    /**
+     * Turns off any active screenshare.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onStopScreenshare() {
+        this.props.onStopScreensharing()
+            .then(() => {
+                // Special case to immediately close the modal when stopping
+                // screenshare while only wireless screenshare is available.
+                if (this._isWirelessScreenshareSupported
+                    && !this.props.wiredScreensharingEnabled) {
+                    this.props.onHideModal();
+                }
+            });
+    }
 }
 
-export default ScreenshareModal;
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code ScreenshareModal}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    const {
+        screensharingType,
+        wiredScreensharingEnabled
+    } = getInMeetingStatus(state);
+
+    return {
+        screensharingType,
+        wiredScreensharingEnabled
+    };
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        /**
+         * Sets the {@code ScreenshareModal} to be hidden.
+         *
+         * @returns {void}
+         */
+        onHideModal() {
+            dispatch(hideModal());
+        },
+
+        /**
+         * Triggers the wireless screensharing flow to be started.
+         *
+         * @returns {Promise}
+         */
+        onStartWirelessScreenshare() {
+            return dispatch(startWirelessScreensharing());
+        },
+
+        /**
+         * Triggers wired screensharing to be enabled.
+         *
+         * @returns {void}
+         */
+        onStartWiredScreenshare() {
+            dispatch(startWiredScreensharing());
+        },
+
+        /**
+         * Turns off any active screenshare.
+         *
+         * @returns {Promise}
+         */
+        onStopScreensharing() {
+            return dispatch(stopScreenshare());
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ScreenshareModal);

--- a/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/screenshare-modal.js
@@ -9,6 +9,7 @@ import {
     startWirelessScreensharing,
     stopScreenshare
 } from 'common/app-state';
+import { Modal } from 'common/ui';
 import { isWirelessScreenshareSupported } from 'common/utils';
 
 import { ScreensharePicker } from './../../components';
@@ -49,31 +50,22 @@ export class ScreenshareModal extends React.Component {
      */
     render() {
         return (
-            <div className = 'modal'>
-                <div className = 'modal-shroud' />
-                <div className = 'modal-content'>
-                    <button
-                        className = 'close'
-                        onClick = { this.props.onHideModal }
-                        type = 'button'>
-                        x
-                    </button>
-                    <div className = 'share-select-view'>
-                        <ScreensharePicker
-                            onStartWiredScreenshare
-                                = { this.props.onStartWiredScreenshare }
-                            onStartWirelessScreenshare
-                                = { this.props.onStartWirelessScreenshare }
-                            onStopScreensharing
-                                = { this._onStopScreenshare }
-                            screensharingType = { this.props.screensharingType }
-                            wiredScreenshareEnabled
-                                = { this.props.wiredScreensharingEnabled }
-                            wirelessScreenshareEnabled
-                                = { this._isWirelessScreenshareSupported } />
-                    </div>
+            <Modal onClose = { this.props.onHideModal }>
+                <div className = 'share-select-view'>
+                    <ScreensharePicker
+                        onStartWiredScreenshare
+                            = { this.props.onStartWiredScreenshare }
+                        onStartWirelessScreenshare
+                            = { this.props.onStartWirelessScreenshare }
+                        onStopScreensharing
+                            = { this._onStopScreenshare }
+                        screensharingType = { this.props.screensharingType }
+                        wiredScreenshareEnabled
+                            = { this.props.wiredScreensharingEnabled }
+                        wirelessScreenshareEnabled
+                            = { this._isWirelessScreenshareSupported } />
                 </div>
-            </div>
+            </Modal>
         );
     }
 


### PR DESCRIPTION
Encapsulate the display and switching of modals
in its own service.

Known todos:
- [x] test/fix z-indexing with the electron desktop picker
- [x] encapsulate modal dom structure

For future PRs:
- Create screenshare and more button components
- Handle escape key, maybe.
- Autofocus keyboard on the modal.