### PR TITLE
fix(code-input): specify left position for older browsers

### DIFF
--- a/spot-client/src/common/css/_code-entry.scss
+++ b/spot-client/src/common/css/_code-entry.scss
@@ -45,6 +45,7 @@
         caret-color: transparent;
         color: transparent;
         font-size: $font-size-x-large;
+        left: 0;
         letter-spacing: 2em;
         pointer-events: none;
         position: absolute;


### PR DESCRIPTION
Older browesrs, namely iOS 10 safari, may place the
hidden input to the right of the input boxes instead
of below.