### PR TITLE
Fixes around the backend flow

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -217,7 +217,14 @@ export class SpotBackendService extends Emitter {
 
         this._refreshTimeout = setTimeout(() => {
             this._refreshRegistration(this.registration)
-                .then(() => this.emit(SpotBackendService.REGISTRATION_UPDATED, { jwt: this.getJwt() }));
+                .then(
+                    () => this.emit(SpotBackendService.REGISTRATION_UPDATED, { jwt: this.getJwt() }),
+                    error => {
+                        logger.error('Access token refresh failed', { error });
+
+                        // Emit event with empty jwt which means the backend registration is lost
+                        this.emit(SpotBackendService.REGISTRATION_UPDATED, { jwt: undefined });
+                    });
         }, delay);
     }
 

--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -78,6 +78,7 @@ export class BaseRemoteControlService extends Emitter {
         });
 
         this.xmppConnectionPromise = this._createConnectionPromise(this._options);
+        this.xmppConnectionPromise.catch(error => this.disconnect().then(() => Promise.reject(error)));
 
         return this.xmppConnectionPromise;
     }
@@ -115,7 +116,6 @@ export class BaseRemoteControlService extends Emitter {
                     onDisconnect: this._onDisconnect
                 });
             })
-            .catch(error => this.disconnect().then(() => Promise.reject(error)))
             .then(() => roomProfile);
     }
 


### PR DESCRIPTION
Fix for infinite loop and adds connection drop on token refresh error.

Will split into two PRs if needed, but the 2nd depends on the 1st being merged to avoid merge conflict, so it's less time this way.