### PR TITLE
fix(BaseRemoteControlService): infinite loop on rejected promise

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -78,6 +78,7 @@ export class BaseRemoteControlService extends Emitter {
         });
 
         this.xmppConnectionPromise = this._createConnectionPromise(this._options);
+        this.xmppConnectionPromise.catch(error => this.disconnect().then(() => Promise.reject(error)));
 
         return this.xmppConnectionPromise;
     }
@@ -115,7 +116,6 @@ export class BaseRemoteControlService extends Emitter {
                     onDisconnect: this._onDisconnect
                 });
             })
-            .catch(error => this.disconnect().then(() => Promise.reject(error)))
             .then(() => roomProfile);
     }
 


### PR DESCRIPTION
Both remote control server and remote control client further extend the connect promise. The 'catch' must be attached on top of the promises created by the subclasses in order to always reset
the 'xmppConnectionPromise'. Otherwise the app will loop forever on the rejected promise.