### PR TITLE
ref(device-id): include device type in device ID

### DIFF
--- a/spot-client/src/common/app-state/device-id/action-types.js
+++ b/spot-client/src/common/app-state/device-id/action-types.js
@@ -1,1 +1,3 @@
 export const SET_DEVICE_ID = 'SET_DEVICE_ID';
+
+export const SET_SPOT_INSTANCE_INFO = 'SET_SPOT_INSTANCE_INFO';

--- a/spot-client/src/common/app-state/device-id/actions.js
+++ b/spot-client/src/common/app-state/device-id/actions.js
@@ -1,5 +1,5 @@
 import {
-    SET_DEVICE_ID
+    SET_DEVICE_ID, SET_SPOT_INSTANCE_INFO
 } from './action-types';
 
 /**
@@ -12,5 +12,24 @@ export function setDeviceId(deviceId) {
     return {
         type: SET_DEVICE_ID,
         deviceId
+    };
+}
+
+/**
+ * Sets the extra information that can be used to generate a new device ID if
+ * needed.
+ *
+ * @param {string} roomId - A Spot room ID assigned by teh backend.
+ * @param {boolean} isSpotTv - Tells whether it's a Spot TV or a Spot Remote.
+ * @param {boolean} isPairingPermanent - When set to true means that it's a permanent backend pairing using long lived
+ * pairing code.
+ * @returns {Object}
+ */
+export function setSpotInstanceInfo({ roomId, isSpotTv, isPairingPermanent }) {
+    return {
+        type: SET_SPOT_INSTANCE_INFO,
+        roomId,
+        isSpotTv,
+        isPairingPermanent
     };
 }

--- a/spot-client/src/common/app-state/device-id/index.js
+++ b/spot-client/src/common/app-state/device-id/index.js
@@ -1,4 +1,5 @@
 export * from './action-types';
+export * from './actions';
 export * from './selectors';
 
 import './middleware';

--- a/spot-client/src/common/app-state/device-id/middleware.js
+++ b/spot-client/src/common/app-state/device-id/middleware.js
@@ -3,8 +3,8 @@ import { MiddlewareRegistry } from 'common/redux';
 import { generate8Characters, generateGuid } from '../../utils';
 
 import { BOOTSTRAP_STARTED } from '../bootstrap';
-import { SET_ROOM_ID } from '../setup/action-types';
 
+import { SET_SPOT_INSTANCE_INFO } from './action-types';
 import { setDeviceId } from './actions';
 import { getDeviceId } from './selectors';
 
@@ -18,15 +18,20 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         dispatch(setDeviceId(deviceId));
     }
         break;
-    case SET_ROOM_ID: {
+    case SET_SPOT_INSTANCE_INFO: {
         const deviceId = getDeviceId(getState());
-        const roomId = action.id;
+        const {
+            roomId,
+            isSpotTv,
+            isPairingPermanent
+        } = action;
+        const deviceIdPrefix = _getDeviceIdPrefix(roomId, isSpotTv, isPairingPermanent);
 
         // Update the device ID to start with the room ID.
         // At the time of this writing the purpose is to easier find device logs for devices
         // connected to specific room. Remove once the problem is solved in another way.
-        if (roomId && (!deviceId || !deviceId.startsWith(roomId))) {
-            const newDeviceId = `${roomId}-${generate8Characters()}`;
+        if (roomId && (!deviceId || !deviceId.startsWith(deviceIdPrefix))) {
+            const newDeviceId = `${deviceIdPrefix}-${generate8Characters()}`;
 
             dispatch(setDeviceId(newDeviceId));
         }
@@ -36,3 +41,23 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
     return result;
 });
+
+/**
+ * Generates a device ID prefix.
+ *
+ * @param {string} roomId - The room ID assigned by the backend.
+ * @param {boolean} isSpotTv - Spot TV or Spot Remote ?
+ * @param {boolean} isPairingPermanent - Is it permanent(long lived) backend pairing.
+ * @returns {string}
+ * @private
+ */
+function _getDeviceIdPrefix(roomId, isSpotTv, isPairingPermanent) {
+    const middlePart
+        = isSpotTv
+            ? 'spot-tv'
+            : isPairingPermanent
+                ? 'remote-perm'
+                : 'remote-temp';
+
+    return `${roomId}-${middlePart}`;
+}

--- a/spot-client/src/common/app-state/setup/action-types.js
+++ b/spot-client/src/common/app-state/setup/action-types.js
@@ -9,5 +9,3 @@ export const SET_IS_SPOT = 'SET_IS_SPOT';
 export const SET_JWT = 'SET_JWT_TOKEN';
 
 export const SET_PREFERRED_DEVICES = 'SET_PREFERRED_DEVICES';
-
-export const SET_ROOM_ID = 'SET_ROOM_ID';

--- a/spot-client/src/common/app-state/setup/actions.js
+++ b/spot-client/src/common/app-state/setup/actions.js
@@ -4,8 +4,7 @@ import {
     SET_DISPLAY_NAME,
     SET_IS_SPOT,
     SET_JWT,
-    SET_PREFERRED_DEVICES,
-    SET_ROOM_ID
+    SET_PREFERRED_DEVICES
 } from './action-types';
 
 /**
@@ -78,20 +77,6 @@ export function setPreferredDevices(cameraLabel, micLabel, speakerLabel) {
         cameraLabel,
         micLabel,
         speakerLabel
-    };
-}
-
-/**
- * Updates the known id provided to the room by the backend for which Spot is
- * integrated with.
- *
- * @param {string} id - The room id.
- * @returns {Object}
- */
-export function setRoomId(id) {
-    return {
-        type: SET_ROOM_ID,
-        id
     };
 }
 

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -5,9 +5,9 @@ import {
     getSpotServicesConfig,
     setCalendarEvents,
     setReconnectState,
-    setRoomId,
     setSpotTVState
 } from 'common/app-state';
+import { setSpotInstanceInfo } from 'common/app-state/device-id';
 import { createAsyncActionWithStates } from 'common/async-actions';
 import { isBackendEnabled, SpotBackendService } from 'common/backend';
 import { history } from 'common/history';
@@ -105,7 +105,11 @@ export function connectToSpotTV(joinCode, shareMode) {
 
             const roomId = roomProfile && roomProfile.id;
 
-            roomId && dispatch(setRoomId(roomId));
+            roomId && dispatch(setSpotInstanceInfo({
+                roomId,
+                isSpotTv: false,
+                isPairingPermanent: backend && backend.isPairingPermanent()
+            }));
         }
 
         /**

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -6,9 +6,9 @@ import {
     setDisplayName,
     setRemoteJoinCode,
     setJwt,
-    setReconnectState,
-    setRoomId
+    setReconnectState
 } from 'common/app-state';
+import { setSpotInstanceInfo } from 'common/app-state/device-id';
 import { createAsyncActionWithStates } from 'common/async-actions';
 import { isBackendEnabled } from 'common/backend';
 import { logger } from 'common/logger';
@@ -68,7 +68,11 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
             dispatch(setPermanentPairingCode(permanentPairingCode));
 
             if (isBackendEnabled(getState())) {
-                dispatch(setRoomId(roomProfile.id));
+                dispatch(setSpotInstanceInfo({
+                    isPairingPermanent: true,
+                    isSpotTv: true,
+                    roomId: roomProfile.id
+                }));
                 dispatch(setDisplayName(roomProfile.name));
             }
         }


### PR DESCRIPTION
Will add 'spot-tv', 'remote-perm' or 'remote-temp' as part of the device ID to be able to tell the device type instantly.