### PR TITLE
fix(backend-calendar): implement `meetingUrlFields`

### DIFF
--- a/spot-client/src/spot-tv/calendars/backend-calendar.js
+++ b/spot-client/src/spot-tv/calendars/backend-calendar.js
@@ -46,7 +46,7 @@ export default {
 
                     output.push({
                         id: i,
-                        meetingUrl: inputEvent.meetingLink,
+                        meetingUrlFields: [ inputEvent.meetingLink, inputEvent.summary ],
                         start: inputEvent.start,
                         title: inputEvent.summary
                     });


### PR DESCRIPTION
Pass over the fields which could contain a meeting URL.