### PR TITLE
feat(update): automatically reload the page

### DIFF
--- a/spot-client/docs/manua-test-plan.md
+++ b/spot-client/docs/manua-test-plan.md
@@ -109,3 +109,9 @@ Share Mode
 - [ ] At mode select, clicking the "Remote Control" button takes Spot-Remote to the full remote control view
 - [ ] At mode select, unsupported browsers cannot start wireless screensharing
 - [ ] At mode select, Spot-Remote cannot start a wireless screenshare if Spot-TV is already screensharing
+
+Updating
+---
+- [ ] Spot-TV automatically reloads the page when the current time falls between the configured update window
+- [ ] Spot-TV does not automatically reload if a reload has already taken place. in the configured update window.
+- [ ] Spot-Remote automatically reloads the page after Spot-TV completes reload

--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -54,6 +54,15 @@ export default {
         joinCodeServiceUrl: process.env.JOIN_CODE_SERVICE_URL
     },
 
+    UPDATES: {
+        START_HOUR: typeof process.env.UPDATE_START_HOUR === undefined
+            ? 2
+            : process.env.UPDATE_START_HOUR,
+        END_HOUR: typeof process.env.UPDATE_END_HOUR === undefined
+            ? 6
+            : process.env.UPDATE_END_HOUR
+    },
+
     ULTRASOUND: {
         EMSCRIPTEN_PATH: process.env.ULTRASOUND_EMSCRIPTEN_PATH || '/dist/',
         MEM_INITIALIZER_PATH:

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -153,3 +153,25 @@ export function getSpotServicesConfig(state) {
 export function getUltrasoundConfig(state) {
     return state.config.ULTRASOUND;
 }
+
+/**
+ * A selector which returns the starting hour in the day when the app may reload
+ * itself to get updates.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {number}
+ */
+export function getUpdateStartHour(state) {
+    return state.config.UPDATES.START_HOUR;
+}
+
+/**
+ * A selector which returns the ending hour in the day when the app may no
+ * longer reload itself to get updates.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {number}
+ */
+export function getUpdateEndHour(state) {
+    return state.config.UPDATES.END_HOUR;
+}

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -49,11 +49,22 @@ export const COMMANDS = {
  * An enumeration of custom connection-related events that can be emitted.
  */
 export const CONNECTION_EVENTS = {
+    /**
+     * There is an error with the {@code RemoteControlServer} and a wait will
+     * for a possible reconnect.
+     */
+    SERVER_DISCONNECT_PENDING: 'server-disconnect-pending',
 
     /**
      * The {@code RemoteControlServer} is no longer available.
      */
-    SERVER_DISCONNECTED: 'server-disconnected'
+    SERVER_DISCONNECTED: 'server-disconnected',
+
+    /**
+     * The {@code RemoteControlServer} has become available again after a
+     * pending disconnect.
+     */
+    SERVER_RECONNECTED: 'server-reconnected'
 };
 
 /**

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -184,12 +184,14 @@ function _onReconnectStatusChange({ dispatch }, { isReconnecting }) {
  * Callback invoked when the remote control client has recovered from a reload
  * and the remote control should reload itself.
  *
+ * @param {string} remoteJoinCode - The Spot-TV join code that should be used
+ * after reloading the page.
  * @private
  * @returns {void}
  */
-function _onReloadSpotRemote(joinCode) {
+function _onReloadSpotRemote(remoteJoinCode) {
     // Purposefully use window.location to force a reload of the page
-    window.location = `${ROUTES.CODE}${joinCode}`;
+    window.location = `${ROUTES.CODE}${remoteJoinCode}`;
 }
 
 /**

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -18,7 +18,6 @@ import {
     SPOT_REMOTE_WILL_VALIDATE_JOIN_CODE
 } from './actionTypes';
 
-
 /**
  * Presence attributes from Spot-TV to store as booleans in redux.
  *
@@ -182,6 +181,18 @@ function _onReconnectStatusChange({ dispatch }, { isReconnecting }) {
 }
 
 /**
+ * Callback invoked when the remote control client has recovered from a reload
+ * and the remote control should reload itself.
+ *
+ * @private
+ * @returns {void}
+ */
+function _onReloadSpotRemote(joinCode) {
+    // Purposefully use window.location to force a reload of the page
+    window.location = `${ROUTES.CODE}${joinCode}`;
+}
+
+/**
  * Callback invoked when {@code remoteControlClient} has an update about the current state of
  * a Spot-TV.
  *
@@ -243,6 +254,10 @@ function _setSubscriptions(store) {
     remoteControlClient.addListener(
         SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT,
         onDisconnectedHandler);
+
+    remoteControlClient.addListener(
+        SERVICE_UPDATES.SERVER_RECONNECTED,
+        _onReloadSpotRemote);
 }
 
 /**
@@ -272,6 +287,6 @@ export function exitShareMode() {
             type: SPOT_REMOTE_EXIT_SHARE_MODE
         });
 
-        history.push('/remote-control');
+        history.push(ROUTES.REMOTE_CONTROL);
     };
 }

--- a/spot-client/src/spot-tv/ui/components/auto-reload/AutoReload.js
+++ b/spot-client/src/spot-tv/ui/components/auto-reload/AutoReload.js
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import {
+    getSpotServicesConfig,
+    getUpdateEndHour,
+    getUpdateStartHour
+} from 'common/app-state';
+import { scheduleSpotTVUpdate } from '../../../app-state';
+
+const checkInterval = 5 * 60 * 1000; // 5 minutes in milliseconds
+const reloadThreshold = 23 * 60 * 60 * 1000; // 23 hours in milliseconds
+
+const lastLoadTime = new Date();
+
+/**
+ * Periodically checks for when the last time the page was loaded and will
+ * reload if it has been 24 hours. This reload is to get any bundle updates and
+ * to clear any memory leaks.
+ *
+ * @extends React.Component
+ */
+export class AutoReload extends React.Component {
+    static propTypes = {
+        enabled: PropTypes.bool,
+        onReload: PropTypes.func,
+        updateEndHour: PropTypes.number,
+        updateStartHour: PropTypes.number
+    };
+
+    /**
+     * Initializes a new {@code AutoReload} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._reloadTimeCheckInterval = null;
+
+        this._maybeReload = this._maybeReload.bind(this);
+    }
+
+    /**
+     * Starts an interval to check if the app should automatically reload.
+     *
+     * @inheritdoc
+     */
+    componentDidMount() {
+        if (this.props.enabled) {
+            this._reloadTimeCheckInterval = setInterval(
+                this._maybeReload,
+                checkInterval
+            );
+        }
+    }
+
+    /**
+     * Clears the interval to check if the app should automatically reload.
+     *
+     * @inheritdoc
+     */
+    componentWillUnmount() {
+        clearInterval(this._reloadTimeCheckInterval);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return null;
+    }
+
+    /**
+     * Checks if it is time to reload and executes the reload.
+     *
+     * @private
+     * @returns {void}
+     */
+    _maybeReload() {
+        const now = new Date();
+        const currentHour = now.getHours();
+
+        if (currentHour > this.props.updateStartHour
+            && currentHour < this.props.updateEndHour
+            && now.getTime() - lastLoadTime.getTime() >= reloadThreshold) {
+            this.props.onReload();
+        }
+    }
+}
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code AutoReload}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    const spotServicesConfig = getSpotServicesConfig(state);
+
+    return {
+        enabled:
+            !spotServicesConfig || !spotServicesConfig.joinCodeServiceUrl,
+        updateEndHour: getUpdateEndHour(state),
+        updateStartHour: getUpdateStartHour(state)
+    };
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        onReload() {
+            dispatch(scheduleSpotTVUpdate());
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AutoReload);

--- a/spot-client/src/spot-tv/ui/components/auto-reload/index.js
+++ b/spot-client/src/spot-tv/ui/components/auto-reload/index.js
@@ -1,0 +1,1 @@
+export { default as AutoReload } from './AutoReload';

--- a/spot-client/src/spot-tv/ui/components/index.js
+++ b/spot-client/src/spot-tv/ui/components/index.js
@@ -1,4 +1,5 @@
 export * from './admin';
+export * from './auto-reload';
 export * from './join-info';
 export * from './meeting-frame';
 export * from './meeting-status';

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -16,6 +16,7 @@ import { Clock, LoadingIcon, ScheduledMeetings } from 'common/ui';
 import { getRandomMeetingName } from 'common/utils';
 
 import {
+    AutoReload,
     FullscreenToggle,
     JoinInfo,
     SettingsButton,
@@ -101,6 +102,7 @@ export class Home extends React.Component {
         return (
             <WiredScreenshareChangeListener
                 onDeviceConnected = { this._onRedirectToMeeting }>
+                <AutoReload />
                 <div className = 'spot-home'>
                     <Clock />
                     { this._getCalendarEventsView() }


### PR DESCRIPTION
Setting as draft to get any initial feedback and because this work may conflict with work in-progress for backend integration, which I think should take priority for merging.

Left todo
- [x] implement automatic reload for the remote control
- [ ] test a lot, a lot, a lot

Future todo
implement autoreload with the backend integration