### PR TITLE
fix(setup): set display name on backend connection only

### DIFF
--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -66,7 +66,10 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
             dispatch(setRemoteJoinCode(remoteJoinCode));
             dispatch(setJwt(jwt));
             dispatch(setPermanentPairingCode(permanentPairingCode));
-            dispatch(setDisplayName(roomProfile.name));
+
+            if (isBackendEnabled(getState())) {
+                dispatch(setDisplayName(roomProfile.name));
+            }
         }
 
         /**


### PR DESCRIPTION
Or else the open source flow will have its configured
display name cleared.