### PR TITLE
ref(ultrasound): remove workaround of playing on interaction

### DIFF
--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -22,7 +22,6 @@ import {
     setAPiReceivedJoinCode
 } from './../../app-state';
 import { NavButton, NavContainer } from './../components';
-import { withUltrasound } from './../loaders';
 
 /**
  * Displays a view to enter a join code for connecting with a Spot-TV instance.
@@ -46,7 +45,6 @@ export class JoinCodeEntry extends React.Component {
         onDisconnect: PropTypes.func,
         permanentPairingCode: PropTypes.string,
         shareDomain: PropTypes.string,
-        ultrasoundService: PropTypes.object,
         updateReadyStatus: PropTypes.func
     };
 
@@ -78,7 +76,6 @@ export class JoinCodeEntry extends React.Component {
      */
     componentDidMount() {
         this.props.updateReadyStatus(true);
-        this.props.ultrasoundService.setMessage('');
         this.props.onDisconnect();
 
         const { pathname } = this.props.location;
@@ -291,11 +288,6 @@ export class JoinCodeEntry extends React.Component {
         });
         const trimmedCode = code.trim().toLowerCase();
 
-        // Trigger ultrasound playing now to piggyback on the connect button tap
-        // as workaround for mobile Safari requiring a user action to autoplay
-        // any sound.
-        this.props.ultrasoundService.setMessage(trimmedCode);
-
         submitPromise
             .then(() => this.props.onConnectToSpotTV(trimmedCode, this._isInShareModeEnv()))
             .then(() => {
@@ -407,4 +399,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withUltrasound(connect(mapStateToProps, mapDispatchToProps)(JoinCodeEntry));
+export default connect(mapStateToProps, mapDispatchToProps)(JoinCodeEntry);


### PR DESCRIPTION
Before it was known a mobile application was required,
ultrasound was built to be played from mobile safari,
which requires a user interaction before playing sound.
The workaround was to start playing sound on join code
submit, but that is not needed anymore as the react
native webview can allow sound to play without
interaction.

Probably a larger refactoring of ultrasound is needed to
move away from the "loader" pattern.