### PR TITLE
fix(logging): stringify error objects manually

### DIFF
--- a/spot-client/src/common/logger/logger.js
+++ b/spot-client/src/common/logger/logger.js
@@ -20,7 +20,21 @@ function formatMessage(level, message, context) {
     };
 
     if (context) {
-        formattedMessage.context = context;
+        const contextCopy = { ...context };
+
+        for (const key in contextCopy) {
+            if (contextCopy.hasOwnProperty(key)
+                && contextCopy[key] instanceof Error) {
+                const error = contextCopy[key];
+
+                contextCopy[key] = JSON.stringify(
+                    error,
+                    Object.getOwnPropertyNames(error)
+                );
+            }
+        }
+
+        formattedMessage.context = contextCopy;
     }
 
     return formattedMessage;


### PR DESCRIPTION
jitsi-meet-logger calls JSON.stringify on
Error instance, but error does not have
enumerable properties so only "{}" gets
logged.