### PR TITLE
fix(tests): remove unused global afterEach

### DIFF
--- a/spot-webdriver/specs/helpers/global-after-each.js
+++ b/spot-webdriver/specs/helpers/global-after-each.js
@@ -1,4 +1,0 @@
-afterEach(() => {
-    // Delete all persisted app state.
-    browser.deleteLocalStorageItem('spot');
-});

--- a/spot-webdriver/wdio.conf.js
+++ b/spot-webdriver/wdio.conf.js
@@ -53,7 +53,6 @@ exports.config = {
     services: [ 'selenium-standalone' ],
 
     specs: [
-        path.resolve(__dirname, 'specs', 'helpers', '**/*.js'),
         path.resolve(__dirname, 'specs', '**/*.spec.js')
     ],
 


### PR DESCRIPTION
Ever since upgrading webdriverio, each spec
file runs in its own browser session. The
global afterEach was running in its own
browser session, not affecting any other
spec file.