### PR TITLE
feat(join): 8 character code for permanent remote

### DIFF
--- a/spot-admin/app.js
+++ b/spot-admin/app.js
@@ -31,7 +31,7 @@ console.info('Spot room id: ' + spot1Id);
 
 const spot1 = new SpotRoom(spot1Id, {
     pairingCode: {
-        code: '123456',
+        code: '12345678',
         expiresIn: 60 * 60 * 1000
     },
     jwtToken: {

--- a/spot-client/src/common/css/_code-entry.scss
+++ b/spot-client/src/common/css/_code-entry.scss
@@ -38,7 +38,7 @@
         }
     }
 
-    input {
+    textarea {
         background: transparent;
         border: 0;
         bottom: 0;
@@ -47,8 +47,10 @@
         font-size: $font-size-x-large;
         left: 0;
         letter-spacing: 2em;
+        overflow: hidden;
         pointer-events: none;
         position: absolute;
+        resize: none;
         top: 0;
         width: 100%;
         z-index: $z-index-base;

--- a/spot-client/src/common/css/page-layouts/_join-code-view.scss
+++ b/spot-client/src/common/css/page-layouts/_join-code-view.scss
@@ -20,8 +20,25 @@
     .code-entry-wrapper {
         @include centered-content;
 
+        &.boxes-8 .code-entry {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr 1fr;
+
+            @media #{$mq-tablet} {
+                display: flex;
+            }
+        }
+        &.boxes-6 .code-entry {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+
+
+            @media #{$mq-tablet} {
+                display: flex;
+            }
+        }
+
         .code-entry {
-            display: flex;
             justify-content: center;
             margin: auto;
 

--- a/spot-client/src/common/ui/components/code-input/CodeInput.js
+++ b/spot-client/src/common/ui/components/code-input/CodeInput.js
@@ -183,11 +183,12 @@ export default class CodeInput extends React.Component {
      */
     _renderHiddenInput() {
         return (
-            <input
+            <textarea
                 autoCapitalize = 'off'
                 autoComplete = 'off'
                 autoCorrect = 'off'
                 autoFocus = { this._isAutoFocusSupported }
+                className = 'hidden-user-input'
                 maxLength = { this.props.length }
                 onBlur = { this._onBlur }
                 onChange = { this._onChange }

--- a/spot-client/src/common/ui/components/code-input/CodeInput.test.js
+++ b/spot-client/src/common/ui/components/code-input/CodeInput.test.js
@@ -21,7 +21,7 @@ describe('CodeInput', () => {
      * @returns {void}
      */
     function setValue(value) {
-        const input = codeInput.find('input');
+        const input = codeInput.find('.hidden-user-input');
 
         input.at(0).instance().value = value;
         input.simulate('change');

--- a/spot-client/src/spot-remote/ui/views/help.js
+++ b/spot-client/src/spot-remote/ui/views/help.js
@@ -6,6 +6,7 @@ import {
     getPrivacyPolicyURL,
     getTermsAndConditionsURL
 } from 'common/app-state';
+import { isBackendEnabled } from 'common/backend';
 import { isSpotControllerApp } from 'common/detection';
 import { history } from 'common/history';
 import { ROUTES } from 'common/routing';
@@ -21,6 +22,7 @@ import { setHasCompletedOnboarding } from '../../app-state';
  */
 class Help extends React.Component {
     static propTypes = {
+        codeLength: PropTypes.number,
         onContinue: PropTypes.func,
         privacyPolicyURL: PropTypes.string,
         termsAndConditionsURL: PropTypes.string
@@ -53,7 +55,8 @@ class Help extends React.Component {
                             This app is a remote controller for a conference room.
                             <div>
                                 Open { Help._getSpotTvUrl() } in a desktop Google Chrome browser in the conference room
-                                to set it up and obtain a share key. Next enter the 6-character share key in this app.
+                                to set it up and obtain a share key. Next enter the { this.props.codeLength }-character
+                                share key in this app.
                             </div>
                         </div>
                         <Button
@@ -108,6 +111,7 @@ class Help extends React.Component {
  */
 function mapStateToProps(state) {
     return {
+        codeLength: isSpotControllerApp(state) && isBackendEnabled(state) ? 8 : 6,
         privacyPolicyURL: getPrivacyPolicyURL(state),
         termsAndConditionsURL: getTermsAndConditionsURL(state)
     };

--- a/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
+++ b/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
@@ -59,7 +59,9 @@ export class SyncWithBackend extends React.Component {
                     </div>
                 </div>
                 <div className = { `code-input ${this.state.loading ? 'with-loading' : ''}` }>
-                    <CodeInput onChange = { this._onChange } />
+                    <CodeInput
+                        length = { 8 }
+                        onChange = { this._onChange } />
                     { this.state.loading && <LoadingIcon /> }
                 </div>
             </div>
@@ -74,7 +76,7 @@ export class SyncWithBackend extends React.Component {
      * @returns {void}
      */
     _onChange(value) {
-        if (value.length !== 6) {
+        if (value.length !== 8) {
             return;
         }
 

--- a/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.test.js
+++ b/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.test.js
@@ -6,6 +6,7 @@ import { LoadingIcon } from 'common/ui';
 import { SyncWithBackend } from './SyncWithBackend';
 
 describe('SyncWithBackend', () => {
+    const MOCK_JOIN_CODE = '12345678';
     let onAttemptSyncSpy, onSuccessSpy, onSyncErrorSpy, syncWithBackend;
 
     beforeEach(() => {
@@ -29,7 +30,7 @@ describe('SyncWithBackend', () => {
      * @returns {void}
      */
     function setValue(joinCode) {
-        const input = syncWithBackend.find('input');
+        const input = syncWithBackend.find('textarea');
 
         input.at(0).instance().value = joinCode;
         input.simulate('change');
@@ -40,7 +41,7 @@ describe('SyncWithBackend', () => {
 
         expect(syncWithBackend.find(LoadingIcon).length).toBe(0);
 
-        setValue('123456');
+        setValue(MOCK_JOIN_CODE);
 
         expect(syncWithBackend.find(LoadingIcon).length).toBe(1);
     });
@@ -48,7 +49,7 @@ describe('SyncWithBackend', () => {
     it('calls the success callback', () => {
         onAttemptSyncSpy.mockImplementation(() => Promise.resolve());
 
-        setValue('123456');
+        setValue(MOCK_JOIN_CODE);
 
         const runSyncPromise = new Promise(resolve => process.nextTick(resolve));
 
@@ -59,7 +60,7 @@ describe('SyncWithBackend', () => {
     it('calls the error callback', () => {
         onAttemptSyncSpy.mockImplementation(() => Promise.reject());
 
-        setValue('123456');
+        setValue(MOCK_JOIN_CODE);
 
         const runSyncPromise = new Promise(resolve => process.nextTick(resolve));
 


### PR DESCRIPTION
- If backend flow and app, show 8 boxes
- If backend flow and not the app, show 6 boxes
- If open source flow, always show 6 boxes

Note: this commit re-introduces usage of css-grid
which is not supported in old chrome (polycom).

Android phone open source flow.
<img width="445" alt="Screen Shot 2019-08-06 at 11 27 58 AM" src="https://user-images.githubusercontent.com/1243084/62566840-c3902e00-b83e-11e9-8fd4-654d910ac4db.png">

Android phone backend flow.
<img width="445" alt="Screen Shot 2019-08-06 at 11 29 40 AM" src="https://user-images.githubusercontent.com/1243084/62566763-95aae980-b83e-11e9-8153-9f0031cbc0be.png">

iPad open source flow.
<img width="842" alt="Screen Shot 2019-08-06 at 11 38 36 AM" src="https://user-images.githubusercontent.com/1243084/62566878-d6a2fe00-b83e-11e9-887e-e51c87f48a5d.png">

iPad backend flow.
<img width="842" alt="Screen Shot 2019-08-06 at 11 38 47 AM" src="https://user-images.githubusercontent.com/1243084/62566932-f1757280-b83e-11e9-9c30-a5d2033e8a75.png">