### PR TITLE
ref(setup): remove open-source setup flow step of pairing remote

### DIFF
--- a/spot-client/src/spot-tv/ui/components/setup/PairRemote.js
+++ b/spot-client/src/spot-tv/ui/components/setup/PairRemote.js
@@ -2,12 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import {
-    getPairedRemotesCount,
-    getPermanentPairedRemotesCount,
-    getRemoteJoinCode
-} from 'common/app-state';
-import { isBackendEnabled } from 'common/backend';
+import { getPermanentPairedRemotesCount } from 'common/app-state';
 import { Button } from 'common/ui';
 
 import { getLongLivedPairingCodeInfo } from '../../../backend';
@@ -78,12 +73,8 @@ export class PairRemote extends React.Component {
  */
 function mapStateToProps(state) {
     return {
-        code: isBackendEnabled(state)
-            ? (getLongLivedPairingCodeInfo(state) || {}).code
-            : getRemoteJoinCode(state),
-        permanentRemotesCount: isBackendEnabled(state)
-            ? getPermanentPairedRemotesCount(state)
-            : getPairedRemotesCount(state)
+        code: (getLongLivedPairingCodeInfo(state) || {}).code,
+        permanentRemotesCount: getPermanentPairedRemotesCount(state)
     };
 }
 

--- a/spot-client/src/spot-tv/ui/views/setup.js
+++ b/spot-client/src/spot-tv/ui/views/setup.js
@@ -2,11 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+
 import { setSetupCompleted } from 'common/app-state';
 import { isBackendEnabled } from 'common/backend';
 import { logger } from 'common/logger';
 import { ROUTES } from 'common/routing';
 import { Modal } from 'common/ui';
+
 import { withCalendar } from '../loaders';
 
 import {
@@ -49,8 +51,7 @@ export class Setup extends React.Component {
                 CalendarAuth,
                 SelectRoom,
                 Profile,
-                SelectMedia,
-                PairRemote
+                SelectMedia
             ];
 
         this.state = {


### PR DESCRIPTION
There is no "permanent remote control" for the open source
flows.