### PR TITLE
ref(join-code): do not spread all props onto join code component

### DIFF
--- a/spot-client/src/common/ui/components/remote-join-code/RemoteJoinCode.js
+++ b/spot-client/src/common/ui/components/remote-join-code/RemoteJoinCode.js
@@ -14,7 +14,7 @@ import { getRemoteJoinCode } from 'common/app-state';
 export function RemoteJoinCode(props) {
     const {
         remoteJoinCode,
-        ...rest
+        qaId
     } = props;
 
     if (!remoteJoinCode) {
@@ -23,14 +23,15 @@ export function RemoteJoinCode(props) {
 
     return (
         <span
-            { ...rest }
-            className = 'join-code'>
+            className = 'join-code'
+            data-qa-id = { qaId }>
             { remoteJoinCode }
         </span>
     );
 }
 
 RemoteJoinCode.propTypes = {
+    qaId: PropTypes.string,
     remoteJoinCode: PropTypes.string
 };
 

--- a/spot-client/src/spot-tv/ui/components/join-info/join-info.js
+++ b/spot-client/src/spot-tv/ui/components/join-info/join-info.js
@@ -62,7 +62,7 @@ class JoinInfo extends React.Component {
     _getCopyToDisplay() {
         const { shareDomain, showDomain } = this.props;
 
-        const codeElement = <RemoteJoinCode data-qa-id = 'info-code' />;
+        const codeElement = <RemoteJoinCode qaId = 'info-code' />;
 
         if (!showDomain) {
             return codeElement;


### PR DESCRIPTION
Because redux's dispatch is a prop and trying to set
that as an attribute logs an error.