### PR TITLE
fix(backend): clear pairing code on missing jwt

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -2,7 +2,13 @@ import { logger } from 'common/logger';
 
 import { persistence } from '../utils';
 
-import { fetchRoomInfo, refreshAccessToken, registerDevice } from './utils';
+import { errorConstants } from './constants';
+import {
+    fetchRoomInfo,
+    isUnrecoverableError,
+    refreshAccessToken,
+    registerDevice
+} from './utils';
 
 const ONE_SECOND = 1000;
 const ONE_MINUTE = 60 * ONE_SECOND;
@@ -147,11 +153,11 @@ export class SpotBackendService {
                 this._setRegistration(pairingCode, registration);
 
                 if (!this.getJwt()) {
-                    throw new Error('No JWT');
+                    throw new Error(errorConstants.NO_JWT);
                 }
             })
             .catch(error => {
-                if (error === 'unrecoverable-error' && usingStoredRegistration) {
+                if (isUnrecoverableError(error) && usingStoredRegistration) {
                     persistence.set(PERSISTENCE_KEY, undefined);
                 }
 

--- a/spot-client/src/common/backend/constants.js
+++ b/spot-client/src/common/backend/constants.js
@@ -1,0 +1,4 @@
+export const errorConstants = {
+    NO_JWT: 'no-jwt',
+    REQUEST_FAILED: 'request-failed'
+};

--- a/spot-client/src/common/backend/index.js
+++ b/spot-client/src/common/backend/index.js
@@ -1,3 +1,9 @@
+export * from './constants';
 export * from './selectors';
 export * from './SpotBackendService';
-export { fetchCalendarEvents, getRemotePairingCode, refreshAccessToken } from './utils';
+export {
+    fetchCalendarEvents,
+    getRemotePairingCode,
+    isUnrecoverableError,
+    refreshAccessToken
+} from './utils';

--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -1,6 +1,8 @@
 import { logger } from 'common/logger';
 import { getJitterDelay } from 'common/utils/retry';
 
+import { errorConstants } from './constants';
+
 /**
  * Converts 'emitted' string date to a milliseconds date since the epoch and calculates the expiration date in
  * milliseconds since the epoch based on given 'expiresIn' value.
@@ -60,7 +62,7 @@ function fetchWithRetry(fetchOptions, maxRetries = 3) {
 
                         if (response.status < 500 || response.status >= 600) {
                             // Break the retry chain
-                            reject('unrecoverable-error');
+                            reject(errorConstants.REQUEST_FAILED);
 
                             return;
                         }
@@ -201,6 +203,20 @@ export function getRemotePairingCode(serviceEndpointUrl, jwt) {
             ...convertToEmittedAndExpires(json)
         };
     });
+}
+
+/**
+ * Returns whether or not the error is one in which a request cannot continue.
+ *
+ * @param {Error|string} error - The error object with details about the error
+ * or a string that identifies the error.
+ * @returns {boolean}
+ */
+export function isUnrecoverableError(error) {
+    const message = typeof error === 'object' ? error.message : error;
+
+    return message === errorConstants.REQUEST_FAILED
+        || message === errorConstants.NO_JWT;
 }
 
 /**

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -7,7 +7,11 @@ import {
     setReconnectState,
     setSpotTVState
 } from 'common/app-state';
-import { isBackendEnabled, SpotBackendService } from 'common/backend';
+import {
+    isBackendEnabled,
+    isUnrecoverableError,
+    SpotBackendService
+} from 'common/backend';
 import { history } from 'common/history';
 import { logger } from 'common/logger';
 import { createAsyncActionWithStates } from 'common/redux';
@@ -119,7 +123,7 @@ export function connectToSpotTV(joinCode, shareMode) {
             logger.error('On Spot Remote disconnect', { error });
 
             // Retry for permanent pairing as long as the backend accepts the code
-            if (error !== 'unrecoverable-error' && getPermanentPairingCode(getState())) {
+            if (!isUnrecoverableError(error) && getPermanentPairingCode(getState())) {
 
                 return doConnect();
             }

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -9,7 +9,8 @@ import {
     setReconnectState
 } from 'common/app-state';
 import {
-    isBackendEnabled
+    isBackendEnabled,
+    isUnrecoverableError
 } from 'common/backend';
 import { logger } from 'common/logger';
 import { createAsyncActionWithStates } from 'common/redux';
@@ -80,7 +81,7 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
             logger.error('Spot-TV disconnected from the remote control server.', { error });
             dispatch(setRemoteJoinCode(''));
 
-            if (pairingCode && error === 'unrecoverable-error') {
+            if (pairingCode && isUnrecoverableError(error)) {
                 // Clear the permanent pairing code
                 dispatch(setPermanentPairingCode(''));
 


### PR DESCRIPTION
Otherwise on initial load the connection
creation  will be retried indefinitely.