### PR TITLE
fix(meeting): prevent deep linking on meeting join

### DIFF
--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -132,6 +132,7 @@ export class MeetingFrame extends React.Component {
                     max: this.props.maxDesktopSharingFramerate,
                     min: this.props.minDesktopSharingFramerate
                 },
+                disableDeepLinking: true,
                 startScreenSharing: Boolean(this.props.screenshareDevice)
                     && this.props.startWithScreenshare,
                 startWithVideoMuted: Boolean(this.props.startWithVideoMuted)


### PR DESCRIPTION
Relies https://github.com/jitsi/jitsi-meet/pull/4466 being merged in and deployed. 