### PR TITLE
Refresh the access token and retry if backend replies with 401

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -114,7 +114,8 @@ export class SpotBackendService extends Emitter {
     isUnrecoverableRequestError(error) {
         const message = typeof error === 'object' ? error.message : error;
 
-        return message === errorConstants.REQUEST_FAILED;
+        return message === errorConstants.REQUEST_FAILED
+            || message === errorConstants.NOT_AUTHORIZED;
     }
 
     /**

--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -243,7 +243,6 @@ export class SpotBackendService extends Emitter {
      * @param {SpotRegistration} registration - The backend registration structure to be stored.
      * @private
      * @returns {void}
-     * @throws Throws {@link errorConstants.NO_JWT} if the new registration does not contain an access token.
      */
     _setRegistration(pairingCode, registration) {
         this.registration = {
@@ -252,7 +251,7 @@ export class SpotBackendService extends Emitter {
         };
 
         if (!this.getJwt()) {
-            throw new Error(errorConstants.NO_JWT);
+            throw new Error('no-jwt');
         }
 
         // Only long lived registrations are persisted

--- a/spot-client/src/common/backend/constants.js
+++ b/spot-client/src/common/backend/constants.js
@@ -1,5 +1,10 @@
 export const errorConstants = {
     /**
+     * Error response returned by the backend when the client tries to use expires access token.
+     */
+    NOT_AUTHORIZED: 'not-authorized',
+
+    /**
      * When backend receives an error response from which there is no recovery.
      */
     REQUEST_FAILED: 'request-failed'

--- a/spot-client/src/common/backend/constants.js
+++ b/spot-client/src/common/backend/constants.js
@@ -1,11 +1,5 @@
 export const errorConstants = {
     /**
-     * Thrown during connecting process if for any reason there is no access token in the registration object.
-     * This is most likely a bug in the code and should not be handled.
-     */
-    NO_JWT: 'no-jwt',
-
-    /**
      * When backend receives an error response from which there is no recovery.
      */
     REQUEST_FAILED: 'request-failed'

--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -93,7 +93,11 @@ function fetchWithRetry(fetchOptions, maxRetries = 3) {
                         requestId: requestOptions.headers.get('request-id')
                     });
 
-                    if (response.status < 500 || response.status >= 600) {
+                    if (response.status === 401) {
+                        reject(errorConstants.NOT_AUTHORIZED);
+
+                        return;
+                    } else if (response.status < 500 || response.status >= 600) {
                         // Break the retry chain early
                         reject(errorConstants.REQUEST_FAILED);
 

--- a/spot-client/src/common/backend/utils.test.js
+++ b/spot-client/src/common/backend/utils.test.js
@@ -363,7 +363,7 @@ describe('utils', () => {
             });
 
             it('does not retry when the server returns an error', () => {
-                fetch.mockResponseOnce('', { status: 401 });
+                fetch.mockResponseOnce('', { status: 400 });
 
                 return utils.fetchRoomInfo(MOCK_SERVICE_ENDPOINT, MOCK_JWT)
                     .then(

--- a/spot-client/src/spot-tv/backend/SpotTVBackendService.test.js
+++ b/spot-client/src/spot-tv/backend/SpotTVBackendService.test.js
@@ -1,0 +1,135 @@
+import { persistence } from 'common/utils';
+
+import { SpotTvBackendService } from './SpotTvBackendService';
+
+// FIXME duplicated with SpotBackendService.test.js
+jest.mock('common/utils', () => {
+    return {
+        ...jest.requireActual('common/utils'),
+        generateGuid: jest.fn()
+    };
+});
+
+// FIXME duplicated with SpotBackendService.test.js
+/**
+ * Creates a matcher for refresh request for given params.
+ *
+ * @param {string} refreshToken - The refresh token.
+ * @returns {*}
+ */
+function refreshRequestMatcher(refreshToken) {
+    return expect.objectContaining({
+        body: `{"refreshToken":"${refreshToken}"}`,
+        method: 'PUT',
+        mode: 'cors'
+    });
+}
+
+describe('SpotTvBackendService', () => {
+    const PAIRING_SERVICE_URL = 'test/pairing/url';
+    const REFRESH_SERVICE_URL = `${PAIRING_SERVICE_URL}/regenerate`;
+    const ROOM_KEEPER_SERVICE_URL = 'test/keeper/url';
+    let spotBackendService;
+
+    beforeEach(() => {
+        spotBackendService = new SpotTvBackendService({
+            pairingServiceUrl: PAIRING_SERVICE_URL,
+            roomKeeperServiceUrl: ROOM_KEEPER_SERVICE_URL
+        });
+    });
+
+    describe('generates pairing codes', () => {
+        const MOCK_PAIRING_CODE = '123456';
+        const MOCK_RESPONSE = {
+            accessToken: 'new-access-token',
+            emitted: Date.now(),
+            expiresIn: 10 * 60 * 1000,
+            refreshToken: 'new-refresh-token'
+        };
+
+        describe('and refreshes the access token if backend returns 401', () => {
+            const MOCK_REGISTRATION = {
+                ...MOCK_RESPONSE,
+                pairingCode: MOCK_PAIRING_CODE,
+                expiresIn: undefined,
+                expires: MOCK_RESPONSE.emitted + MOCK_RESPONSE.expiresIn
+            };
+
+            beforeEach(() => {
+                jest.useFakeTimers();
+                jest.spyOn(persistence, 'get')
+                    .mockReturnValue(MOCK_REGISTRATION);
+                fetch.resetMocks();
+            });
+
+            it('when trying to get a short lived code', () =>
+                spotBackendService.register(MOCK_PAIRING_CODE)
+                    .then(() => {
+                        const testShortLivedCode = '113366';
+
+                        // Mock the initial request to fetch the code
+                        fetch.once('', {
+                            status: 401,
+                            ok: false
+                        });
+
+                        // Mock the refreshing of the token
+                        fetch.once(JSON.stringify(MOCK_RESPONSE));
+
+                        // Mock the request to get room info
+                        fetch.once(JSON.stringify({
+                            emitted: Date.now(),
+                            expiresIn: 60 * 1000,
+                            code: testShortLivedCode
+                        }));
+
+                        return spotBackendService.fetchShortLivedPairingCode().then(code => {
+                            expect(code).toEqual(testShortLivedCode);
+
+                            // Check if the refresh was done (does not check other requests)
+                            expect(fetch)
+                                .toHaveBeenCalledWith(
+                                    REFRESH_SERVICE_URL,
+                                    refreshRequestMatcher(MOCK_RESPONSE.refreshToken)
+                                );
+                        });
+                    }));
+            it('when trying to get a long lived code', () =>
+                spotBackendService.register(MOCK_PAIRING_CODE)
+                    .then(() => {
+                        const testLongLivedCode = '11336688';
+
+                        // Mock the initial request to fetch the code
+                        fetch.once('', {
+                            status: 401,
+                            ok: false
+                        });
+
+                        // Mock the refreshing of the token
+                        fetch.once(JSON.stringify(MOCK_RESPONSE));
+
+                        // Mock the request to get room info
+                        fetch.once(JSON.stringify({
+                            emitted: Date.now(),
+                            expiresIn: 60 * 1000,
+                            code: testLongLivedCode
+                        }));
+
+                        return spotBackendService.generateLongLivedPairingCode()
+                            .then(longLivedCodeInfo => {
+                                expect(longLivedCodeInfo)
+                                    .toMatchObject({
+                                        code: testLongLivedCode
+                                    });
+
+                                // Check if the refresh was done (does not check other requests)
+                                expect(fetch)
+                                    .toHaveBeenCalledWith(
+                                        REFRESH_SERVICE_URL,
+                                        refreshRequestMatcher(MOCK_RESPONSE.refreshToken)
+                                    );
+                            });
+                    }));
+        });
+    });
+});

--- a/spot-client/src/spot-tv/backend/SpotTvBackendService.js
+++ b/spot-client/src/spot-tv/backend/SpotTvBackendService.js
@@ -81,10 +81,12 @@ export class SpotTvBackendService extends SpotBackendService {
             return Promise.reject('Spot TV backend is not registered - no JWT');
         }
 
-        return getRemotePairingCode(
+        const requestCreator = () => getRemotePairingCode(
             `${this.pairingServiceUrl}/code?pairingType=${type}`,
             this.getJwt()
         );
+
+        return this._wrapJwtBackendRequest(requestCreator);
     }
 }
 

--- a/spot-client/src/spot-tv/backend/SpotTvBackendService.js
+++ b/spot-client/src/spot-tv/backend/SpotTvBackendService.js
@@ -22,10 +22,6 @@ export class SpotTvBackendService extends SpotBackendService {
      * @returns {Promise<string>}
      */
     fetchShortLivedPairingCode() {
-        if (!this.getJwt()) {
-            return Promise.reject('Spot TV backend is not registered - no JWT');
-        }
-
         return this._fetchPairingCode()
             .then(remotePairingInfo => {
                 this.remotePairingInfo = remotePairingInfo;
@@ -81,6 +77,10 @@ export class SpotTvBackendService extends SpotBackendService {
      * @returns {Promise<Object>}
      */
     _fetchPairingCode(type = 'SHORT_LIVED') {
+        if (!this.getJwt()) {
+            return Promise.reject('Spot TV backend is not registered - no JWT');
+        }
+
         return getRemotePairingCode(
             `${this.pairingServiceUrl}/code?pairingType=${type}`,
             this.getJwt()


### PR DESCRIPTION
Adds a logic which will retry a backend request in case it responds with 401.

Still not sure whether the calendar request should be included or not ?