### PR TITLE
feature(analytics): log page event when a View is displayed

### DIFF
--- a/spot-client/src/common/analytics/analytics.js
+++ b/spot-client/src/common/analytics/analytics.js
@@ -34,6 +34,19 @@ export class Analytics {
     }
 
     /**
+     * Logs a page/view being displayed.
+     *
+     * @param {string} name - A name which describes and identifies the page to be logged.
+     * @param {Object} properties - Additional information to log which describe the page event in greater detail.
+     * @returns {void}
+     */
+    page(name, properties) {
+        this._handlers.forEach(handler => {
+            handler.page && handler.page(name, properties);
+        });
+    }
+
+    /**
      * Sets the new local analytics user id on all handlers.
      *
      * @param {string} newId - The new unique id for the local user.

--- a/spot-client/src/common/analytics/analytics.js
+++ b/spot-client/src/common/analytics/analytics.js
@@ -37,7 +37,7 @@ export class Analytics {
      * Logs a page/view being displayed.
      *
      * @param {string} name - A name which describes and identifies the page to be logged.
-     * @param {Object} properties - Additional information to log which describe the page event in greater detail.
+     * @param {Object} [properties] - Additional information to log which describe the page event in greater detail.
      * @returns {void}
      */
     page(name, properties) {

--- a/spot-client/src/common/analytics/libs/segment.js
+++ b/spot-client/src/common/analytics/libs/segment.js
@@ -135,5 +135,16 @@ export default {
      */
     track(event, properties) {
         window.analytics.track(event, properties);
+    },
+
+    /**
+     * Records a "page" event in Segment.
+     *
+     * @param {string} name - The name of the viewed page.
+     * @param {Object} properties - Additional details about the event.
+     * @returns {void}
+     */
+    page(name, properties) {
+        window.analytics.page(/* category */ undefined, name, properties);
     }
 };

--- a/spot-client/src/common/analytics/middleware.js
+++ b/spot-client/src/common/analytics/middleware.js
@@ -4,6 +4,7 @@ import { getSpotClientVersion } from '../app-state';
 import { BOOTSTRAP_COMPLETE } from '../app-state/bootstrap';
 import { SET_DEVICE_ID } from '../app-state/device-id';
 import { getPermanentPairingCode, SET_PERMANENT_PAIRING_CODE } from '../backend';
+import { VIEW_DISPLAYED } from '../ui/actionTypes';
 
 import analytics from './analytics';
 import { permanentPairingCodeEvents } from './events';
@@ -20,6 +21,10 @@ MiddlewareRegistry.register(({ getState }) => next => action => {
         break;
     case SET_PERMANENT_PAIRING_CODE:
         return _permanentPairingAnalytics({ getState }, next, action);
+    case VIEW_DISPLAYED:
+        analytics.page(action.name);
+
+        break;
     }
 
     return next(action);

--- a/spot-client/src/common/analytics/segment-handler.js
+++ b/spot-client/src/common/analytics/segment-handler.js
@@ -29,6 +29,17 @@ export default class SegmentHandler {
     }
 
     /**
+     * Records a "page" event in Segment.
+     *
+     * @param {string} name - The name of the viewed page.
+     * @param {Object} properties - Additional details about the event.
+     * @returns {void}
+     */
+    page(name, properties) {
+        segment.page(name, properties);
+    }
+
+    /**
      * Updates the known id of the user.
      *
      * @param {string} deviceId - The user identifier for the current user.

--- a/spot-client/src/common/ui/actionTypes.js
+++ b/spot-client/src/common/ui/actionTypes.js
@@ -1,0 +1,2 @@
+
+export const VIEW_DISPLAYED = 'VIEW_DISPLAYED';

--- a/spot-client/src/common/ui/actions.js
+++ b/spot-client/src/common/ui/actions.js
@@ -1,0 +1,14 @@
+import { VIEW_DISPLAYED } from './actionTypes';
+
+/**
+ * Action dispatched when a {@code View} has been displayed.
+ *
+ * @param {string} name - The view's name.
+ * @returns {Object}
+ */
+export function viewDisplayed(name) {
+    return {
+        type: VIEW_DISPLAYED,
+        name
+    };
+}

--- a/spot-client/src/common/ui/index.js
+++ b/spot-client/src/common/ui/index.js
@@ -1,3 +1,4 @@
+export * from './actionTypes';
 export * from './components';
 export * from './loaders';
 export * from './views';

--- a/spot-client/src/common/ui/views/view.js
+++ b/spot-client/src/common/ui/views/view.js
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { analytics } from 'common/analytics';
 import { getBackgroundUrl, isAnyModalOpen } from 'common/app-state';
 import { logger } from 'common/logger';
+
+import { viewDisplayed } from '../actions';
 
 /**
  * A React Component representing a single screen in the single-page application
@@ -16,6 +17,7 @@ class View extends React.Component {
     static propTypes = {
         backgroundUrl: PropTypes.string,
         children: PropTypes.node,
+        dispatch: PropTypes.func,
         hideBackground: PropTypes.bool,
         isAnyModalOpen: PropTypes.bool,
         name: PropTypes.string
@@ -28,7 +30,7 @@ class View extends React.Component {
      */
     componentDidMount() {
         logger.log('View mounted', { name: this.props.name });
-        analytics.page(this.props.name);
+        this.props.dispatch(viewDisplayed(this.props.name));
     }
 
     /**

--- a/spot-client/src/common/ui/views/view.js
+++ b/spot-client/src/common/ui/views/view.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { analytics } from 'common/analytics';
 import { getBackgroundUrl, isAnyModalOpen } from 'common/app-state';
 import { logger } from 'common/logger';
 
@@ -27,6 +28,7 @@ class View extends React.Component {
      */
     componentDidMount() {
         logger.log('View mounted', { name: this.props.name });
+        analytics.page(this.props.name);
     }
 
     /**


### PR DESCRIPTION
Will log a page event when view is being displayed.

Know issue: all Spot-TV setup steps fall under one page as those are modals displayed on the setup view.