### PR TITLE
fix(reconnect): RCS should clean up own connection on disconnect

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -75,7 +75,8 @@ export class BaseRemoteControlService extends EventEmitter {
             onDisconnect: this._onDisconnect
         });
 
-        return this.xmppConnectionPromise;
+        return this.xmppConnectionPromise
+            .catch(error => this.disconnect().then(() => Promise.reject(error)));
     }
 
     /**
@@ -99,7 +100,9 @@ export class BaseRemoteControlService extends EventEmitter {
     _onDisconnect(reason) {
         if (reason === CONNECTION_EVENTS.SERVER_DISCONNECTED
             || reason === 'not-authorized') {
-            this.emit(SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT, { reason });
+            this.disconnect()
+                .then(() => this.emit(
+                    SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT, { reason }));
 
             return;
         }

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -52,12 +52,8 @@ export function createSpotTVRemoteControlConnection() {
         function onDisconnect() {
             logger.error(
                 'Spot-TV disconnected from the remote control server.');
-            remoteControlServer.disconnect()
-                .then(() => {
-                    dispatch(setJoinCode(''));
-
-                    doConnect();
-                });
+            dispatch(setJoinCode(''));
+            doConnect();
         }
 
         /**


### PR DESCRIPTION
If a disconnect occurs, or a failed connection occurs,
it was possible to attempt the before the disconnect
logic finished. This could lead to a state where the
remote is connected to the service but the reference
to the xmpp connection was made null. To fix this,
ensure the connection is cleaned up and events of
a disconnect happen after cleanup.