### PR TITLE
feat: pass JWT to the meeting iframe

### DIFF
--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -27,6 +27,7 @@ export class MeetingFrame extends React.Component {
         avatarUrl: PropTypes.string,
         displayName: PropTypes.string,
         invites: PropTypes.array,
+        jwt: PropTypes.string,
         maxDesktopSharingFramerate: PropTypes.number,
         meetingUrl: PropTypes.string,
         minDesktopSharingFramerate: PropTypes.number,
@@ -134,6 +135,7 @@ export class MeetingFrame extends React.Component {
                 ENFORCE_NOTIFICATION_AUTO_DISMISS_TIMEOUT: 15000,
                 TOOLBAR_BUTTONS: this.props.showMeetingToolbar ? undefined : []
             },
+            jwt: this.props.jwt,
             onload: this._onMeetingLoaded,
             parentNode: this._meetingContainer,
             roomName: meetingName

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -9,6 +9,7 @@ import {
     getDesktopSharingFramerate,
     getDisplayName,
     getInMeetingStatus,
+    getJwt,
     getMeetingOptions,
     getPreferredCamera,
     getPreferredMic,
@@ -34,6 +35,7 @@ export class Meeting extends React.Component {
         dispatch: PropTypes.func,
         displayName: PropTypes.string,
         history: PropTypes.object,
+        jwt: PropTypes.string,
         location: PropTypes.object,
         match: PropTypes.object,
         maxDesktopSharingFramerate: PropTypes.number,
@@ -96,6 +98,7 @@ export class Meeting extends React.Component {
         const {
             avatarUrl,
             displayName,
+            jwt,
             maxDesktopSharingFramerate,
             minDesktopSharingFramerate,
             preferredCamera,
@@ -113,6 +116,7 @@ export class Meeting extends React.Component {
                     avatarUrl = { avatarUrl }
                     displayName = { displayName }
                     invites = { invites }
+                    jwt = { jwt }
                     maxDesktopSharingFramerate = { maxDesktopSharingFramerate }
                     meetingUrl = { location }
                     minDesktopSharingFramerate = { minDesktopSharingFramerate }
@@ -258,6 +262,7 @@ function mapStateToProps(state) {
         avatarUrl: getAvatarUrl(state),
         defaultMeetingDomain: getDefaultMeetingDomain(state),
         displayName: getDisplayName(state),
+        jwt: getJwt(state),
         maxDesktopSharingFramerate,
         minDesktopSharingFramerate,
         showPasswordPrompt: getInMeetingStatus(state).needPassword,


### PR DESCRIPTION
Will use 'jwt' option of the external API to pass a token retrieved from the backend when a meeting is joined by Spot TV.