### PR TITLE
fix(calendar): prevent multiple polls from enqueuing

### DIFF
--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -50,6 +50,7 @@
         "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",
+        "lodash.isequal": "4.5.0",
         "lodash.merge": "4.6.1",
         "lodash.throttle": "4.1.1",
         "lolex": "4.1.0",

--- a/spot-client/src/spot-tv/calendars/calendarService.test.js
+++ b/spot-client/src/spot-tv/calendars/calendarService.test.js
@@ -150,5 +150,39 @@ describe('calendarService', () => {
                     expect(events[1].meetingUrl).toEqual(undefined);
                 });
         });
+
+        it('does not notify of old requests after multiple poll starts', () => {
+            const notExpectedEvents = [
+                {
+                    meetingUrlFields: [],
+                    testEvent: 1
+                }
+            ];
+            const expectedEvents = [
+                {
+                    meetingUrlFields: [],
+                    testEvent: 2
+                }
+            ];
+
+            jest.spyOn(calendarService, 'getCalendar').mockImplementation(options => {
+                if (options.testValue === 1) {
+                    return Promise.resolve(notExpectedEvents);
+                }
+
+                return Promise.resolve(expectedEvents);
+            });
+            const eventPromise = createOneTimeCalendarServiceListener(
+                SERVICE_UPDATES.EVENTS_UPDATED
+            );
+
+            // Queue up two polls immediately, expecting the first not to
+            // be honored.
+            calendarService.startPollingForEvents({ testValue: 1 });
+            calendarService.startPollingForEvents({ testValue: 2 });
+
+            return eventPromise
+                .then(({ events }) => expect(events).toEqual(expectedEvents));
+        });
     });
 });


### PR DESCRIPTION
calendarService should only have one polling process
running at a time, but it could have multiple if
all queued up before the first completed. To prevent
such, use the passed in options to trigger cleanup
of any existing polling process but also check
against the latest polling options to prevent
notifications from old polling processes.