### PR TITLE
fix(screenshare): mention device not supported on mobile

### DIFF
--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -6,6 +6,7 @@
     .screenshare-select {
         @include centered-content;
         flex-direction: column;
+        text-align: center;
         padding: 30px 40px;
         width: 100%;
 

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { getAdvertisementAppName } from 'common/app-state';
 import { WiredScreenshare, WirelessScreenshare } from 'common/icons';
 import { Button } from 'common/ui';
+import { isDesktopBrowser } from 'common/utils';
 
 import { NavButton } from '../nav';
 
@@ -278,7 +279,9 @@ export class ScreensharePicker extends React.Component {
      */
     _renderWirelessScreenshareNotSupported() {
         const { advertisedAppName } = this.props;
-        const title = 'Your browser is currently not supported. To share content please use Chrome on desktop.';
+        const title = 'Sharing content is currently not supported on this '
+            + `${isDesktopBrowser() ? 'browser' : 'device'}. `
+            + 'To share please use Chrome on desktop.';
         const advertisement = this.props.advertisedAppName && (
             <div>
                 or

--- a/spot-client/src/spot-remote/ui/views/share/mode-select.js
+++ b/spot-client/src/spot-remote/ui/views/share/mode-select.js
@@ -37,7 +37,7 @@ export class ModeSelect extends React.Component {
 
         if (!isWirelessScreenshareSupported) {
             disabled = true;
-            footerMessage = 'Your browser is currently not supported. '
+            footerMessage = 'This browser is currently not supported. '
                 + 'To share content please use Chrome.';
         } else if (isScreenshareActive) {
             disabled = true;


### PR DESCRIPTION
Instead of calling it a browser.
<img width="961" alt="Screen Shot 2019-05-30 at 7 07 14 PM" src="https://user-images.githubusercontent.com/1243084/58676786-6348b180-830e-11e9-8abf-06034d5ccae3.png">
<img width="1110" alt="Screen Shot 2019-05-30 at 7 06 48 PM" src="https://user-images.githubusercontent.com/1243084/58676811-78bddb80-830e-11e9-9385-dc59c1dd57c3.png">
