### PR TITLE
fix(SpotBackendService): clear registration on initial refresh failure

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -191,6 +191,8 @@ export class SpotBackendService extends Emitter {
                 const expiresIn = getExpiresIn(storedRegistration);
 
                 if (expiresIn < FIVE_MINUTES) {
+                    // Need to attach the registration, so that it is correctly cleared on refresh failure.
+                    this.registration = storedRegistration;
                     registerDevicePromise = this._refreshRegistration(storedRegistration);
                 } else {
                     registerDevicePromise = Promise.resolve(storedRegistration);
@@ -199,7 +201,10 @@ export class SpotBackendService extends Emitter {
         }
 
         if (!registerDevicePromise) {
-            logger.log('No stored registration');
+            logger.log('No stored registration', {
+                pairingCode,
+                storedPairingCode: storedRegistration && storedRegistration.pairingCode
+            });
             registerDevicePromise
                 = registerDevice(`${this.pairingServiceUrl}`, pairingCode)
                     .catch(error => this._maybeClearRegistration(error));

--- a/spot-client/src/common/backend/SpotBackendService.test.js
+++ b/spot-client/src/common/backend/SpotBackendService.test.js
@@ -226,6 +226,25 @@ describe('SpotBackendService', () => {
                             .toBe(true);
                     })
             );
+            it('clears the registration if starts with expired token and initial refresh fails', () => {
+                // Starting with expired registration
+                const persistenceSpy = jest.spyOn(persistence, 'set');
+
+                jest.spyOn(persistence, 'get').mockReturnValue({
+                    ...MOCK_REGISTRATION,
+                    expires: Date.now() - 1000
+                });
+
+                // Reject the initial refresh
+                fetch.once('', {
+                    status: 401,
+                    ok: false
+                });
+
+                return spotBackendService.register(MOCK_PAIRING_CODE).catch(() => {
+                    expect(persistenceSpy).toHaveBeenCalledWith('spot-backend-registration', undefined);
+                });
+            });
         });
 
         describe('tries to refresh the access token if backend returns 401', () => {


### PR DESCRIPTION
If service starts with expired access token and the refresh operation fails the stored registration is not cleared correctly, because 'this.registration' was not set.