### PR TITLE
fix(electron): add skip and submit buttons for desktop picker

### DIFF
--- a/spot-client/src/common/css/_desktop-picker.scss
+++ b/spot-client/src/common/css/_desktop-picker.scss
@@ -5,11 +5,17 @@
         background-color: black;
         opacity: 0.7;
     }
+
+    .desktop-picker {
+        width: 100%;
+
+        @media #{$mq-tablet} {
+            width: 50vw;
+        }
+    }
 }
 
 .desktop-picker {
-    width: 100%;
-
     .picker-tabs {
         button {
             @include button-reset;
@@ -31,7 +37,7 @@
         overflow: auto;
         padding: 10px;
     }
-    
+
     .picker-choice {
         @include button-reset;
         background-color: rgba(0, 0, 0, 0);
@@ -44,7 +50,7 @@
             background-color: var(--container-content-highlight-bg-color);
         }
     }
-    
+
     .picker-choice-thumbnail {
         height: auto;
         padding: 10px;
@@ -63,6 +69,15 @@
     &.left-most-tab {
         .picker-choices  {
             border-top-left-radius: 0px;
+        }
+    }
+
+    .picker-footer {
+        margin-top: 34px;
+        text-align: center;
+
+        .button:not(:last-child) {
+            margin-right: 10px;
         }
     }
 }

--- a/spot-client/src/spot-remote/ui/components/electron-desktop-picker/desktop-picker.js
+++ b/spot-client/src/spot-remote/ui/components/electron-desktop-picker/desktop-picker.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { logger } from 'common/logger';
+import { Button } from 'common/ui';
 
 import SourcePreview from './source-preview';
 
@@ -13,6 +14,7 @@ import SourcePreview from './source-preview';
  */
 export default class DesktopPicker extends React.Component {
     static propTypes = {
+        onCancel: PropTypes.func,
         onSelect: PropTypes.func
     };
 
@@ -47,6 +49,7 @@ export default class DesktopPicker extends React.Component {
         this._onDoubleClick = this._onDoubleClick.bind(this);
         this._onShowScreenPreviews = this._onShowScreenPreviews.bind(this);
         this._onShowWindowPreviews = this._onShowWindowPreviews.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
         this._updateSources = this._updateSources.bind(this);
     }
 
@@ -97,6 +100,18 @@ export default class DesktopPicker extends React.Component {
                 </div>
                 <div className = 'picker-choices'>
                     { this._renderPreviews() }
+                </div>
+                <div className = 'picker-footer'>
+                    <Button
+                        appearance = 'subtle'
+                        onClick = { this.props.onCancel }>
+                        Cancel
+                    </Button>
+                    <Button
+                        disabled = { !this.state.selected.id }
+                        onClick = { this._onSubmit }>
+                        Select
+                    </Button>
                 </div>
             </div>
         );
@@ -189,6 +204,21 @@ export default class DesktopPicker extends React.Component {
             selected: this._getSelectedSource(this.state.sources, 'window'),
             tab: 'window'
         });
+    }
+
+    /**
+     * Callback invoked when a screensharing source has been selected.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onSubmit() {
+        const {
+            id,
+            type
+        } = this.state.selected;
+
+        this.props.onSelect(id, type);
     }
 
     /**

--- a/spot-client/src/spot-remote/ui/components/electron-desktop-picker/electron-desktop-picker-modal.js
+++ b/spot-client/src/spot-remote/ui/components/electron-desktop-picker/electron-desktop-picker-modal.js
@@ -64,7 +64,9 @@ export default class ElectronDesktopPickerModal extends React.Component {
             <Modal
                 onClose = { this._onClose }
                 rootClassName = 'electron-desktop-picker-modal'>
-                <DesktopPicker onSelect = { this._onClose } />
+                <DesktopPicker
+                    onCancel = { this._onClose }
+                    onSelect = { this._onClose } />
             </Modal>
         );
     }


### PR DESCRIPTION
I forgot this modal even existed.

<img width="1089" alt="Screen Shot 2019-08-10 at 8 37 01 AM" src="https://user-images.githubusercontent.com/1243084/62823810-46b8c900-bb4a-11e9-813e-d9f9d9947545.png">
