### PR TITLE
ref(rcs): rename subclasses to RCServer and RCClient

### DIFF
--- a/spot-client/docs/glossary.md
+++ b/spot-client/docs/glossary.md
@@ -23,7 +23,13 @@ The javascript library which contains XMPP, MUC, and WebRTC code used by Jitsi-M
 A library for ultrasound transmitting and decoding. The main library is lib-quiet, written in C, but the maintainer provides iOS, Android, and JS libraries to use lib-quiet. See Ultrasound.
 
 ### RCS, Remote Control Service
-The object which encapsulates setting up a connection between a Spot-Remote and a Spot-TV and encapsulates how they communicate with each other. Spot-TV and Spot-Remote have their own versions of the service, with Spot-Remote having more functionality around sending commands whereas Spot-TV has more functionality around processing commands and sending status updates.
+The objects which encapsulates setting up a connection between a Spot-Remote and a Spot-TV and encapsulates how they communicate with each other. Spot-TV and Spot-Remote have their own versions of the service, with Spot-Remote having more functionality around sending commands whereas Spot-TV has more functionality around processing commands and sending status updates.
+
+### Remote Control Client
+The name for the subclass of Remote Control Service used by Spot-Remote.
+
+### Remote Control Server
+The name for the subclass of Remote Control Service used by Spot-TV.
 
 ### Share Mode
 Spot-Remote supports a special UX flow where the UI is reduced mainly to starting and stopping wireless screensharing. 

--- a/spot-client/src/common/app-state/remote-control-service/actions.js
+++ b/spot-client/src/common/app-state/remote-control-service/actions.js
@@ -1,7 +1,7 @@
 import { logger } from 'common/logger';
 import { avUtils } from 'common/media';
 import { createAsyncActionWithStates } from 'common/redux';
-import { spotRemoteRemoteControlService } from 'common/remote-control';
+import { remoteControlClient } from 'common/remote-control';
 
 import { setSpotTVState } from './../spot-tv/actions';
 
@@ -27,7 +27,7 @@ import {
  */
 export function joinWithScreensharing(meetingName, screensharingType) {
     return dispatch => {
-        spotRemoteRemoteControlService
+        remoteControlClient
             .goToMeeting(
                 meetingName,
                 {
@@ -63,7 +63,7 @@ export function joinWithScreensharing(meetingName, screensharingType) {
  */
 export function joinScheduledMeeting(meetingName) {
     return dispatch => {
-        spotRemoteRemoteControlService.goToMeeting(meetingName);
+        remoteControlClient.goToMeeting(meetingName);
         dispatch({
             type: JOIN_SCHEDULED_MEETING,
             meetingName
@@ -79,7 +79,7 @@ export function joinScheduledMeeting(meetingName) {
  */
 export function joinAdHocMeeting(meetingName) {
     return dispatch => {
-        spotRemoteRemoteControlService.goToMeeting(meetingName);
+        remoteControlClient.goToMeeting(meetingName);
         dispatch({
             type: JOIN_AD_HOC_MEETING,
             meetingName
@@ -105,7 +105,7 @@ export function dialOut(meetingName, phoneNumber) {
     };
 
     return dispatch => {
-        spotRemoteRemoteControlService.goToMeeting(meetingName, options);
+        remoteControlClient.goToMeeting(meetingName, options);
         dispatch({
             type: DIAL_OUT,
             meetingName,
@@ -123,7 +123,7 @@ export function dialOut(meetingName, phoneNumber) {
  */
 export function hangUp(skipFeedback) {
     return dispatch => {
-        spotRemoteRemoteControlService.hangUp(skipFeedback);
+        remoteControlClient.hangUp(skipFeedback);
         dispatch({
             type: HANG_UP,
             skipFeedback
@@ -140,7 +140,7 @@ export function hangUp(skipFeedback) {
 export function setAudioMute(mute) {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setAudioMute(mute),
+        () => remoteControlClient.setAudioMute(mute),
         AUDIO_MUTE,
         mute
     ).then(() => dispatch(setSpotTVState({ audioMuted: mute })));
@@ -155,7 +155,7 @@ export function setAudioMute(mute) {
 export function setTileView(tileView) {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setTileView(tileView),
+        () => remoteControlClient.setTileView(tileView),
         TILE_VIEW,
         tileView
     ).then(() => dispatch(setSpotTVState({ tileView })));
@@ -170,7 +170,7 @@ export function setTileView(tileView) {
 export function setVideoMute(mute) {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setVideoMute(mute),
+        () => remoteControlClient.setVideoMute(mute),
         VIDEO_MUTE,
         mute
     ).then(() => dispatch(setSpotTVState({ videoMuted: mute })));
@@ -184,7 +184,7 @@ export function setVideoMute(mute) {
 export function startWiredScreensharing() {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setScreensharing(true),
+        () => remoteControlClient.setScreensharing(true),
         SCREENSHARE,
         'wired');
 }
@@ -197,7 +197,7 @@ export function startWiredScreensharing() {
 export function startWirelessScreensharing() {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setWirelessScreensharing(
+        () => remoteControlClient.setWirelessScreensharing(
             true,
             { onClose: () => dispatch(stopScreenshare()) }
         ),
@@ -217,7 +217,7 @@ export function startWirelessScreensharing() {
  */
 export function forceStopWirelessScreenshare() {
     return dispatch => {
-        spotRemoteRemoteControlService.destroyWirelessScreenshareConnections();
+        remoteControlClient.destroyWirelessScreenshareConnections();
 
         dispatch(setLocalWirelessScreensharing(false));
     };
@@ -231,7 +231,7 @@ export function forceStopWirelessScreenshare() {
 export function stopScreenshare() {
     return dispatch => createAsyncActionWithStates(
         dispatch,
-        () => spotRemoteRemoteControlService.setScreensharing(false),
+        () => remoteControlClient.setScreensharing(false),
         SCREENSHARE,
         undefined
     ).then(() => {

--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -97,7 +97,7 @@ export class BaseRemoteControlService extends EventEmitter {
      * @returns {void}
      */
     _onDisconnect(reason) {
-        if (reason === CONNECTION_EVENTS.SPOT_TV_DISCONNECTED
+        if (reason === CONNECTION_EVENTS.SERVER_DISCONNECTED
             || reason === 'not-authorized') {
             this.emit(SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT, { reason });
 
@@ -249,7 +249,7 @@ export class BaseRemoteControlService extends EventEmitter {
         const message = iq.getElementsByTagName('message')[0];
         const messageType = message.getAttribute('type');
 
-        logger.log('remoteControlService received message', { messageType });
+        logger.log('RemoteControlService received message', { messageType });
 
         let data;
 

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -1,6 +1,6 @@
 /**
- * An enumeration of supported commands Spot can processes. All values are from
- * events triggered by the jitsi meet iframe api.
+ * An enumeration of supported commands {@code RemoteControlServer} can process.
+ * All values are from events triggered by the Jitsi-Meet iFrame API.
  */
 export const COMMANDS = {
 
@@ -51,9 +51,9 @@ export const COMMANDS = {
 export const CONNECTION_EVENTS = {
 
     /**
-     * A Spot-TV has is no longer available.
+     * A {@code RemoteControlServer} has is no longer available.
      */
-    SPOT_TV_DISCONNECTED: 'spot-tv-disconnected'
+    SERVER_DISCONNECTED: 'server-disconnected'
 };
 
 /**
@@ -78,26 +78,35 @@ export const IQ_NAMESPACES = {
 export const IQ_TIMEOUT = 5000;
 
 /**
- * An enumneration of supported messages that can be sent between Spot and
- * remote control instances.
+ * An enumeration of supported messages that can be sent between
+ * {@code RemoteControlServer} and {@code RemoteControlClient} instances.
  */
 export const MESSAGES = {
+    /**
+     * A {@code RemoteControlClient} is no longer connected to a
+     * {@code RemoteControlServer}.
+     */
+    CLIENT_LEFT: 'remote-control-client-left',
 
     /**
-     * A message about wireless screensharing from Jitsi-Meet to a remote
-     * control, sent by proxy by Spot.
+     * A {@code RemoteControlClient} has sent a message pass into a Jitsi-Meet
+     * meeting.
+     */
+    CLIENT_PROXY_MESSAGE: 'remote-control-client-message',
+
+    /**
+     * A message about wireless screensharing from Jitsi-Meet, to be sent to
+     * a {@code RemoteControlServer} which should resend to a
+     * {@code RemoteControlClient}.
      */
     JITSI_MEET_UPDATE: 'update-message-from-jitsi-meet',
 
     /**
-     * A message from a remote control to Spot that is intended for Spot to
-     * pass into the Jitsi-Meet meeting.
+     * A message from a {@code RemoteControlClient} to a
+     * {@code RemoteControlServer}, intended to be passed into the Jitsi-Meet
+     * meeting.
      */
-    REMOTE_CONTROL_UPDATE: 'update-message-from-remote-control',
-
-    SPOT_REMOTE_LEFT: 'spot-remote-left',
-
-    SPOT_REMOTE_PROXY_MESSAGE: 'spot-remote-message'
+    REMOTE_CONTROL_UPDATE: 'update-message-from-remote-control'
 };
 
 export const SERVICE_UPDATES = {
@@ -108,14 +117,14 @@ export const SERVICE_UPDATES = {
     JOIN_CODE_CHANGE: 'join-code-change',
 
     /**
-     * A command from a Spot-Remote has been received.
+     * A command from a {@code RemoteControlClient} has been received.
      */
-    SPOT_REMOTE_MESSAGE_RECEIVED: 'message-received',
+    CLIENT_MESSAGE_RECEIVED: 'message-received',
 
     /**
      * The remote control service has received an updated Spot-TV state.
      */
-    SPOT_TV_STATE_CHANGE: 'spot-tv-state-change',
+    SERVER_STATE_CHANGE: 'remote-control-server--state-change',
 
     /**
      * The remote control service has lost the XMPP connection and cannot

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -51,7 +51,7 @@ export const COMMANDS = {
 export const CONNECTION_EVENTS = {
 
     /**
-     * A {@code RemoteControlServer} has is no longer available.
+     * The {@code RemoteControlServer} is no longer available.
      */
     SERVER_DISCONNECTED: 'server-disconnected'
 };
@@ -89,8 +89,8 @@ export const MESSAGES = {
     CLIENT_LEFT: 'remote-control-client-left',
 
     /**
-     * A {@code RemoteControlClient} has sent a message pass into a Jitsi-Meet
-     * meeting.
+     * A {@code RemoteControlClient} has sent a message to a
+     * a {@code RemoteControlServer} to pass into a Jitsi-Meet meeting.
      */
     CLIENT_PROXY_MESSAGE: 'remote-control-client-message',
 
@@ -122,9 +122,10 @@ export const SERVICE_UPDATES = {
     CLIENT_MESSAGE_RECEIVED: 'message-received',
 
     /**
-     * The remote control service has received an updated Spot-TV state.
+     * The {@code RemoteControlClient} has received an updated state for the
+     * {@code RemoteControlServer}.
      */
-    SERVER_STATE_CHANGE: 'remote-control-server--state-change',
+    SERVER_STATE_CHANGE: 'remote-control-server-state-change',
 
     /**
      * The remote control service has lost the XMPP connection and cannot

--- a/spot-client/src/common/remote-control/index.js
+++ b/spot-client/src/common/remote-control/index.js
@@ -1,7 +1,5 @@
 export * from './constants';
 export { default as RemoteControlServiceSubscriber }
     from './remote-control-service-subscriber';
-export { default as spotRemoteRemoteControlService }
-    from './spotRemoteRemoteControlService';
-export { default as spotTvRemoteControlService }
-    from './spotTvRemoteControlService';
+export { default as remoteControlClient } from './remoteControlClient';
+export { default as remoteControlServer } from './remoteControlServer';

--- a/spot-client/src/common/remote-control/remote-control-service-subscriber.js
+++ b/spot-client/src/common/remote-control/remote-control-service-subscriber.js
@@ -1,9 +1,9 @@
-import spotRemoteRemoteControlService from './spotRemoteRemoteControlService';
-import spotTvRemoteControlService from './spotTvRemoteControlService';
+import remoteControlClient from './remoteControlClient';
+import remoteControlServer from './remoteControlServer';
 
 /**
- * A class which automatically invokes {@code remoteControlService} methods as
- * the state of Spot-TV changes.
+ * A class which automatically invokes {@code remoteControlClient} and
+ * {@code remoteControlServer} methods to sync with changes to the redux state.
  */
 export default class RemoteControlServiceSubscriber {
     /**
@@ -21,7 +21,7 @@ export default class RemoteControlServiceSubscriber {
      * meeting, trigger any deferred screenshares.
      *
      * @param {Object} store - The redux store from which to subscribe to
-     * app-state updates and notify the remoteControlService.
+     * app-state updates and notify the remote control services.
      * @returns {oid}
      */
     onUpdate(store) {
@@ -36,7 +36,7 @@ export default class RemoteControlServiceSubscriber {
             return;
         }
 
-        spotTvRemoteControlService.updateStatus({
+        remoteControlServer.updateStatus({
             ...newSpotTvState,
             roomName: newRoomName,
             calendar: newCalendarEvents
@@ -44,7 +44,7 @@ export default class RemoteControlServiceSubscriber {
 
         if (this._previousSpotTvState.inMeeting !== newSpotTvState.inMeeting
             && newSpotTvState.inMeeting) {
-            spotRemoteRemoteControlService.startAnyDeferredWirelessScreenshare();
+            remoteControlClient.startAnyDeferredWirelessScreenshare();
         }
 
         this._previousRoomName = newRoomName;

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -19,19 +19,21 @@ import ScreenshareService from './screenshare-connection';
 
 
 /**
- * Communication service for the Spot-Remote to talk to Spot-TV.
+ * Communication service to send commands and receive updates from an instance
+ * of {@code RemoteControlServer}.
  *
  * @extends BaseRemoteControlService
  */
-export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
+export class RemoteControlClient extends BaseRemoteControlService {
     /**
-     * Initializes a new {@code SpotRemoteRemoteControlService} instance.
+     * Initializes a new {@code RemoteControlClient} instance.
      */
     constructor() {
         super();
 
         /**
          * Prevents from triggering more than one go to meeting actions at the same time.
+         *
          * @type {Promise|null}
          * @private
          */
@@ -43,7 +45,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to change its audio level to a specific direction.
+     * Requests the {@code RemoteControlServer} to change its audio level to a
+     * specific direction.
      *
      * @param {string} direction - The direction of the volume adjustment.
      * One of 'up' or 'down'.
@@ -99,8 +102,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Implements a way to get the current join code to connect to this Spot-TV
-     * instance.
+     * Implements a way to get the current join code to connect to the
+     * {@code RemoteControlServer}.
      *
      * @inheritdoc
      * @override
@@ -111,7 +114,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot to join a meeting.
+     * Requests a {@code RemoteControlServer} to join a meeting.
      *
      * @param {string} meetingName - The meeting to join.
      * @param {GoToMeetingOptions} options - Additional details about how to join the
@@ -158,7 +161,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to leave a meeting in progress.
+     * Requests a {@code RemoteControlServer} to leave a meeting in progress.
      *
      * @param {boolean} skipFeedback - Whether or not to immediately navigate
      * out of the meeting instead of display feedback entry.
@@ -177,7 +180,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to change its audio mute status.
+     * Requests a {@code RemoteControlServer} to change its audio mute status.
      *
      * @param {boolean} mute - Whether or not Spot should be audio muted.
      * @returns {Promise} Resolves if the command has been acknowledged.
@@ -188,12 +191,12 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to change its screensharing status. Turning on the
-     * screensharing will enable wired screensharing, while turning off applies
-     * to both wired and wireless screensharing.
+     * Requests a {@code RemoteControlServer} to change its screensharing status.
+     * Turning on the screensharing will enable wired screensharing, while
+     * turning off applies to both wired and wireless screensharing.
      *
-     * @param {boolean} screensharing - Whether or not Spot-TV should start or
-     * stop screensharing.
+     * @param {boolean} screensharing - Whether or not {@code RemoteControlServer}
+     * should start or stop screensharing.
      * @returns {Promise} Resolves if the command has been acknowledged.
      */
     setScreensharing(screensharing) {
@@ -205,10 +208,10 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to enter or exit tile view mode.
+     * Requests a {@code RemoteControlServer} to enter or exit tile view mode.
      *
-     * @param {boolean} tileView - Whether or not Spot-TV should be in or not be
-     * in tile view.
+     * @param {boolean} tileView - Whether or not {@code RemoteControlServer}
+     * should be in or not be in tile view.
      * @returns {Promise} Resolves if the command has been acknowledged.
      */
     setTileView(tileView) {
@@ -220,9 +223,10 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to change its video mute status.
+     * Requests a {@code RemoteControlServer} to change its video mute status.
      *
-     * @param {boolean} mute - Whether or not Spot should be video muted.
+     * @param {boolean} mute - Whether or not {@code RemoteControlServer} should
+     * be video muted.
      * @returns {Promise} Resolves if the command has been acknowledged.
      */
     setVideoMute(mute) {
@@ -231,8 +235,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Begins or stops the process for a Spot-Remote to connect to the local
-     * in-meeting Jitsi in order to directly share a local screen.
+     * Begins or stops the process for a {@code RemoteControlClient} to connect
+     * to the Jitsi-Meet participant in order to directly share a local screen.
      *
      * @param {boolean} enable - Whether to start ot stop screensharing.
      * @param {Object} options - Additional configuration to use for creating
@@ -247,8 +251,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
 
     /**
      * Triggers any stored wireless screesharing connections to start the
-     * process of establishing a connection to a a local Jitsi meeting
-     * participant.
+     * process of establishing a connection to a Jitsi-Meet meeting participant.
      *
      * @returns {void}
      */
@@ -267,7 +270,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a Spot-TV to submit post-meeting feedback.
+     * Requests a {@code RemoteControlServer} to submit post-meeting feedback.
      *
      * @param {Object} feedback - The feedback to submit.
      * @returns {Promise} Resolves if the command has been acknowledged.
@@ -278,8 +281,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Invoked by a Spot-Remote to initialize a new {@link ScreenshareService}
-     * instance.
+     * Initialize a new {@link ScreenshareService} instance.
      *
      * @param {Object} options - Additional configuration to use for creating
      * the screenshare connection.
@@ -309,10 +311,11 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
 
             /**
              * Callback invoked by {@code ScreenshareService} in order to
-             * communicate out to a Spot-TV an update about the screensharing
-             * connection.
+             * communicate out to a {@code RemoteControlServer} an update about
+             * the screensharing connection.
              *
-             * @param {string} to - The Spot-TV jid to send the message to.
+             * @param {string} to - The {@code RemoteControlServer} jid to send
+             * the message to.
              * @param {Object} data - A payload to send along with the
              * message.
              * @returns {Promise}
@@ -328,8 +331,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Called internally by Spot-Remote to the Spot-TV jid for which to send
-     * commands and messages.
+     * Get the {@code RemoteControlServer} jid for which to send commands and
+     * messages.
      *
      * @private
      * @returns {string|null}
@@ -350,9 +353,7 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
             const from = presence.getAttribute('from');
 
             if (this._getSpotId() === from) {
-                // A Spot-Remote needs to be updated about no longer being
-                // connected to a Spot-TV.
-                this._onDisconnect(CONNECTION_EVENTS.SPOT_TV_DISCONNECTED);
+                this._onDisconnect(CONNECTION_EVENTS.SERVER_DISCONNECTED);
             }
 
             return;
@@ -360,8 +361,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
 
         if (updateType === 'error') {
             logger.log(
-                'error presence received, interpreting as Spot-TV disconnect');
-            this._onDisconnect(CONNECTION_EVENTS.SPOT_TV_DISCONNECTED);
+                'error presence received, interpreting as disconnect');
+            this._onDisconnect(CONNECTION_EVENTS.SERVER_DISCONNECTED);
 
             return;
         }
@@ -375,22 +376,23 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
             }, {});
 
         if (status.isSpot !== 'true') {
-            // Ignore presence from others not identified as a Spot-TV.
+            // Ignore presence from others not identified as a
+            // {@code RemoteControlServer}.
             return;
         }
 
         const spotTvJid = presence.getAttribute('from');
 
-        // Redundantly update the known Spot-TV jid in case there are multiple
-        // due to ghosts left form disconnect, in which case the active Spot-TV
-        // should be emitting updates.
+        // Redundantly update the known {@code RemoteControlServer} jid in case
+        // there are multiple due to ghosts left form disconnect, in which case
+        // the active {@code RemoteControlServer} should be emitting updates.
         this._lastSpotState = {
             ...status,
             spotId: spotTvJid
         };
 
         this.emit(
-            SERVICE_UPDATES.SPOT_TV_STATE_CHANGE,
+            SERVICE_UPDATES.SERVER_STATE_CHANGE,
             {
                 updatedState: this._lastSpotState
             }
@@ -407,7 +409,6 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     _processMessage(messageType, from, data) {
         switch (messageType) {
         case MESSAGES.JITSI_MEET_UPDATE:
-            // The Spot-Remote has an update from the Jitsi participant.
             this._screenshareConnection
                 && this._screenshareConnection.processMessage({
                     data,
@@ -418,13 +419,13 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Begins the process of Spot-Remote creating a direct connection to the
-     * local in-meeting Jitsi participant.
+     * Begins the process of creating a direct connection to the  Jitsi-Meet
+     * participant.
      *
      * @param {ScreenshareConnection} connection - Optionally use an existing
      * instance of ScreenshareConnection instead of instantiating one. This
      * would be used when creating a desktop track to stream first but the
-     * actual connection to the JItsi participant must occur later.
+     * actual connection to the Jitsi participant must occur later.
      * @param {Object} options - Additional configuration to use for creating
      * the screenshare connection.
      * @private
@@ -454,8 +455,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 
     /**
-     * Cleans up screensharing connections between the Spot-Remote and Jitsi
-     * participant that are pending or have successfully been made.
+     * Cleans up screensharing connections between the {@code RemoteControlClient}
+     * and Jitsi-Meet participant that are pending or have successfully been made.
      *
      * @private
      * @returns {Promise}
@@ -467,9 +468,8 @@ export class SpotRemoteRemoteControlService extends BaseRemoteControlService {
     }
 }
 
-const spotRemoteRemoteControlService = new SpotRemoteRemoteControlService();
+const remoteControlClient = new RemoteControlClient();
 
-globalDebugger.register(
-    'spotRemoteRemoteControlService', spotRemoteRemoteControlService);
+globalDebugger.register('remoteControlClient', remoteControlClient);
 
-export default spotRemoteRemoteControlService;
+export default remoteControlClient;

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -19,7 +19,7 @@ import reducers, {
 import { MiddlewareRegistry, ReducerRegistry } from 'common/redux';
 import {
     RemoteControlServiceSubscriber,
-    spotRemoteRemoteControlService
+    remoteControlClient
 } from 'common/remote-control';
 import {
     getDeviceId,
@@ -78,7 +78,7 @@ if (loggingEndpoint) {
     loggingService.start();
 }
 
-spotRemoteRemoteControlService.configureWirelessScreensharing({
+remoteControlClient.configureWirelessScreensharing({
     desktopSharingFrameRate: getDesktopSharingFramerate(reduxState)
 });
 

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -3,7 +3,7 @@ import {
     getSpotServicesConfig,
     setCalendarEvents
 } from 'common/app-state';
-import { spotRemoteRemoteControlService } from 'common/remote-control';
+import { remoteControlClient } from 'common/remote-control';
 import { history } from 'common/history';
 
 import {
@@ -30,7 +30,7 @@ export function connectToSpotTV(joinCode, shareMode) {
 
         const { joinCodeServiceUrl } = getSpotServicesConfig(getState());
 
-        return spotRemoteRemoteControlService.exchangeCode(joinCode, { joinCodeServiceUrl })
+        return remoteControlClient.exchangeCode(joinCode, { joinCodeServiceUrl })
             .then(roomInfo => {
                 dispatch({
                     type: SPOT_REMOTE_JOIN_CODE_VALID,
@@ -57,7 +57,7 @@ export function connectToSpotTV(joinCode, shareMode) {
  */
 export function disconnectFromSpotTV() {
     return dispatch => {
-        spotRemoteRemoteControlService.disconnect();
+        remoteControlClient.disconnect();
 
         dispatch(setCalendarEvents([]));
         dispatch(clearSpotTVState());

--- a/spot-client/src/spot-remote/remote-control/middleware.js
+++ b/spot-client/src/spot-remote/remote-control/middleware.js
@@ -1,5 +1,5 @@
 import { MiddlewareRegistry } from 'common/redux';
-import { spotRemoteRemoteControlService } from 'common/remote-control';
+import { remoteControlClient } from 'common/remote-control';
 
 import { ADJUST_VOLUME, SUBMIT_FEEDBACK } from './action-types';
 
@@ -8,10 +8,10 @@ MiddlewareRegistry.register(() => next => action => {
 
     switch (action.type) {
     case ADJUST_VOLUME:
-        spotRemoteRemoteControlService.adjustVolume(action.direction);
+        remoteControlClient.adjustVolume(action.direction);
         break;
     case SUBMIT_FEEDBACK: {
-        spotRemoteRemoteControlService.submitFeedback({
+        remoteControlClient.submitFeedback({
             score: action.score,
             message: action.message
         });

--- a/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
+++ b/spot-client/src/spot-remote/ui/loaders/withRemoteControl.js
@@ -12,7 +12,7 @@ import {
 import { logger } from 'common/logger';
 import {
     SERVICE_UPDATES,
-    spotRemoteRemoteControlService
+    remoteControlClient
 } from 'common/remote-control';
 import { AbstractLoader, generateWrapper } from 'common/ui';
 
@@ -73,35 +73,35 @@ export class RemoteControlLoader extends AbstractLoader {
     }
 
     /**
-     * Adds listeners for {@code spotRemoteRemoteControlService} updates.
+     * Adds listeners for {@code remoteControlClient} updates.
      *
      * @inheritdoc
      */
     componentDidMount() {
         super.componentDidMount();
 
-        spotRemoteRemoteControlService.addListener(
+        remoteControlClient.addListener(
             SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT,
             this._onDisconnect
         );
-        spotRemoteRemoteControlService.addListener(
-            SERVICE_UPDATES.SPOT_TV_STATE_CHANGE,
+        remoteControlClient.addListener(
+            SERVICE_UPDATES.SERVER_STATE_CHANGE,
             this._onSpotTVStateChange
         );
     }
 
     /**
-     * Clears the listeners for {@code spotRemoteRemoteControlService} updates.
+     * Clears the listeners for {@code remoteControlClient} updates.
      *
      * @inheritdoc
      */
     componentWillUnmount() {
-        spotRemoteRemoteControlService.removeListener(
+        remoteControlClient.removeListener(
             SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT,
             this._onDisconnect
         );
-        spotRemoteRemoteControlService.removeListener(
-            SERVICE_UPDATES.SPOT_TV_STATE_CHANGE,
+        remoteControlClient.removeListener(
+            SERVICE_UPDATES.SERVER_STATE_CHANGE,
             this._onSpotTVStateChange
         );
     }
@@ -114,7 +114,7 @@ export class RemoteControlLoader extends AbstractLoader {
      */
     _getPropsForChildren() {
         return {
-            remoteControlService: spotRemoteRemoteControlService
+            remoteControlClient
         };
     }
 
@@ -138,7 +138,7 @@ export class RemoteControlLoader extends AbstractLoader {
             return Promise.reject();
         }
 
-        return spotRemoteRemoteControlService.connect({
+        return remoteControlClient.connect({
             autoReconnect: true,
             roomInfo,
             serverConfig: this.props.remoteControlConfiguration
@@ -158,8 +158,8 @@ export class RemoteControlLoader extends AbstractLoader {
     }
 
     /**
-     * Callback invoked when {@code spotRemoteRemoteControlService} has an update about
-     * the current state of a Spot-TV.
+     * Callback invoked when {@code remoteControlClient} has an update about the
+     * current state of a Spot-TV.
      *
      * @param {Object} data - Details of the Spot-TV's current state.
      * @private

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -19,8 +19,8 @@ import { ElectronDesktopPickerModal } from './../components/electron-desktop-pic
 import { Feedback, InCall, WaitingForCall } from './remote-views';
 
 /**
- * Displays the remote control view for controlling a Spot-TV instance from am
- * instance of Spot-Remote. This view has sub-views for interactiog with
+ * Displays the remote control view for controlling a Spot-TV instance from an
+ * instance of Spot-Remote. This view has sub-views for interacting with
  * Spot-TV in its different states.
  *
  * @extends React.PureComponent
@@ -32,7 +32,6 @@ export class RemoteControl extends React.PureComponent {
         isConnectedToSpot: PropTypes.bool,
         onDisconnect: PropTypes.func,
         onUnexpectedDisconnected: PropTypes.func,
-        remoteControlService: PropTypes.object,
         view: PropTypes.string
     };
 
@@ -80,9 +79,7 @@ export class RemoteControl extends React.PureComponent {
      * @returns {ReactElement}
      */
     _getView() {
-        const { remoteControlService, view } = this.props;
-
-        switch (view) {
+        switch (this.props.view) {
         case 'admin':
             return <div>currently in admin tools</div>;
         case 'feedback':
@@ -92,7 +89,7 @@ export class RemoteControl extends React.PureComponent {
         case 'home':
             return <WaitingForCall events = { this.props.events } />;
         case 'meeting':
-            return <InCall remoteControlService = { remoteControlService } />;
+            return <InCall />;
         case 'setup':
             return <div>currently in setup</div>;
         default:

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -35,7 +35,6 @@ export class InCall extends React.Component {
         onHangUp: PropTypes.func,
         onShowScreenshareModal: PropTypes.func,
         onStartWirelessScreenshare: PropTypes.func,
-        remoteControlService: PropTypes.object,
         screensharingType: PropTypes.string,
         wiredScreensharingEnabled: PropTypes.bool
     };

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -12,7 +12,7 @@ import { logger } from 'common/logger';
 import { createAsyncActionWithStates } from 'common/redux';
 import {
     SERVICE_UPDATES,
-    spotTvRemoteControlService
+    remoteControlServer
 } from 'common/remote-control';
 import { generateRandomString } from 'common/utils';
 
@@ -23,7 +23,7 @@ import { generateRandomString } from 'common/utils';
  */
 export function createSpotTVRemoteControlConnection() {
     return (dispatch, getState) => {
-        if (spotTvRemoteControlService.hasConnection()) {
+        if (remoteControlServer.hasConnection()) {
             logger.warn('Called to create connection while connection exists');
 
             return;
@@ -31,7 +31,7 @@ export function createSpotTVRemoteControlConnection() {
 
         /**
          * Callback invoked when a connect has been successfully made with
-         * {@code spotTvRemoteControlService}.
+         * {@code remoteControlServer}.
          *
          * @param {Object} result - Includes information specific about the
          * connection.
@@ -43,7 +43,7 @@ export function createSpotTVRemoteControlConnection() {
         }
 
         /**
-         * Callback invoked when {@code spotTvRemoteControlService} has been
+         * Callback invoked when {@code remoteControlServer} has been
          * disconnected from an unrecoverable error. Tries to reconnect.
          *
          * @private
@@ -51,8 +51,8 @@ export function createSpotTVRemoteControlConnection() {
          */
         function onDisconnect() {
             logger.error(
-                'Spot-TV disconnected from the remote control service.');
-            spotTvRemoteControlService.disconnect()
+                'Spot-TV disconnected from the remote control server.');
+            remoteControlServer.disconnect()
                 .then(() => {
                     dispatch(setJoinCode(''));
 
@@ -61,7 +61,7 @@ export function createSpotTVRemoteControlConnection() {
         }
 
         /**
-         * Callback invoked when {@code spotTvRemoteControlService} has changed
+         * Callback invoked when {@code remoteControlServer} has changed
          * the join code necessary to pair with the Spot-TV.
          *
          * @param {Object} data - An object containing the update.
@@ -87,11 +87,11 @@ export function createSpotTVRemoteControlConnection() {
             .catch(onDisconnect);
         }
 
-        spotTvRemoteControlService.addListener(
+        remoteControlServer.addListener(
             SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT,
             onDisconnect
         );
-        spotTvRemoteControlService.addListener(
+        remoteControlServer.addListener(
             SERVICE_UPDATES.JOIN_CODE_CHANGE,
             onJoinCodeChange
         );
@@ -101,7 +101,7 @@ export function createSpotTVRemoteControlConnection() {
 }
 
 /**
- * Interacts with the {@code spotTvRemoteControlService} to create a connection
+ * Interacts with the {@code remoteControlServer} to create a connection
  * to be consumed by a Spot-TV client.
  *
  * @param {Object} state - The Redux state.
@@ -141,7 +141,7 @@ function createConnection(state) {
             let getRoomInfoPromise;
 
             if (joinCodeServiceUrl) {
-                getRoomInfoPromise = spotTvRemoteControlService.exchangeCode(
+                getRoomInfoPromise = remoteControlServer.exchangeCode(
                     joinCode,
                     {
                         joinCodeServiceUrl
@@ -158,7 +158,7 @@ function createConnection(state) {
 
             return getRoomInfoPromise;
         })
-        .then(roomInfo => spotTvRemoteControlService.connect({
+        .then(roomInfo => remoteControlServer.connect({
             autoReconnect: true,
             joinAsSpot: true,
 
@@ -170,8 +170,7 @@ function createConnection(state) {
         }))
         .then(() => {
             return {
-                joinCode:
-                    finalJoinCode || spotTvRemoteControlService.getJoinCode(),
+                joinCode: finalJoinCode || remoteControlServer.getJoinCode(),
                 jwt: finalJwt
             };
         });

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -35,7 +35,7 @@ export class MeetingFrame extends React.Component {
         preferredCamera: PropTypes.string,
         preferredMic: PropTypes.string,
         preferredSpeaker: PropTypes.string,
-        remoteControlService: PropTypes.object,
+        remoteControlServer: PropTypes.object,
         screenshareDevice: PropTypes.string,
         showMeetingToolbar: PropTypes.bool,
         startWithScreenshare: PropTypes.bool,
@@ -168,8 +168,8 @@ export class MeetingFrame extends React.Component {
         this._jitsiApi.executeCommand('avatarUrl', this.props.avatarUrl || '');
         this._jitsiApi.executeCommand('displayName', this.props.displayName);
 
-        this.props.remoteControlService.addListener(
-            SERVICE_UPDATES.SPOT_REMOTE_MESSAGE_RECEIVED,
+        this.props.remoteControlServer.addListener(
+            SERVICE_UPDATES.CLIENT_MESSAGE_RECEIVED,
             this._onMeetingCommand
         );
 
@@ -186,8 +186,8 @@ export class MeetingFrame extends React.Component {
     componentWillUnmount() {
         clearTimeout(this._assumeMeetingFailedTimeout);
 
-        this.props.remoteControlService.removeListener(
-            SERVICE_UPDATES.SPOT_REMOTE_MESSAGE_RECEIVED,
+        this.props.remoteControlServer.removeListener(
+            SERVICE_UPDATES.CLIENT_MESSAGE_RECEIVED,
             this._onMeetingCommand
         );
 
@@ -339,8 +339,8 @@ export class MeetingFrame extends React.Component {
             this._jitsiApi.executeCommand('submitFeedback', data);
             break;
 
-        case MESSAGES.SPOT_REMOTE_LEFT:
-        case MESSAGES.SPOT_REMOTE_PROXY_MESSAGE:
+        case MESSAGES.CLIENT_LEFT:
+        case MESSAGES.CLIENT_PROXY_MESSAGE:
             this._jitsiApi.sendProxyConnectionEvent(data);
             break;
         }
@@ -536,7 +536,7 @@ export class MeetingFrame extends React.Component {
             data
         });
 
-        this.props.remoteControlService.sendMessageToRemoteControl(to, data);
+        this.props.remoteControlServer.sendMessageToRemoteControl(to, data);
     }
 
     /**

--- a/spot-client/src/spot-tv/ui/loaders/SpotTVRemoteControlLoader.js
+++ b/spot-client/src/spot-tv/ui/loaders/SpotTVRemoteControlLoader.js
@@ -8,7 +8,7 @@ import {
     isConnectionPending,
     setIsSpot
 } from 'common/app-state';
-import { spotTvRemoteControlService } from 'common/remote-control';
+import { remoteControlServer } from 'common/remote-control';
 import { Loading } from 'common/ui';
 
 import { createSpotTVRemoteControlConnection } from './../../app-state';
@@ -29,7 +29,7 @@ export class SpotTVRemoteControlLoader extends React.Component {
 
     /**
      * Configures analytics to report events as a Spot-TV and starts the
-     * connection to the remote control service for sending updates and
+     * connection for the remote control server for sending sending updates and
      * receiving commands.
      *
      * @inheritdoc
@@ -72,7 +72,7 @@ export class SpotTVRemoteControlLoader extends React.Component {
      */
     _getPropsForChildren() {
         return {
-            remoteControlService: spotTvRemoteControlService
+            remoteControlServer
         };
     }
 }

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -42,7 +42,7 @@ export class Home extends React.Component {
         history: PropTypes.object,
         isSetupComplete: PropTypes.bool,
         joinCode: PropTypes.string,
-        remoteControlService: PropTypes.object,
+        remoteControlServer: PropTypes.object,
         spotRoomName: PropTypes.string
     };
 
@@ -69,8 +69,8 @@ export class Home extends React.Component {
      * @inheritdoc
      */
     componentDidMount() {
-        this.props.remoteControlService.addListener(
-            SERVICE_UPDATES.SPOT_REMOTE_MESSAGE_RECEIVED,
+        this.props.remoteControlServer.addListener(
+            SERVICE_UPDATES.CLIENT_MESSAGE_RECEIVED,
             this._onCommand
         );
     }
@@ -81,8 +81,8 @@ export class Home extends React.Component {
      * @inheritdoc
      */
     componentWillUnmount() {
-        this.props.remoteControlService.removeListener(
-            SERVICE_UPDATES.SPOT_REMOTE_MESSAGE_RECEIVED,
+        this.props.remoteControlServer.removeListener(
+            SERVICE_UPDATES.CLIENT_MESSAGE_RECEIVED,
             this._onCommand
         );
     }

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -40,7 +40,7 @@ export class Meeting extends React.Component {
         preferredCamera: PropTypes.string,
         preferredMic: PropTypes.string,
         preferredSpeaker: PropTypes.string,
-        remoteControlService: PropTypes.object,
+        remoteControlServer: PropTypes.object,
         screenshareDevice: PropTypes.string,
         showMeetingToolbar: PropTypes.bool
     };
@@ -99,7 +99,7 @@ export class Meeting extends React.Component {
             preferredCamera,
             preferredMic,
             preferredSpeaker,
-            remoteControlService,
+            remoteControlServer,
             screenshareDevice,
             showMeetingToolbar
         } = this.props;
@@ -118,7 +118,7 @@ export class Meeting extends React.Component {
                     preferredCamera = { preferredCamera }
                     preferredMic = { preferredMic }
                     preferredSpeaker = { preferredSpeaker }
-                    remoteControlService = { remoteControlService }
+                    remoteControlServer = { remoteControlServer }
                     screenshareDevice = { screenshareDevice }
                     showMeetingToolbar = { showMeetingToolbar }
                     startWithScreenshare = { screenshare }

--- a/spot-client/src/spot-tv/ui/views/spot-view.js
+++ b/spot-client/src/spot-tv/ui/views/spot-view.js
@@ -17,7 +17,7 @@ class SpotView extends React.Component {
     static propTypes = {
         children: PropTypes.any,
         name: PropTypes.string,
-        remoteControlService: PropTypes.object,
+        remoteControlServer: PropTypes.object,
         spotRoomName: PropTypes.string,
         updateSpotTvState: PropTypes.func
     };
@@ -48,11 +48,11 @@ class SpotView extends React.Component {
      * @inheritdoc
      */
     render() {
-        const { children, spotRoomName } = this.props;
+        const { children, remoteControlServer, spotRoomName } = this.props;
         const childComponents = React.Children.map(children, child =>
             React.cloneElement(
                 child,
-                { remoteControlService: this.props.remoteControlService }
+                { remoteControlServer }
             ));
 
         return (


### PR DESCRIPTION
This is phase two of a refactor effort to separate spot-remote and spot-tv remote control service logic. Phase 1 was #318, splitting remote control service into two separate objects. Phase 3 will be moving files around.

This PR is built on top of #326, which has some moving of remote control service actions.