### PR TITLE
fix(calendar): allow searching for room in google calendar

### DIFF
--- a/spot-client/src/common/css/page-layouts/spot-tv/_setup-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_setup-view.scss
@@ -17,6 +17,11 @@
     }
     
     .setup-roomList {
+        /**
+         * Define a set height to prevent the room list from causing the modal
+         * to resize frequently.
+         */
+        height: 300px;
         overflow: auto;
     }
     
@@ -29,6 +34,17 @@
         font-size: $font-size-medium-plus;
         margin-bottom: 34px;
         text-align: center;
+    }
+}
+
+.room-selection {
+    background-color: var(--container-content-bg-color);
+    cursor: pointer;
+    margin: 10px 0;
+    padding: 10px;
+
+    &:hover {
+        background-color: var(--container-content-bg-color-no-opacity);
     }
 }
 

--- a/spot-client/src/spot-tv/calendars/calendarService.js
+++ b/spot-client/src/spot-tv/calendars/calendarService.js
@@ -85,10 +85,12 @@ export class CalendarService extends EventEmitter {
      * Requests the rooms accessible by the account linked to the currently
      * active calendar integration.
      *
+     * @param {string} roomNameFilter - A string to use for filtering rooms by
+     * name.
      * @returns {Promise<Array<Object>>}
      */
-    getRooms() {
-        return this._calendarIntegration.getRooms();
+    getRooms(roomNameFilter = '') {
+        return this._calendarIntegration.getRooms(roomNameFilter);
     }
 
     /**

--- a/spot-client/src/spot-tv/calendars/google.js
+++ b/spot-client/src/spot-tv/calendars/google.js
@@ -92,12 +92,17 @@ export default {
      * Requests the rooms accessible by the Google calendar of the email
      * currently authenticated with the Google API.
      *
+     * @param {string} roomNameFilter - Filter results so only room names that
+     * begin with the specified string are returned. Google only allows
+     * searching from the start of the room name and is case sensitive.
      * @returns {Promise<Array<Object>>}
      */
-    getRooms() {
+    getRooms(roomNameFilter = '') {
+        const escapedQuery = encodeURIComponent(`name:"${roomNameFilter}*"`);
         const roomsListEndpoint
             = 'https://www.googleapis.com/admin/directory/v1/customer/'
-                + 'my_customer/resources/calendars';
+                + 'my_customer/resources/calendars'
+                + `?maxResults=5&query=${escapedQuery}`;
 
         return gapi.client.request(roomsListEndpoint)
             .then(response => response.result.items.filter(


### PR DESCRIPTION
Google and Outlook truncate room list results to 100. If
a company has more than 100 rooms then not all rooms will
be returned. The Google API allows for querying for rooms,
which provides some search functionality, so that has been
introduced to get around the 100 room limit. Outlook does
not seem to provide such so it's going to have to survive
for a bit in its current state.

Note that this is a partial solution until the real
backend service is complete. Google's API querying matches
to the start of field values only, not in the middle,
and is case sensitive.

![Jun-02-2019 10-28-31](https://user-images.githubusercontent.com/1243084/58764930-2523db80-8522-11e9-8b7f-46dcbb01591b.gif)