### PR TITLE
fix(button): change video mute button to start/stop camera

### DIFF
--- a/spot-client/src/spot-remote/ui/components/nav/buttons/VideoMuteButton.js
+++ b/spot-client/src/spot-remote/ui/components/nav/buttons/VideoMuteButton.js
@@ -47,10 +47,10 @@ export class VideoMuteButton extends React.Component {
         let qaId;
 
         if (changePending) {
-            label = videoMuted ? 'Muting...' : 'Unmuting...';
+            label = videoMuted ? 'Stopping...' : 'Starting...';
             qaId = 'mute-video-change-pending';
         } else {
-            label = videoMuted ? 'Unmute Video' : 'Mute Video';
+            label = videoMuted ? 'Start Camera' : 'Stop Camera';
             qaId = videoMuted ? 'unmute-video' : 'mute-video';
         }
 

--- a/spot-client/src/spot-remote/ui/components/nav/buttons/VideoMuteButton.test.js
+++ b/spot-client/src/spot-remote/ui/components/nav/buttons/VideoMuteButton.test.js
@@ -25,7 +25,7 @@ describe('VideoMuteButton', () => {
 
     describe('when not muted', () => {
         it('displays UI showing no mute', () => {
-            expect(videoMuteButton.find('.nav-label').text()).toEqual('Mute Video');
+            expect(videoMuteButton.find('.nav-label').text()).toEqual('Stop Camera');
             expect(videoMuteButton.find(Videocam).length).toBe(1);
             expect(videoMuteButton.find(VideocamOff).length).toBe(0);
         });
@@ -39,7 +39,7 @@ describe('VideoMuteButton', () => {
         it('displays pending state when unmute is still processing', () => {
             videoMuteButton.setProps({ changePending: true });
 
-            expect(videoMuteButton.find('.nav-label').text()).toEqual('Unmuting...');
+            expect(videoMuteButton.find('.nav-label').text()).toEqual('Starting...');
             expect(videoMuteButton.find(Videocam).length).toBe(1);
             expect(videoMuteButton.find(VideocamOff).length).toBe(0);
         });
@@ -51,7 +51,7 @@ describe('VideoMuteButton', () => {
         });
 
         it('displays UI showing mute', () => {
-            expect(videoMuteButton.find('.nav-label').text()).toEqual('Unmute Video');
+            expect(videoMuteButton.find('.nav-label').text()).toEqual('Start Camera');
             expect(videoMuteButton.find(Videocam).length).toBe(0);
             expect(videoMuteButton.find(VideocamOff).length).toBe(1);
         });
@@ -65,7 +65,7 @@ describe('VideoMuteButton', () => {
         it('displays pending state when mute is still processing', () => {
             videoMuteButton.setProps({ changePending: true });
 
-            expect(videoMuteButton.find('.nav-label').text()).toEqual('Muting...');
+            expect(videoMuteButton.find('.nav-label').text()).toEqual('Stopping...');
             expect(videoMuteButton.find(Videocam).length).toBe(0);
             expect(videoMuteButton.find(VideocamOff).length).toBe(1);
         });


### PR DESCRIPTION
This aligns better with jitsi-meet's tooltip for
video muting.

![Screen Shot 2019-07-24 at 3 15 32 PM](https://user-images.githubusercontent.com/1243084/61832762-060d4000-ae27-11e9-94ce-6117a8b5da70.png)
![Screen Shot 2019-07-24 at 3 15 29 PM](https://user-images.githubusercontent.com/1243084/61832765-073e6d00-ae27-11e9-8833-d3d0809d699e.png)
