### PR TITLE
feat(logging): show device id in admin debug

### DIFF
--- a/spot-client/src/spot-tv/ui/components/admin/DeviceId.js
+++ b/spot-client/src/spot-tv/ui/components/admin/DeviceId.js
@@ -1,0 +1,19 @@
+import React, { memo } from 'react';
+import { getDeviceId } from 'common/utils';
+
+import AdminEntry from './admin-entry';
+
+/**
+ * Displays the debug device id.
+ *
+ * @returns {ReactNode}
+ */
+function DeviceId() {
+    return (
+        <AdminEntry entryLabel = 'Device ID'>
+            { getDeviceId() }
+        </AdminEntry>
+    );
+}
+
+export default memo(DeviceId);

--- a/spot-client/src/spot-tv/ui/components/admin/admin.js
+++ b/spot-client/src/spot-tv/ui/components/admin/admin.js
@@ -8,6 +8,7 @@ import { Modal } from 'common/ui';
 import { SelectMedia } from '../setup';
 
 import CalendarStatus from './calendar-status';
+import DeviceId from './DeviceId';
 import InMeetingConfig from './in-meeting-config';
 import PreferredDevices from './preferred-devices';
 import ResetApp from './reset-app';
@@ -73,6 +74,7 @@ class AdminModal extends React.Component {
         default:
             return [
                 <CalendarStatus key = 'key-calendarStatus' />,
+                <DeviceId key = 'device-id' />,
                 <PreferredDevices
                     key = 'key=preferredDevices'
                     onClick = { this._onChangeDevices } />,


### PR DESCRIPTION
Don't know where I'll shove it for spot-remote.

![Screen Shot 2019-07-11 at 3 00 15 PM](https://user-images.githubusercontent.com/1243084/61088192-9b9edd80-a3ec-11e9-93d4-2c614ef883a5.png)

