### PR TITLE
fix(screenshare): use roboto mono for code

### DIFF
--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -38,6 +38,10 @@
         font-size: $font-size-medium-plus;
         font-weight: bold;
         margin-top: 1em;
+
+        .join-code {
+            @include join-code;
+        }
     }
 
     .subtitle {

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -296,7 +296,8 @@ export class ScreensharePicker extends React.Component {
                         To share, use Chrome desktop and go to
                     </div>
                     <div className = 'share-url'>
-                        { `${shareDomain || windowHandler.getHost()}/${remoteJoinCode}` }
+                        { `${shareDomain || windowHandler.getHost()}/` }
+                        <span className = 'join-code'>{ remoteJoinCode }</span>
                     </div>
                 </div>
             </>


### PR DESCRIPTION
Missed a spot.

Edit: maybe this means I should make a separate component that's just `<span>{ remoteJoinCode }</span>`.