### PR TITLE
fix(screenshare): adjust copy to handle various env cases

### DIFF
--- a/spot-client/src/common/utils/window-handler.js
+++ b/spot-client/src/common/utils/window-handler.js
@@ -32,7 +32,9 @@ export default {
      * @returns {string}
      */
     getHost() {
-        return window.location.hostname;
+        const url = new URL(window.location);
+
+        return url.host;
     },
 
     /**

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -2,10 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { getAdvertisementAppName } from 'common/app-state';
+import {
+    getAdvertisementAppName,
+    getJoinCode,
+    getShareDomain
+} from 'common/app-state';
 import { WiredScreenshare, WirelessScreenshare } from 'common/icons';
 import { Button } from 'common/ui';
-import { isDesktopBrowser } from 'common/utils';
+import { windowHandler } from 'common/utils';
 
 import { NavButton } from '../nav';
 
@@ -17,10 +21,12 @@ import { NavButton } from '../nav';
 export class ScreensharePicker extends React.Component {
     static propTypes = {
         advertisedAppName: PropTypes.string,
+        joinCode: PropTypes.string,
         onStartWiredScreenshare: PropTypes.func,
         onStartWirelessScreenshare: PropTypes.func,
         onStopScreensharing: PropTypes.func,
         screensharingType: PropTypes.string,
+        shareDomain: PropTypes.string,
         wiredScreenshareEnabled: PropTypes.bool,
         wirelessScreenshareEnabled: PropTypes.bool
     }
@@ -278,10 +284,14 @@ export class ScreensharePicker extends React.Component {
      * @returns {ReactElement}
      */
     _renderWirelessScreenshareNotSupported() {
-        const { advertisedAppName } = this.props;
-        const title = 'Sharing content is currently not supported on this '
-            + `${isDesktopBrowser() ? 'browser' : 'device'}. `
-            + 'To share please use Chrome on desktop.';
+        const { advertisedAppName, joinCode, shareDomain } = this.props;
+        const title = (
+            <span>
+                To share, use Chrome desktop and go to <span className = 'share-url'>
+                    { `${shareDomain || windowHandler.getHost()}/${joinCode}` }
+                </span>
+            </span>
+        );
         const advertisement = this.props.advertisedAppName && (
             <div>
                 or
@@ -321,7 +331,9 @@ export class ScreensharePicker extends React.Component {
  */
 function mapStateToProps(state) {
     return {
-        advertisedAppName: getAdvertisementAppName(state)
+        advertisedAppName: getAdvertisementAppName(state),
+        joinCode: getJoinCode(state),
+        shareDomain: getShareDomain(state)
     };
 }
 


### PR DESCRIPTION
To make sense on Firefox, Safari, the native mobile apps,
and mobile browsers.
<img width="961" alt="Screen Shot 2019-05-31 at 10 52 30 AM" src="https://user-images.githubusercontent.com/1243084/58725804-ef9db780-8394-11e9-9863-c1e18cb88ad5.png">
![Screen Shot 2019-05-31 at 10 56 09 AM](https://user-images.githubusercontent.com/1243084/58725810-f2001180-8394-11e9-85e1-d517c3604a95.png)
![Screen Shot 2019-05-31 at 10 54 59 AM](https://user-images.githubusercontent.com/1243084/58725825-f9bfb600-8394-11e9-82cd-914f2202a121.png)
