### PR TITLE
fix(spot-controller): respect reset query param

### DIFF
--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -28,6 +28,7 @@ import {
     remoteControlClient
 } from 'common/remote-control';
 import {
+    clearPersistedState,
     getPersistedState,
     loadScript,
     setPersistedState
@@ -37,6 +38,12 @@ import { ExternalApiSubscriber } from 'spot-remote/external-api';
 import App from './app';
 
 const queryParams = new URLSearchParams(window.location.search);
+
+// On Aug 22, 2019, this param is used by old spot-controllers. Remove this code
+// after some time.
+if (queryParams.get('reset') === 'true') {
+    clearPersistedState();
+}
 
 const store = createStore(
     ReducerRegistry.combineReducers(reducers),


### PR DESCRIPTION
Old controllers (app store) are still using this
query param.