### PR TITLE
feat(join-code-entry): allow either 6 or 8 characters as code from URL

### DIFF
--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -83,8 +83,8 @@ export class JoinCodeEntry extends React.Component {
         this.props.onDisconnect();
 
         const { pathname } = this.props.location;
-        const codeMatch = pathname.match(new RegExp(`^/(\\w{${this.props.codeLength}})$`));
-        let code = codeMatch && codeMatch[1];
+        const codeMatch = pathname.match(new RegExp('^/(\\w{8})|(\\w{6})$'));
+        let code = codeMatch && (codeMatch[1] || codeMatch[2]);
 
         if (!code && this.props.location.hash && this.props.location.hash.includes('#/?')) {
             const parts = this.props.location.hash.substr(3);


### PR DESCRIPTION
Will allow either 6 or 8 characters long pairing codes to be used when entered as part of the URL.