### PR TITLE
fix(rcs): capture errors from disconnecting on unload

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -29,7 +29,11 @@ export class BaseRemoteControlService extends EventEmitter {
 
         this._onDisconnect = this._onDisconnect.bind(this);
 
-        window.addEventListener('beforeunload', () => this.disconnect());
+        window.addEventListener(
+            'beforeunload',
+            () => this.disconnect()
+                .catch(() => { /* swallow unload errors from bubbling up */ })
+        );
     }
 
     /**


### PR DESCRIPTION
This type of logic was recently added to ljm to
prevent uncaught exceptions from breaking unload
logic..