### PR TITLE
feat: use JWT to establish XMPP connection with the RCS MUC

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -56,6 +56,7 @@ export class BaseRemoteControlService extends Emitter {
         this._options = options;
 
         const {
+            backend,
             joinAsSpot,
             joinCode,
             retryOnUnauthorized,
@@ -76,6 +77,7 @@ export class BaseRemoteControlService extends Emitter {
         this.xmppConnectionPromise = this.exchangeCode(joinCode)
             .then(roomInfo => this.xmppConnection.joinMuc({
                 joinAsSpot,
+                jwt: backend ? backend.getJwt() : null,
                 retryOnUnauthorized,
                 roomName: roomInfo.roomName,
                 roomLock: roomInfo.roomLock,

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -46,6 +46,8 @@ export default class XmppConnection {
      * @param {Object} options - Information necessary for creating the MUC.
      * @param {boolean} options.joinAsSpot - Whether or not this connection is
      * being made by a Spot client.
+     * @param {string} options.jwt - The JWT token to be used with the XMPP
+     * connection.
      * @param {boolean} [options.retryOnUnauthorized] - Whether or not to retry
      * connection without a roomLock if an unauthorized error occurs.
      * @param {string} [options.roomLock] - The lock code to use when joining or
@@ -59,6 +61,7 @@ export default class XmppConnection {
     joinMuc(options) {
         const {
             joinAsSpot,
+            jwt,
             retryOnUnauthorized,
             roomLock,
             roomName,
@@ -73,7 +76,7 @@ export default class XmppConnection {
 
         this.xmppConnection = new JitsiMeetJS.JitsiConnection(
             null,
-            null,
+            jwt,
             {
                 p2p: {
                     useStunTurn: true


### PR DESCRIPTION
If backend is in use it will try to use existing lib-jitsi-meet machinery to connect with the JWT to the remote control XMPP server.