### PR TITLE
ref(backend): prevent retry loop on some more errors

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -6,7 +6,6 @@ import { persistence } from '../utils';
 import { errorConstants } from './constants';
 import {
     fetchRoomInfo,
-    isUnrecoverableError,
     refreshAccessToken,
     registerDevice
 } from './utils';
@@ -107,8 +106,11 @@ export class SpotBackendService extends Emitter {
      * error or a string that identifies the error.
      * @returns {boolean}
      */
-    isUnrecoverableError(error) {
-        return isUnrecoverableError(error);
+    isUnrecoverableRequestError(error) {
+        const message = typeof error === 'object' ? error.message : error;
+
+        return message === errorConstants.REQUEST_FAILED
+            || message === errorConstants.NO_JWT;
     }
 
     /**

--- a/spot-client/src/common/backend/index.js
+++ b/spot-client/src/common/backend/index.js
@@ -4,6 +4,5 @@ export * from './SpotBackendService';
 export {
     fetchCalendarEvents,
     getRemotePairingCode,
-    isUnrecoverableError,
     refreshAccessToken
 } from './utils';

--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -223,20 +223,6 @@ export function getRemotePairingCode(serviceEndpointUrl, jwt) {
 }
 
 /**
- * Returns whether or not the error is one in which a request cannot continue.
- *
- * @param {Error|string} error - The error object with details about the error
- * or a string that identifies the error.
- * @returns {boolean}
- */
-export function isUnrecoverableError(error) {
-    const message = typeof error === 'object' ? error.message : error;
-
-    return message === errorConstants.REQUEST_FAILED
-        || message === errorConstants.NO_JWT;
-}
-
-/**
  * @typedef {Object} RefreshTokenResponse
  * @property {string} accessToken - A new/refreshed access token.
  * @property {number} emitted - A date expressed in milliseconds since the epoch which indicate when

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -7,11 +7,7 @@ import {
     setReconnectState,
     setSpotTVState
 } from 'common/app-state';
-import {
-    isBackendEnabled,
-    isUnrecoverableError,
-    SpotBackendService
-} from 'common/backend';
+import { isBackendEnabled, SpotBackendService } from 'common/backend';
 import { history } from 'common/history';
 import { logger } from 'common/logger';
 import { createAsyncActionWithStates } from 'common/redux';
@@ -116,7 +112,8 @@ export function connectToSpotTV(joinCode, shareMode) {
             logger.error('On Spot Remote disconnect', { error });
 
             // Retry for permanent pairing as long as the backend accepts the code
-            if (!isUnrecoverableError(error) && getPermanentPairingCode(getState())) {
+            if (getPermanentPairingCode(getState())
+                && !remoteControlClient.isUnrecoverableRequestError(error)) {
 
                 return doConnect();
             }

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -9,10 +9,7 @@ import {
     setReconnectState,
     setRoomId
 } from 'common/app-state';
-import {
-    isBackendEnabled,
-    isUnrecoverableError
-} from 'common/backend';
+import { isBackendEnabled } from 'common/backend';
 import { logger } from 'common/logger';
 import { createAsyncActionWithStates } from 'common/redux';
 import {
@@ -86,7 +83,7 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
             logger.error('Spot-TV disconnected from the remote control server.', { error });
             dispatch(setRemoteJoinCode(''));
 
-            if (pairingCode && isUnrecoverableError(error)) {
+            if (pairingCode && remoteControlServer.isUnrecoverableRequestError(error)) {
                 // Clear the permanent pairing code
                 dispatch(setPermanentPairingCode(''));
 


### PR DESCRIPTION
- Move isUnrecoverable(Request)Error into the
  remote control service to prevent direct
  calls into SpotBackendService
- Add checks for not-authorized and password
  required when determining if a retry should
  occur

If the path of the change looks good, then more testing will have to be doe. Likely some kind of manual test plan will also have to be written and executed to account for the various errors. Unit tests will be coming within the next month.