### PR TITLE
fix(modal): take up available height, not view height

### DIFF
--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -17,7 +17,7 @@
 
     .modal-content {
         background-color: var(--container-content-bg-color-no-opacity);
-        height: 100vh;
+        height: 100%;
         max-height: 100vh;
         overflow: auto;
         pointer-events: all;


### PR DESCRIPTION
View height might get obscured by available height
on iOS safari. As such, drop down to using available
height instead.

I bet this breaks something somewhere.

With fix (notice top-right):
<img width="559" alt="with_fix" src="https://user-images.githubusercontent.com/1243084/63556645-81cbdc80-c4fa-11e9-9b22-eabcf39baa67.png">

Without fix:
<img width="559" alt="Screen Shot 2019-08-22 at 4 29 53 PM" src="https://user-images.githubusercontent.com/1243084/63556663-8f816200-c4fa-11e9-90aa-995d704b8967.png">
