### PR TITLE
ref(Spot Remote/backend): do not disconnect when no Spot TV in MUC

### DIFF
--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -431,7 +431,20 @@ export class RemoteControlClient extends BaseRemoteControlService {
 
             if (this._getSpotId() === from) {
                 logger.log('Spot TV left the MUC');
-                this._onDisconnect(CONNECTION_EVENTS.SERVER_DISCONNECTED);
+                if (this._options.backend) {
+                    // With backend it is okay for remote to sit in the MUC without Spot TV connected.
+                    this._lastSpotState = {
+                        spotId: undefined
+                    };
+                    this.emit(
+                        SERVICE_UPDATES.SERVER_STATE_CHANGE,
+                        {
+                            updatedState: this._lastSpotState
+                        }
+                    );
+                } else {
+                    this._onDisconnect(CONNECTION_EVENTS.SERVER_DISCONNECTED);
+                }
             }
 
             return;

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -4,7 +4,8 @@ import { connect } from 'react-redux';
 
 import {
     getCalendarEvents,
-    getCurrentView
+    getCurrentView,
+    isConnectedToSpot
 } from 'common/app-state';
 import { LoadingIcon, ReconnectOverlay, View } from 'common/ui';
 
@@ -27,6 +28,7 @@ export class RemoteControl extends React.PureComponent {
     static propTypes = {
         events: PropTypes.array,
         history: PropTypes.object,
+        isConnectedToSpot: PropTypes.bool,
         onDisconnect: PropTypes.func,
         view: PropTypes.string
     };
@@ -63,6 +65,10 @@ export class RemoteControl extends React.PureComponent {
      * @returns {ReactElement}
      */
     _getView() {
+        if (!this.props.isConnectedToSpot) {
+            return <div>Waiting for Spot TV to connect...</div>;
+        }
+
         switch (this.props.view) {
         case 'admin':
             return <div>currently in admin tools</div>;
@@ -93,7 +99,8 @@ export class RemoteControl extends React.PureComponent {
 function mapStateToProps(state) {
     return {
         events: getCalendarEvents(state),
-        view: getCurrentView(state)
+        view: getCurrentView(state),
+        isConnectedToSpot: isConnectedToSpot(state)
     };
 }
 


### PR DESCRIPTION
In the backend mode there's no need to drop the RCS connection when Spot TV is not in the MUC.