### PR TITLE
feat(RCS): specify MUC JID resource name for Spot Remotes

### DIFF
--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -53,6 +53,7 @@ export default class XmppConnection {
      * being made by a Spot client.
      * @param {string} options.jwt - The JWT token to be used with the XMPP
      * connection.
+     * @param {string} [options.resourceName] - The resource part of the MUC JID to be used(optional).
      * @param {boolean} [options.retryOnUnauthorized] - Whether or not to retry
      * connection without a roomLock if an unauthorized error occurs.
      * @param {string} [options.roomLock] - The lock code to use when joining or
@@ -67,6 +68,7 @@ export default class XmppConnection {
         const {
             joinAsSpot,
             jwt,
+            resourceName,
             retryOnUnauthorized,
             roomLock,
             roomName,
@@ -195,7 +197,7 @@ export default class XmppConnection {
         let mucJoinedPromise;
 
         this.initPromise = connectionPromise
-            .then(() => this._createMuc(roomName, joinAsSpot && 'spot-tv'))
+            .then(() => this._createMuc(roomName, resourceName))
             .then(room => {
                 mucJoinedPromise = new Promise(resolve => {
                     room.addEventListener('xmpp.muc_joined', resolve);


### PR DESCRIPTION
Will use 'remote-perm' prefix for a permanent Spot Remote and
'remote-temp' for a temporary one. This will allow the backend to figure
out what's being connected to the MUC.

Example value for a permanent Spot Remote:

'remote-perm-12345678'

Example for a temporary Spot Remote:

'remote-temp-123455678'

The numbers at the end will be 8 random hex characters.