### PR TITLE
fix(spot-tv/analytics): do not emit pairing analytics for reconnect

### DIFF
--- a/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
+++ b/spot-client/src/spot-tv/ui/components/setup/SyncWithBackend.js
@@ -6,11 +6,7 @@ import { addNotification } from 'common/app-state';
 import { CodeInput, LoadingIcon } from 'common/ui';
 import { logger } from 'common/logger';
 
-import {
-    createSpotTVRemoteControlConnection,
-    disconnectSpotTvRemoteControl,
-    generateLongLivedPairingCode
-} from '../../../app-state';
+import { pairWithBackend } from '../../../app-state';
 
 /**
  * Displays the setup step for Spot-TV to enter a code to create a connection
@@ -111,23 +107,7 @@ export class SyncWithBackend extends React.Component {
 function mapDispatchToProps(dispatch) {
     return {
         onAttemptSync(pairingCode) {
-            return dispatch(createSpotTVRemoteControlConnection({
-                pairingCode,
-                retry: false
-            }))
-            .then(
-                () => dispatch(generateLongLivedPairingCode())
-                    .catch(error => {
-
-                        // This intentionally disconnects only on the generateLongLivedPairingCode failure, because
-                        // it's not part of the connect promise and will not cause disconnect, causing the connection
-                        // to be left behind.
-                        logger.error('Failed to generate long lived pairing code', { error });
-                        dispatch(disconnectSpotTvRemoteControl());
-
-                        throw error;
-                    })
-            );
+            return dispatch(pairWithBackend(pairingCode));
         },
 
         onSyncError() {


### PR DESCRIPTION
Adds extra action to be used by the UI in order to establish backend pairing, so that the pairing analytics are not dispatched by the reconnect logic.