### PR TITLE
fix(code-input): use scale to hide caret

### DIFF
--- a/spot-client/src/common/css/_code-entry.scss
+++ b/spot-client/src/common/css/_code-entry.scss
@@ -49,6 +49,11 @@
         pointer-events: none;
         position: absolute;
         top: 0;
+
+        /**
+         * Use scale to work around iOS 11 not supporting caret-color.
+         */
+        transform: scale(0, 0);
         width: 100%;
         z-index: $z-index-base;
 


### PR DESCRIPTION
For iOS 10 and 11.0.