### PR TITLE
Revert "fix(code-input): use scale to hide caret"

### DIFF
--- a/spot-client/src/common/css/_code-entry.scss
+++ b/spot-client/src/common/css/_code-entry.scss
@@ -50,11 +50,6 @@
         pointer-events: none;
         position: absolute;
         top: 0;
-
-        /**
-         * Use scale to work around iOS 11 not supporting caret-color.
-         */
-        transform: scale(0, 0);
         width: 100%;
         z-index: $z-index-base;
 


### PR DESCRIPTION
This reverts commit a96e612c8be1721222ae0cd6704c0d1cd3f685f4.

This breaks iOS auto centering the code input.