### PR TITLE
fix(nav): prevent overflow cutoff on safari

### DIFF
--- a/spot-client/src/common/css/nav/_nav-button.scss
+++ b/spot-client/src/common/css/nav/_nav-button.scss
@@ -59,6 +59,11 @@
 
         flex-grow: 1;
         margin: auto;
+
+        /**
+         * Workaround for Safari cutting off text.
+         */
+        position: relative;
         white-space: nowrap;
         width: calc(#{$font-size-large} * 2.5);
     }


### PR DESCRIPTION
Happens on wide resolutions.

Issue:
<img width="1635" alt="Screen Shot 2019-08-08 at 12 37 01 PM" src="https://user-images.githubusercontent.com/1243084/62732688-d3904500-b9d9-11e9-94e4-e8f63928b9dd.png">

With potential fix:
<img width="1635" alt="Screen Shot 2019-08-08 at 12 37 18 PM" src="https://user-images.githubusercontent.com/1243084/62732689-d4c17200-b9d9-11e9-9a00-a01d95a7e826.png">
