### PR TITLE
fix(meeting): make sure meeting fills screen

### DIFF
--- a/spot-client/src/common/css/_temp.scss
+++ b/spot-client/src/common/css/_temp.scss
@@ -151,7 +151,7 @@ body.using-mouse :focus {
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 100%;
+        min-height: 100vh;
     }
 }
 

--- a/spot-client/src/common/css/page-layouts/spot-tv/_meeting-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_meeting-view.scss
@@ -1,16 +1,15 @@
 .meeting-view {
-    height: 100%;
-    min-height: 100vh;
-    width: 100%;
+    height: 100vh;
+    width: 100vw;
 
     .status-overlay,
     .loading-curtain,
     .meetingMouseHider {
-        height: 100%;
+        height: 100vh;
         left: 0;
         position: absolute;
         top: 0;
-        width: 100%;
+        width: 100vw;
         z-index: $z-index-cover-base;
     }
 


### PR DESCRIPTION
Works around an issue currently in beta where
100% height on a child of a parent with 100vh
does not cause the child to also be 100vh.
Also, using vh for the child is more consistent.