### PR TITLE
fix(webdriver): change results directory

### DIFF
--- a/spot-webdriver/wdio.conf.js
+++ b/spot-webdriver/wdio.conf.js
@@ -62,14 +62,15 @@ exports.config = {
         [
             'junit',
             {
-                outputDir: './webdriver-results/junit'
+                outputDir: './webdriver-results'
             }
         ],
         'spec',
         [
             'timeline',
             {
-                outputDir: './webdriver-results/timeline',
+                embedImages: true,
+                outputDir: './webdriver-results',
                 screenshotStrategy: 'before:click'
             }
         ]


### PR DESCRIPTION
TimelineService errors if the nested directory
does not exist but can create directories of
one level.