### PR TITLE
feat(tests): add test for checking no volume control on browsers

### DIFF
--- a/spot-client/src/spot-remote/ui/components/more/MoreModal.js
+++ b/spot-client/src/spot-remote/ui/components/more/MoreModal.js
@@ -60,7 +60,8 @@ export class MoreModal extends React.Component {
                         this.props.supportsVolumeControl && (
                             <NavButton
                                 label = 'Volume control'
-                                onClick = { this._onToggleVolumeModal }>
+                                onClick = { this._onToggleVolumeModal }
+                                qaId = 'volume'>
                                 <VolumeUp />
                             </NavButton>
                         )

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -13,7 +13,7 @@ const TILE_VIEW_ENABLE_BUTTON = '[data-qa-id=enter-tile-view]';
 const TILE_VIEW_DISABLE_BUTTON = '[data-qa-id=exit-tile-view]';
 const VIDEO_MUTE_BUTTON = '[data-qa-id=mute-video]';
 const VIDEO_UNMUTE_BUTTON = '[data-qa-id=unmute-video]';
-
+const VOLUME_BUTTON = '[data-qa-id=volume]';
 
 /**
  * A page object for interacting with the in-meeting view of Spot-Remote.
@@ -30,6 +30,17 @@ class SpotRemoteInMeetingPage extends PageObject {
         this.screensharePicker = new ScreensharePicker(this.driver);
 
         this.rootSelector = REMOTE_CONTROL;
+    }
+
+    /**
+     * Check if the volume button is available for interaction.
+     *
+     * @returns {boolean}
+     */
+    hasVolumeControls() {
+        this.openMoreMenu();
+
+        return this.select(VOLUME_BUTTON).isExisting();
     }
 
     /**

--- a/spot-webdriver/specs/in-meeting.spec.js
+++ b/spot-webdriver/specs/in-meeting.spec.js
@@ -58,4 +58,8 @@ describe('While in a meeting ', () => {
         spotRemoteInMeetingPage.setTileView(inTileView);
         spotTVMeetingPage.waitForTileViewStateToBe(inTileView);
     });
+
+    it('does not have volume control when Spot-TV is in a browser', () => {
+        expect(spotRemote.getInMeetingPage().hasVolumeControls()).toBe(false);
+    });
 });


### PR DESCRIPTION
Not sure how to test for the existence of volume controls,
which is gated for electron only.

Edit: looked around a bit and there's electron-chromedriver for testing electron apps. Probably that'll need to be done one day to test volume control.