### PR TITLE
feat(screenshare): new select designs

### DIFF
--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -22,17 +22,13 @@
         @media #{$mq-tablet} {
             height: auto;
             margin: 50px;
-            min-width: 500px;
             width: unset;
-        }
-
-        @media #{$mq-laptop-l} {
-            min-width: 550px;
         }
 
         .close {
             @include button-reset;
 
+            background-color: transparent;
             border: 0;
             position: absolute;
             top: 10px;

--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -42,7 +42,7 @@
 }
 
 .modal-content {
-    background-color: var(--container-bg-color);
+    background-color: var(--modal-bg-color);
     border-radius: 5px;
     display: flex;
     justify-content: center;

--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -1,6 +1,5 @@
 .share-select-view {
     @include centered-content;
-    align-items: initial;
 }
 
 .screenshare-select {
@@ -37,6 +36,7 @@
     .share-url {
         color: var(--secondary-link-color);
         font-size: $font-size-medium-plus;
+        font-weight: bold;
         margin-top: 1em;
     }
 

--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -1,31 +1,33 @@
 .share-select-view {
     @include centered-content;
+    align-items: initial;
 }
 
 .screenshare-select {
     @include centered-content;
     flex-direction: column;
+    justify-content: space-between;
+    min-width: 360px;
     text-align: center;
     width: 100%;
 
-    .title {
-        margin-bottom: 30px;
+    .options {
+        display: flex;
+        justify-content: space-around;
+        width: 100%;
     }
 
     .nav-label-container {
         white-space: initial;
     }
 
-    .icon {
-        margin-bottom: 30px;
-    }
-
     .icon i {
-        font-size: $font-size-xx-large;
+        font-size: $font-size-xxx-large;
     }
 
     .cta-button {
         display: block;
+        font-size: $font-size-small;
         margin-left: auto;
         margin-right: auto;
         margin-top: 10px;
@@ -33,7 +35,14 @@
     }
 
     .share-url {
-        color: var(--button-active-color);
+        color: var(--secondary-link-color);
+        font-size: $font-size-medium-plus;
+        margin-top: 1em;
+    }
+
+    .subtitle {
+        font-size: $font-size-small;
+        margin-top: 10px;
     }
 }
 

--- a/spot-client/src/common/css/_theme-variables.scss
+++ b/spot-client/src/common/css/_theme-variables.scss
@@ -22,6 +22,7 @@
     --name-entry-gradient-end: rgba(0, 0, 0, 0);
 
     --select-background-color:rgb(82, 97, 118);
+    --secondary-link-color: #8fc3f0;
 
     --mic-preview-active-background-color: rgba(39, 119, 235, 1);
     --mic-preview-background-color: rgba(250, 250, 250, 0.38);

--- a/spot-client/src/common/css/_theme-variables.scss
+++ b/spot-client/src/common/css/_theme-variables.scss
@@ -18,16 +18,16 @@
     --hangup-active-color: lightcoral;
     --hangup-bg-color: red;
 
+    --modal-bg-color: rgba(42, 58, 75, 0.8);
     --name-entry-gradient-start: black;
     --name-entry-gradient-end: rgba(0, 0, 0, 0);
 
     --select-background-color:rgb(82, 97, 118);
     --secondary-link-color: #8fc3f0;
+    --secondary-white: #d1dbe8;
 
     --mic-preview-active-background-color: rgba(39, 119, 235, 1);
     --mic-preview-background-color: rgba(250, 250, 250, 0.38);
     --mic-preview-background-disabled-color: rgba(250, 250, 250, 1);
     --pending: #258AFF;
-
-    --secondary-white: #d1dbe8;
 }

--- a/spot-client/src/common/css/_variables.scss
+++ b/spot-client/src/common/css/_variables.scss
@@ -1,3 +1,4 @@
+$font-size-xxx-large: 6em;
 $font-size-xx-large: 4em;
 $font-size-x-large: 3em;
 $font-size-large: 2em;

--- a/spot-client/src/common/css/page-layouts/_waiting-view.scss
+++ b/spot-client/src/common/css/page-layouts/_waiting-view.scss
@@ -40,7 +40,7 @@
 
     .share-select-view {
         @include centered-content;
-
+        align-items: initial;
         margin: auto;
         width: 100%;
 

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -200,22 +200,18 @@ export class ScreensharePicker extends React.Component {
     _renderStartWiredScreenshare() {
         return (
             <>
-                <div className = 'title'>
-                    {
-                        'To start sharing just plug the HDMI\n'
-                            + 'dongle into your computer.'
-                    }
-                </div>
-                <div className = 'options'>
+                <div className = 'content'>
                     <div className = 'icon'>
                         <i className = 'material-icons'>wired_screen_share</i>
                     </div>
+                    <div className = 'title'>
+                        Plug the HDMI dongle into your computer
+                    </div>
+                    <div className = 'subtitle'>
+                        If sharing doesn't start automatically click start sharing below.
+                    </div>
                 </div>
                 <div className = 'footer'>
-                    {
-                        'If sharing doesn\'t start automatically '
-                            + 'click start sharing below.'
-                    }
                     <Button
                         appearance = 'subtle'
                         className = 'cta-button'
@@ -254,16 +250,18 @@ export class ScreensharePicker extends React.Component {
 
         return (
             <>
-                <div className = 'title'>
-                    You are currently sharing content.
-                </div>
-                <div className = 'options'>
+                <div className = 'content'>
                     <div className = 'icon'>
                         <i className = 'material-icons'>{ icon }</i>
                     </div>
+                    <div className = 'title'>
+                        You're currently sharing content.
+                    </div>
+                    <div className = 'subtitle'>
+                        { ctaTitle }
+                    </div>
                 </div>
                 <div className = 'footer'>
-                    { ctaTitle }
                     <Button
                         appearance = 'subtle-danger'
                         className = 'cta-button'
@@ -284,37 +282,22 @@ export class ScreensharePicker extends React.Component {
      * @returns {ReactElement}
      */
     _renderWirelessScreenshareNotSupported() {
-        const { advertisedAppName, remoteJoinCode, shareDomain } = this.props;
-        const title = (
-            <span>
-                To share, use Chrome desktop and go to <span className = 'share-url'>
-                    { `${shareDomain || windowHandler.getHost()}/${remoteJoinCode}` }
-                </span>
-            </span>
-        );
-        const advertisement = this.props.advertisedAppName && (
-            <div>
-                or
-                <div>
-                    use { advertisedAppName } to connect to the room directly
-                </div>
-            </div>
-        );
+        const { remoteJoinCode, shareDomain } = this.props;
 
         return (
             <>
-                <div className = 'title'>
-                    { title }
-                </div>
-                <div className = 'options'>
+                <div className = 'content'>
                     <div className = 'icon'>
                         <i className = 'material-icons'>
                             wireless_screen_share
                         </i>
                     </div>
-                </div>
-                <div className = 'footer'>
-                    { advertisement }
+                    <div className = 'title'>
+                        To share, use Chrome desktop and go to
+                    </div>
+                    <div className = 'share-url'>
+                        { `${shareDomain || windowHandler.getHost()}/${remoteJoinCode}` }
+                    </div>
                 </div>
             </>
         );


### PR DESCRIPTION
I didn't focus much on the narrow width (mobile) stylings. I just made sure they appear. One of the bigger deviations from the designs is not having a separate "modal" for when on an unsupported browser, as calling out "browser" doesn't work out well for the native apps. So instead for unsupported browsers show the wireless screenshare instructions instead of calling out an unsupported nature; this was a bug fix agreed upon several weeks ago with design anyway but I think it was forgotten about during the current screenshare design revisioning.

<img width="1226" alt="Screen Shot 2019-06-16 at 10 37 01 AM" src="https://user-images.githubusercontent.com/1243084/59567637-f67b2a00-9024-11e9-8b4b-4fb9da3a5704.png">
<img width="1226" alt="Screen Shot 2019-06-16 at 10 36 56 AM" src="https://user-images.githubusercontent.com/1243084/59567633-f3803980-9024-11e9-8265-f22fbadaf4b7.png">
<img width="1410" alt="Screen Shot 2019-06-16 at 10 36 31 AM" src="https://user-images.githubusercontent.com/1243084/59567651-06930980-9025-11e9-9b58-bb7bbd024529.png">
<img width="1226" alt="Screen Shot 2019-06-16 at 10 37 04 AM" src="https://user-images.githubusercontent.com/1243084/59567644-f9761a80-9024-11e9-963d-28411c2c013f.png">
<img width="1410" alt="Screen Shot 2019-06-16 at 10 36 38 AM" src="https://user-images.githubusercontent.com/1243084/59567631-f0854900-9024-11e9-809e-85b7e4b769ef.png">

Mobile ugliness. Narrow width needs work in general. Keep me honest and request any changes you think are necessary now, but we don't have any designs or design attention for most of narrow width.
<img width="501" alt="Screen Shot 2019-06-16 at 10 36 04 AM" src="https://user-images.githubusercontent.com/1243084/59567608-c2a00480-9024-11e9-9096-75e8e3cab98b.png">

