### PR TITLE
fix(rcs): pass onbeforeunload event to xmpp

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -28,8 +28,10 @@ export class BaseRemoteControlService extends Emitter {
 
         window.addEventListener(
             'beforeunload',
-            () => this.disconnect()
-                .catch(() => { /* swallow unload errors from bubbling up */ })
+            event => {
+                this.disconnect(event)
+                    .catch(() => { /* swallow unload errors from bubbling up */ });
+            }
         );
     }
 
@@ -214,11 +216,13 @@ export class BaseRemoteControlService extends Emitter {
     /**
      * Stops the XMPP connection.
      *
-     * @returns {void}
+     * @param {Object} [event] - Optionally, the event which triggered the
+     * necessity to disconnect from the XMPP server.
+     * @returns {Promise}
      */
-    disconnect() {
+    disconnect(event) {
         const destroyPromise = this.xmppConnection
-            ? this.xmppConnection.destroy()
+            ? this.xmppConnection.destroy(event)
             : Promise.resolve();
 
         return destroyPromise

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -121,11 +121,11 @@ export class RemoteControlClient extends BaseRemoteControlService {
      * @inheritdoc
      * @override
      */
-    disconnect() {
+    disconnect(event) {
         this.destroyWirelessScreenshareConnections();
         this._lastSpotState = null;
 
-        return super.disconnect();
+        return super.disconnect(event);
     }
 
     /**

--- a/spot-client/src/common/remote-control/remoteControlServer.js
+++ b/spot-client/src/common/remote-control/remoteControlServer.js
@@ -56,7 +56,7 @@ export class RemoteControlServer extends BaseRemoteControlService {
      * @inheritdoc
      * @override
      */
-    disconnect() {
+    disconnect(event) {
         clearTimeout(this._nextJoinCodeUpdate);
 
         if (this._options.backend) {
@@ -66,7 +66,7 @@ export class RemoteControlServer extends BaseRemoteControlService {
             );
         }
 
-        return super.disconnect();
+        return super.disconnect(event);
     }
 
     /**

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -235,16 +235,18 @@ export default class XmppConnection {
     /**
      * Disconnects from any joined MUC and disconnects the XMPP connection.
      *
+     * @param {Object} [event] - Optionally, the event which triggered the
+     * necessity to disconnect from the XMPP server.
      * @returns {Promise}
      */
-    destroy() {
-        const leavePromise = this.room ? this.room.leave() : Promise.resolve();
+    destroy(event) {
+        const leavePromise = this.xmppConnection
+            ? this.xmppConnection.disconnect(event)
+            : Promise.resolve();
 
-        // FIXME: The leave promise always times out.
         return leavePromise
             .catch(error =>
                 logger.error('XmppConnection error on disconnect', { error }))
-            .then(() => this.xmppConnection && this.xmppConnection.disconnect())
             .then(() => {
                 this._pendingIQRequestRejections.forEach(reject => reject());
                 this._pendingIQRequestRejections.clear();


### PR DESCRIPTION
JitsiConnection#disconnect takes in a browser
event object, which gets passed to its xmpp
connection. If that event is for a beforeunload
or unload event, the the disconnect is fired
synchronously to help ensure it completes.

This should help prevent jid conflicts
while developing and potentially with
upcoming work for selenium tests.