### PR TITLE
feat(controller): add controller identifier to user agent

### DIFF
--- a/spot-controller/src/remote-control.js
+++ b/spot-controller/src/remote-control.js
@@ -124,6 +124,8 @@ export default class RemoteControl extends React.PureComponent {
                     allowsInlineMediaPlayback = { true }
                     allowsLinkPreview = { false }
 
+                    applicationNameForUserAgent = 'SpotController/1'
+
                     // Prevents moving the webview up and down.
                     bounces = { false }
 


### PR DESCRIPTION
Included is an explicit callout to the controller as well as a "feature" version of what the controller supports, which can be used by the controller to do feature compatibility checking if needed.

@paweldomas let me know what you think about this "feature" version part. I was thinking spot-client could use it to check if the spot-controller environment supports some feature and support some kind of legacy behavior (or no-op) if needed. Maybe it's just not needed, plus it's work to manually increment it. At the least I do want this user agent callout.