### PR TITLE
Soft beacon for electron

### DIFF
--- a/spot-client/src/common/app-state/index.js
+++ b/spot-client/src/common/app-state/index.js
@@ -26,6 +26,7 @@ export * from './notifications/actions';
 export * from './remote-control-service/actions';
 export * from './setup/actions';
 export * from './spot-tv/actions';
+export * from './spot-tv/action-types';
 export * from './wired-screenshare/actions';
 
 export * from './remote-control-service/actionTypes';

--- a/spot-client/src/spot-tv/native-functions/bt-beacon/index.js
+++ b/spot-client/src/spot-tv/native-functions/bt-beacon/index.js
@@ -1,0 +1,1 @@
+import './middleware';

--- a/spot-client/src/spot-tv/native-functions/bt-beacon/middleware.js
+++ b/spot-client/src/spot-tv/native-functions/bt-beacon/middleware.js
@@ -1,0 +1,18 @@
+import { SPOT_TV_SET_JOIN_CODE } from 'common/app-state';
+import { MiddlewareRegistry } from 'common/redux';
+
+import { nativeController } from '../native-controller';
+
+MiddlewareRegistry.register(() => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case SPOT_TV_SET_JOIN_CODE:
+        nativeController.sendMessage('updateJoinCode', {
+            joinCode: action.joinCode
+        });
+        break;
+    }
+
+    return result;
+});

--- a/spot-client/src/spot-tv/native-functions/index.js
+++ b/spot-client/src/spot-tv/native-functions/index.js
@@ -1,1 +1,2 @@
+export * from './bt-beacon';
 export * from './volume-control';

--- a/spot-electron/.eslintrc
+++ b/spot-electron/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "env": {
+        "node": true
+    },
     "extends": [
         "eslint-config-jitsi",
         "eslint-config-jitsi/jsdoc"

--- a/spot-electron/config.js
+++ b/spot-electron/config.js
@@ -3,6 +3,17 @@ const process = require('process');
 module.exports = {
 
     /**
+     * Config values for the beacon functionality.
+     */
+    beacon: {
+
+        /**
+         * Region ID for the beacon. This is permanent and must be unique for custom deployments.
+         */
+        region: 'bf23c311-24ae-414b-b153-cf097836947f'
+    },
+
+    /**
      * The default URL to connect to.
      */
     defaultSpotURL: process.env.SPOT_URL || 'https://spot.jitsi.net/spot',

--- a/spot-electron/main.js
+++ b/spot-electron/main.js
@@ -4,6 +4,7 @@ const { createApplicationWindow } = require('./src/application-window');
 
 // Imports from features that we need to load.
 require('./src/application-menu');
+require('./src/bt-beacon');
 require('./src/client-control');
 require('./src/volume-control');
 

--- a/spot-electron/package-lock.json
+++ b/spot-electron/package-lock.json
@@ -134,6 +134,11 @@
       "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -282,6 +287,49 @@
         }
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -397,6 +445,24 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "optional": true,
+      "requires": {
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -616,6 +682,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "dev": true
+    },
     "chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -642,6 +714,12 @@
       "requires": {
         "restore-cursor": "^2.0.0"
       }
+    },
+    "cli-spinners": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz",
+      "integrity": "sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==",
+      "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
@@ -694,6 +772,12 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -713,6 +797,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -800,6 +890,11 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -885,6 +980,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -905,7 +1009,17 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "dmg-builder": {
@@ -1078,6 +1192,91 @@
         "fs-extra-p": "^7.0.1",
         "lazy-val": "^1.0.4",
         "mime": "^2.4.1"
+      }
+    },
+    "electron-rebuild": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.8.5.tgz",
+      "integrity": "sha512-gDwRA3utfiPnFwBZ1z8M4SEMwsdsy6Bg4VGO2ohelMOIO0vxiCrDQ/FVdLk3h2g7fLb06QFUsQU+86jiTSmZxw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.3.3",
+        "debug": "^4.1.1",
+        "detect-libc": "^1.0.3",
+        "fs-extra": "^7.0.1",
+        "node-abi": "^2.8.0",
+        "node-gyp": "^4.0.0",
+        "ora": "^3.4.0",
+        "spawn-rx": "^3.0.0",
+        "yargs": "^13.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "node-gyp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
+          "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^4.4.8",
+            "which": "1"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
@@ -1601,6 +1800,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1690,11 +1895,31 @@
         }
       }
     },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1707,6 +1932,21 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1825,6 +2065,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -2298,6 +2543,21 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -2435,6 +2695,33 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -2464,6 +2751,12 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2476,12 +2769,57 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
+      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "optional": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "optional": true
+        }
+      }
+    },
     "node-osascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-osascript/-/node-osascript-2.1.0.tgz",
       "integrity": "sha512-rW2vA0OGDGtoB+Ek6tKA7OYsBVzPZucHHssPsCbjOHJEcMLbHCDo+9UjgNX1tUIaSfMUtDLtEqY7JdIIINCkXQ==",
       "requires": {
         "buffers": "^0.1.1"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -2503,6 +2841,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nugget": {
@@ -2593,6 +2942,42 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -2635,6 +3020,15 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-defer": {
       "version": "1.0.0",
@@ -3227,6 +3621,34 @@
         }
       }
     },
+    "spawn-rx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-3.0.0.tgz",
+      "integrity": "sha512-dw4Ryg/KMNfkKa5ezAR5aZe9wNwPdKlnHEXtHOjVnyEDSPQyOpIPPRtcIiu7127SmtHhaCjw21yC43HliW0iIg==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.5.1",
+        "lodash.assign": "^4.2.0",
+        "rxjs": "^6.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -3429,6 +3851,17 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "optional": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
       }
     },
     "temp-file": {
@@ -3688,6 +4121,15 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -3702,6 +4144,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "widest-line": {
       "version": "2.0.1",
@@ -3845,6 +4295,16 @@
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
+    },
+    "xpc-connect": {
+      "version": "0.0.0-semantically-released",
+      "resolved": "git+https://git@github.com/jitsi/xpc-connect.git#33fd79673c57f15167067778fc6ade0a4f46da07",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0",
+        "node-gyp": "^3.8.0"
+      }
     },
     "xtend": {
       "version": "2.1.2",

--- a/spot-electron/package.json
+++ b/spot-electron/package.json
@@ -12,6 +12,7 @@
         "babel-eslint": "10.0.1",
         "electron": "5.0.1",
         "electron-builder": "20.40.2",
+        "electron-rebuild": "1.8.5",
         "eslint": "5.16.0",
         "eslint-config-jitsi": "github:jitsi/eslint-config-jitsi#1.0.1",
         "eslint-plugin-flowtype": "3.8.2",
@@ -26,15 +27,17 @@
         "dist": "electron-builder",
         "lint": "eslint .",
         "pack": "electron-builder --dir",
+        "postinstall": "electron-rebuild",
         "start": "electron ."
     },
     "version": "1.0.0",
     "dependencies": {
         "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5da3033d647054457597920252b3387fa43a17fa",
         "lodash": "4.17.11",
-        "node-osascript": "^2.1.0"
+        "node-osascript": "2.1.0"
     },
     "optionalDependencies": {
-        "win-audio": "2.0.2"
+        "win-audio": "2.0.2",
+        "xpc-connect": "git+https://git@github.com/jitsi/xpc-connect.git#33fd79673c57f15167067778fc6ade0a4f46da07"
     }
 }

--- a/spot-electron/src/application-window/applicationwindow.js
+++ b/spot-electron/src/application-window/applicationwindow.js
@@ -8,6 +8,7 @@ const {
 } = require('../../config');
 
 const { config } = require('../config');
+const { logger } = require('../logger');
 
 /**
  * This is the reference for the main window. May be exposed from this scope later, but we don't have
@@ -58,6 +59,8 @@ function createApplicationWindow() {
     applicationWindow.on('exit-html-full-screen', _onHtmlFullScreenChange);
 
     applicationWindow.loadURL(defaultSpotURL);
+
+    logger.info(`Spot started with Spot-TV URL ${defaultSpotURL}`);
 }
 
 /**

--- a/spot-electron/src/bt-beacon/btbeacon.js
+++ b/spot-electron/src/bt-beacon/btbeacon.js
@@ -1,0 +1,61 @@
+const { config } = require('../config');
+
+const { clientController } = require('../client-control');
+const { logger } = require('../logger');
+const { joinCodeToVersion } = require('../utils');
+
+const daemon = require('./daemon');
+
+/**
+ * Represents a soft-beacon emulated by the computer running Spot TV
+ */
+class BTBeacon {
+
+    /**
+     * Instantiates a new instance of the class.
+     */
+    constructor() {
+        this.region = config.getValue('beacon.region');
+
+        if (daemon && this.region) {
+            daemon.connect().then(() => {
+                clientController.on('updateJoinCode', ({ joinCode }) => {
+                    this.joinCodeUpdated(joinCode);
+                });
+            });
+        } else {
+            logger.warn('BT beacon functionality is not available.');
+        }
+    }
+
+    /**
+     * Updates the beacon to emit the newly received join code.
+     *
+     * @param {string} joinCode - The join code to use as major and minor version for the beacon.
+     * @returns {void}
+     */
+    joinCodeUpdated(joinCode) {
+        if (this.joinCode === joinCode) {
+            return;
+        }
+
+        logger.info('Updating BT beacon...');
+        if (joinCode) {
+            const majorMinorVersion = joinCodeToVersion(joinCode);
+
+            daemon.stopBeacon().then(() => {
+                daemon.startBeacon(this.region, majorMinorVersion[0], majorMinorVersion[1]).then(() => {
+                    this.joinCode = joinCode;
+                    logger.info(`BT Beacon updated with join code ${joinCode}`);
+                });
+            });
+        } else {
+            // No join code, we disable the beacon.
+            daemon.stopBeacon().then(() => {
+                logger.info('BT beacon stoppped.');
+            });
+        }
+    }
+}
+
+module.exports = new BTBeacon();

--- a/spot-electron/src/bt-beacon/daemon/darwin/bluetoothd.js
+++ b/spot-electron/src/bt-beacon/daemon/darwin/bluetoothd.js
@@ -1,0 +1,159 @@
+const XpcConnection = require('xpc-connect');
+
+const { logger } = require('../../../logger');
+
+const DEVICE_STATES = [ 'Unknown', 'Resetting', 'Unsupported', 'Unauthorized', 'Powered Off', 'Powered On' ];
+
+/**
+ * Implements a platform specific daemon to interact with the BLE hardware in the computer/device.
+ */
+class BluetoothD {
+    advertisingStatusUpdatedCallback;
+
+    /**
+     * Instantiates a new instance.
+     */
+    constructor() {
+        this.xpcConnection = new XpcConnection('com.apple.bluetoothd');
+
+        this.xpcConnection.on('error', message => {
+            logger.error('XpcError', message);
+        });
+
+        this.xpcConnection.on('event', event => {
+            const messageArguments = event.kCBMsgArgs;
+
+            switch (event.kCBMsgId) {
+            case 4:
+                // Device status update
+                this.setStatus(messageArguments.kCBMsgArgState);
+                break;
+            case 28:
+                // Beacon activation result
+                this.setAdvertisingStatus(!messageArguments.kCBMsgArgResult);
+                break;
+            case 29:
+                // Beacon deactivation result
+                this.setAdvertisingStatus(Boolean(messageArguments.kCBMsgArgResult));
+                break;
+            case 38:
+                // Device ready
+                this.readyPromise && this.readyPromise();
+                break;
+            case 67:
+                // Connection request. We don't need this.
+                break;
+            default:
+                logger.warn('Unknown XpcEvent', event);
+            }
+        });
+    }
+
+    /**
+     * Connects to the BT device (opens XPC channel).
+     *
+     * @returns {Promise<void>}
+     */
+    connect() {
+        return new Promise(resolve => {
+            this.readyPromise = resolve;
+            this.xpcConnection.setup();
+            this.sendMessage(1, {
+                kCBMsgArgName: `jitsi-bt-beacon-${(new Date()).getTime()}`,
+                kCBMsgArgOptions: {
+                    kCBInitOptionShowPowerAlert: 1
+                },
+                kCBMsgArgType: 1,
+                kCBMsgArgVersion: 20161219
+            });
+        });
+    }
+
+    /**
+     * Sends a message to the BT device.
+     *
+     * @param {number} id - The message ID to send.
+     * @param {Object} args - The message args to send.
+     * @returns {void}
+     */
+    sendMessage(id, args) {
+        const message = {
+            kCBMsgId: id
+        };
+
+        if (args) {
+            message.kCBMsgArgs = args;
+        }
+        this.xpcConnection.sendMessage(message);
+    }
+
+    /**
+     * Updates the advertising status of the device.
+     *
+     * @param {boolean} status - The status to set.
+     * @returns {void}
+     */
+    setAdvertisingStatus(status) {
+        this.advertisingStatus = status;
+        logger.info('BluetoothD advertising', this.advertisingStatus ? 'started' : 'stopped');
+        if (typeof this.advertisingStatusUpdatedCallback === 'function') {
+            this.advertisingStatusUpdatedCallback(status);
+            this.advertisingStatusUpdatedCallback = undefined;
+        }
+    }
+
+    /**
+     * Callback to handle status updates from the device.
+     *
+     * @param {number} status - The status identifier to set.
+     * @returns {void}
+     */
+    setStatus(status) {
+        this.status = DEVICE_STATES[status];
+        logger.info('BluetoothD status updated to', this.status);
+    }
+
+    /**
+     * Starts the beacon.
+     *
+     * @param {string} uuid - The uuid of the beacon.
+     * @param {string} major - The major version of the beacon in hex.
+     * @param {string} minor - The minor version of the beacon in hex.
+     * @returns {Promise<boolean>}
+     */
+    startBeacon(uuid, major = 0, minor = 0) {
+        return new Promise((resolve, reject) => {
+            if (this.advertisingStatus) {
+                reject('Beacon is already running');
+            }
+            this.advertisingStatusUpdatedCallback = resolve;
+            const uuidHex = uuid.replace(/-/g, '');
+            const majorHex = major.padStart(4, '0');
+            const minorHex = minor.padStart(4, '0');
+            const beaconKey = `${uuidHex}${majorHex}${minorHex}c5`;
+
+            this.sendMessage(17, {
+                kCBAdvDataAppleBeaconKey: Buffer.from(beaconKey, 'hex')
+            });
+        });
+    }
+
+    /**
+     * Stops the beacon.
+     *
+     * @returns {Promise<boolean>}
+     */
+    stopBeacon() {
+        return new Promise(resolve => {
+            if (this.advertisingStatus) {
+                this.advertisingStatusUpdatedCallback = resolve;
+                this.sendMessage(18, undefined);
+            } else {
+                resolve(false);
+            }
+        });
+    }
+
+}
+
+module.exports = new BluetoothD();

--- a/spot-electron/src/bt-beacon/daemon/darwin/index.js
+++ b/spot-electron/src/bt-beacon/daemon/darwin/index.js
@@ -1,0 +1,5 @@
+const os = require('os');
+const osRelease = parseFloat(os.release());
+
+// older macOS support comes later
+module.exports = osRelease >= 18 ? require('./bluetoothd') : undefined;

--- a/spot-electron/src/bt-beacon/daemon/index.js
+++ b/spot-electron/src/bt-beacon/daemon/index.js
@@ -1,0 +1,3 @@
+const os = require('os');
+
+module.exports = require(`./${os.platform()}`);

--- a/spot-electron/src/bt-beacon/daemon/win32/index.js
+++ b/spot-electron/src/bt-beacon/daemon/win32/index.js
@@ -1,0 +1,1 @@
+module.exports = undefined;

--- a/spot-electron/src/bt-beacon/index.js
+++ b/spot-electron/src/bt-beacon/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    btBeacon: require('./btbeacon')
+};

--- a/spot-electron/src/config/config.js
+++ b/spot-electron/src/config/config.js
@@ -20,7 +20,7 @@ class Config {
      * @param {?Object} defaults - The default config to be applied.
      */
     constructor(defaults) {
-        this._config = _.defaultsDeep(this._config, this._loadPersistedConfig() || defaults);
+        this._config = _.defaultsDeep(this._config, this._loadPersistedConfig(), defaults);
         this._throttledPersist = _.throttle(() => {
             this._persistConfig();
         }, 2000);

--- a/spot-electron/src/utils/index.js
+++ b/spot-electron/src/utils/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    ...require('./stringutils')
+};

--- a/spot-electron/src/utils/stringutils.js
+++ b/spot-electron/src/utils/stringutils.js
@@ -1,0 +1,17 @@
+const _ = require('lodash');
+
+/**
+ * Returns an array of 2 digit hex numbers as the hex representation of the join code.
+ *
+ * @param {string} joinCode - A Spot TV join code.
+ * @returns {Array<string>}
+ */
+function joinCodeToVersion(joinCode) {
+    const hexValue = parseInt(joinCode, 36).toString(16);
+
+    return _.words(_.padStart(hexValue, 8, '0'), /\w{4,4}/g);
+}
+
+module.exports = {
+    joinCodeToVersion
+};


### PR DESCRIPTION
This is the 1st iteration for the soft beacon support for the electron app. This feature starts a soft beacon and starts to emit the join code using the major and minor version of the beacon. The region is fixed, so then we can listen to that explicit region in the mobile app even when the app is not running.

NOTE:
1. The solution only supports mac (mojave) for now, more platforms to coma later.
2. For testing, to resolve the join code from the versions one needs to use this code:
```parseInt((majorInt).toString(16) + (minorInt).toString(16), 16).toString(36)```
This logic will be embedded into the mobile app in iteration 2