### PR TITLE
feat: integrate tenant name if provided by the backend

### DIFF
--- a/spot-admin/app.js
+++ b/spot-admin/app.js
@@ -48,7 +48,8 @@ const spot1 = new SpotRoom(spot1Id, {
     remotePairingCode: {
         code: '112233',
         expiresIn: 6 * 60 * 1000
-    }
+    },
+    tenant: process.env.TENANT
 });
 
 spots.set(spot1.id, spot1);

--- a/spot-admin/backend/pair-device.js
+++ b/spot-admin/backend/pair-device.js
@@ -51,7 +51,8 @@ function registerDeviceController(spots, req, res) {
         emitted: Date.now(),
         expiresIn: jwtStructure.expiresIn,
         id: spotRoom.id,
-        refreshToken: shortLived ? undefined : jwtStructure.refreshToken
+        refreshToken: shortLived ? undefined : jwtStructure.refreshToken,
+        tenant: spotRoom.options.tenant
     };
 
     sendJSON(res, response);

--- a/spot-admin/backend/refresh-code.js
+++ b/spot-admin/backend/refresh-code.js
@@ -23,15 +23,16 @@ function refreshController(spots, req, res) {
         return;
     }
 
-    let jwtToken = null;
+    let spotRoom = null;
     for (const spot of spots.values()) {
         if (spot.options.jwtToken.refreshToken === refreshToken) {
-            jwtToken = spot.options.jwtToken;
+            spotRoom = spot;
+            break;
         }
     }
 
     // Note that there are no checks for roomName duplication
-    if (!jwtToken) {
+    if (!spotRoom) {
         send401Error(res, 'Invalid refresh token');
 
         return;
@@ -43,10 +44,14 @@ function refreshController(spots, req, res) {
         return;
     }
 
+    const jwtToken = spotRoom.options.jwtToken;
+
     const response = {
         accessToken: jwtToken.accessToken,
         emitted: Date.now(),
-        expiresIn: jwtToken.expiresIn
+        expiresIn: jwtToken.expiresIn,
+        tenant: spotRoom.options.tenant
+
     };
 
     sendJSON(res, response);

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -70,7 +70,7 @@ export function getDefaultAvatarUrl(state) {
 * @param {Object} state - The Redux state.
 * @returns {string}
 */
-export function getDefaultMeetingDomain(state) {
+export function getConfiguredMeetingDomain(state) {
     return state.config.DEFAULT_MEETING_DOMAIN;
 }
 

--- a/spot-client/src/common/app-state/setup/action-types.js
+++ b/spot-client/src/common/app-state/setup/action-types.js
@@ -9,3 +9,5 @@ export const SET_IS_SPOT = 'SET_IS_SPOT';
 export const SET_JWT = 'SET_JWT_TOKEN';
 
 export const SET_PREFERRED_DEVICES = 'SET_PREFERRED_DEVICES';
+
+export const SET_TENANT = 'SET_TENANT';

--- a/spot-client/src/common/app-state/setup/actions.js
+++ b/spot-client/src/common/app-state/setup/actions.js
@@ -4,7 +4,8 @@ import {
     SET_DISPLAY_NAME,
     SET_IS_SPOT,
     SET_JWT,
-    SET_PREFERRED_DEVICES
+    SET_PREFERRED_DEVICES,
+    SET_TENANT
 } from './action-types';
 
 /**
@@ -89,5 +90,18 @@ export function setPreferredDevices(cameraLabel, micLabel, speakerLabel) {
 export function setSetupCompleted() {
     return {
         type: SETUP_COMPLETED
+    };
+}
+
+/**
+ * Stores a tenant advertised by the backend in the Redux state.
+ *
+ * @param {?string} tenant - A tenant name(if any) to store.
+ * @returns {Object}
+ */
+export function setTenant(tenant) {
+    return {
+        type: SET_TENANT,
+        tenant
     };
 }

--- a/spot-client/src/common/app-state/setup/reducer.js
+++ b/spot-client/src/common/app-state/setup/reducer.js
@@ -4,7 +4,7 @@ import {
     SET_DISPLAY_NAME,
     SET_IS_SPOT,
     SET_JWT,
-    SET_PREFERRED_DEVICES
+    SET_PREFERRED_DEVICES, SET_TENANT
 } from './action-types';
 
 const DEFAULT_STATE = {
@@ -63,6 +63,12 @@ const setup = (state = DEFAULT_STATE, action) => {
             preferredCamera: action.cameraLabel,
             preferredMic: action.micLabel,
             preferredSpeaker: action.speakerLabel
+        };
+
+    case SET_TENANT:
+        return {
+            ...state,
+            tenant: action.tenant
         };
 
     default:

--- a/spot-client/src/common/app-state/setup/selectors.js
+++ b/spot-client/src/common/app-state/setup/selectors.js
@@ -64,6 +64,16 @@ export function getPreferredSpeaker(state) {
 }
 
 /**
+ * Returns the tenant name stored in the Redux state.
+ *
+ * @param {Object} state - The Redux store.
+ * @returns {?string}
+ */
+export function getTenant(state) {
+    return state.setup.tenant;
+}
+
+/**
  * A selector which returns whether or not the application has been configured.
  *
  * @param {Object} state - The Redux state.

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -51,6 +51,16 @@ export function getRemoteSpotTVRoomName(state) {
 }
 
 /**
+ * Returns a tenant name advertised by Spot TV.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {?string}
+ */
+export function getSpotTVTenant(state) {
+    return state.spotTv.tenant;
+}
+
+/**
 * A selector for Spot-Remote which returns whether or not it is currently
 * able to communicate with a Spot-TV.
 *

--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -100,6 +100,15 @@ export class SpotBackendService extends Emitter {
     }
 
     /**
+     * Returns the tenant part from the backend registration info.
+     *
+     * @returns {string}
+     */
+    getTenant() {
+        return this.registration && this.registration.tenant;
+    }
+
+    /**
      * Returns true if the current pairing is permanent. This means that the backend has granted a refresh token which
      * can be used to refresh an access token indefinitely.
      *
@@ -279,7 +288,10 @@ export class SpotBackendService extends Emitter {
         // Only long lived registrations are persisted
         this.registration.refreshToken && persistence.set(PERSISTENCE_KEY, this.registration);
 
-        this.emit(SpotBackendService.REGISTRATION_UPDATED, { jwt: this.getJwt() });
+        this.emit(SpotBackendService.REGISTRATION_UPDATED, {
+            jwt: this.getJwt(),
+            tenant: this.getTenant()
+        });
 
         this._setRefreshTimeout();
     }

--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -236,6 +236,7 @@ export function getRemotePairingCode(serviceEndpointUrl, jwt) {
  * the token has been emitted.
  * @property {number} expires - A date expressed in milliseconds since the epoch which indicate when
  * the token will expire.
+ * @property {string} [tenant] - A tenant name bound to specific customer for which Spot instance is being registered.
  */
 /**
  * Sends a token refresh request to get a fresh token, before the current one expires.
@@ -300,15 +301,7 @@ export function refreshAccessToken(serviceEndpointUrl, { accessToken, refreshTok
  * the token will expire.
  * @property {string} [refreshToken] - The token used to refresh the authorization. Present only in
  * a permanent type of pairing.
- *
- * Example response:
- *
- * {
- *  "accessToken": "string",
- *  "emitted": "2019-05-28T18:02:31.576Z",
- *  "expiresIn": 0,
- *  "refreshToken": "string"
- * }
+ * @property {string} [tenant] - A tenant name bound to specific customer for which Spot instance is being registered.
  */
 /**
  * Authenticates with the backend service.
@@ -338,7 +331,8 @@ export function registerDevice(serviceEndpointUrl, pairingCode) {
                 accessToken,
                 emitted,
                 expiresIn,
-                refreshToken
+                refreshToken,
+                tenant
             } = json;
 
             if (!accessToken) {
@@ -352,6 +346,7 @@ export function registerDevice(serviceEndpointUrl, pairingCode) {
             return {
                 accessToken,
                 refreshToken,
+                tenant,
                 ...convertToEmittedAndExpires(json)
             };
         });

--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -266,7 +266,12 @@ export class BaseRemoteControlService extends Emitter {
                 const backend = this._getBackend();
 
                 // FIXME define a structure and add a getter for "REGISTRATION" being sent on REGISTRATION_UPDATED event
-                backend && this.emit(SERVICE_UPDATES.REGISTRATION_UPDATED, { jwt: backend.getJwt() });
+                backend
+                    && this.emit(
+                        SERVICE_UPDATES.REGISTRATION_UPDATED, {
+                            jwt: backend.getJwt(),
+                            tenant: backend.getTenant()
+                        });
             })
             .catch(error => {
                 logger.warn('failed to load', { error });

--- a/spot-client/src/common/remote-control/remote-control-service-subscriber.js
+++ b/spot-client/src/common/remote-control/remote-control-service-subscriber.js
@@ -1,3 +1,6 @@
+// FIXME Reaching directly because of circular dependency
+import { getTenant } from 'common/app-state/setup/selectors';
+
 import remoteControlClient from './remoteControlClient';
 import remoteControlServer from './remoteControlServer';
 
@@ -12,6 +15,7 @@ export default class RemoteControlServiceSubscriber {
     constructor() {
         this._previousRoomName = '';
         this._previousSpotTvState = {};
+        this._previousTenant = undefined;
         this._previousCalendarEvents = [];
     }
 
@@ -28,16 +32,20 @@ export default class RemoteControlServiceSubscriber {
         const newSpotTvState = state.spotTv;
         const newCalendarEvents = state.calendars.events || [];
         const newRoomName = state.setup.displayName;
+        const newTenant = getTenant(state);
 
         if (newSpotTvState === this._previousSpotTvState
             && newCalendarEvents === this._previousCalendarEvents
-            && newRoomName === this._previousRoomName) {
+            && newRoomName === this._previousRoomName
+            && newTenant === this._previousTenant
+        ) {
             return;
         }
 
         remoteControlServer.updateStatus({
             ...newSpotTvState,
             roomName: newRoomName,
+            tenant: getTenant(state),
             calendar: newCalendarEvents
         });
 
@@ -48,6 +56,7 @@ export default class RemoteControlServiceSubscriber {
 
         this._previousRoomName = newRoomName;
         this._previousSpotTvState = newSpotTvState;
+        this._previousTenant = newTenant;
         this._previousCalendarEvents = newCalendarEvents;
     }
 }

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -46,6 +46,7 @@ const presenceToStore = new Set([
     'screensharing',
     'screensharingType',
     'spotId',
+    'tenant',
     'tileView',
     'videoMuted',
     'view',

--- a/spot-client/src/spot-remote/app-state/selectors.js
+++ b/spot-client/src/spot-remote/app-state/selectors.js
@@ -1,3 +1,5 @@
+import { getConfiguredMeetingDomain, getSpotTVTenant } from 'common/app-state';
+
 /**
  * A selector which returns the last received join code from the external API.
  *
@@ -6,6 +8,20 @@
  */
 export function getApiReceivedJoinCode(state) {
     return state.spotRemote.apiReceivedJoinCode;
+}
+
+/**
+ * A selector which returns which Jitsi-Meet deployment domain to direct
+ * meetings to which do not specify a domain.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {string}
+ */
+export function getDefaultMeetingDomain(state) {
+    const domain = getConfiguredMeetingDomain(state);
+    const tenant = getSpotTVTenant(state);
+
+    return tenant ? `${domain}/${tenant}` : domain;
 }
 
 /**

--- a/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import {
     dialOut,
-    getDefaultMeetingDomain,
     getInMeetingStatus,
     joinAdHocMeeting,
     joinScheduledMeeting,
@@ -23,6 +22,7 @@ import {
 import { getRandomMeetingName } from 'common/utils';
 
 import {
+    getDefaultMeetingDomain,
     updateSpotRemoteSource
 } from './../../../app-state';
 import {

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -9,7 +9,8 @@ import {
     setDisplayName,
     setRemoteJoinCode,
     setJwt,
-    setReconnectState
+    setReconnectState,
+    setTenant
 } from 'common/app-state';
 import { setSpotInstanceInfo } from 'common/app-state/device-id';
 import { createAsyncActionWithStates } from 'common/async-actions';
@@ -96,11 +97,13 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
                 jwt,
                 permanentPairingCode,
                 remoteJoinCode,
-                roomProfile
+                roomProfile,
+                tenant
             } = result;
 
             dispatch(setRemoteJoinCode(remoteJoinCode));
             dispatch(setJwt(jwt));
+            dispatch(setTenant(tenant));
             dispatch(setPermanentPairingCode(permanentPairingCode));
 
             if (isBackendEnabled(getState())) {
@@ -177,14 +180,16 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
          * connection state with the backend.
          *
          * @param {Object} pairingInfo - Information necessary to establish and
-         * maintain a connection tot he server.
+         * maintain a connection to the server.
          * @param {string} pairingInfo.jwt - The latest valid jwt for
          * communicating with other backend services.
+         * @param {string} [pairingInfo.tenant] - The tenant name advertised by the backend.
          * @private
          * @returns {void}
          */
-        function onRegistrationChange({ jwt }) {
+        function onRegistrationChange({ jwt, tenant }) {
             dispatch(setJwt(jwt));
+            dispatch(setTenant(tenant));
         }
 
         /**
@@ -281,6 +286,7 @@ function createConnection(state, permanentPairingCode) {
             permanentPairingCode,
             remoteJoinCode: remoteControlServer.getRemoteJoinCode(),
             roomProfile,
+            tenant: backend ? backend.getTenant() : undefined,
             jwt: backend ? backend.getJwt() : undefined
         };
     });

--- a/spot-client/src/spot-tv/app-state/index.js
+++ b/spot-client/src/spot-tv/app-state/index.js
@@ -1,4 +1,5 @@
 export * from './actions';
+export * from './selectors';
 
 // This import enabled Spot-TV specific analytics
 import '../analytics';

--- a/spot-client/src/spot-tv/app-state/selectors.js
+++ b/spot-client/src/spot-tv/app-state/selectors.js
@@ -1,0 +1,15 @@
+import { getConfiguredMeetingDomain, getTenant } from 'common/app-state';
+
+/**
+ * A selector which returns which Jitsi-Meet deployment domain to direct
+ * meetings to which do not specify a domain.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {string}
+ */
+export function getDefaultMeetingDomain(state) {
+    const domain = getConfiguredMeetingDomain(state);
+    const tenant = getTenant(state);
+
+    return tenant ? `${domain}/${tenant}` : domain;
+}

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router-dom';
 import {
     addNotification,
     getAvatarUrl,
-    getDefaultMeetingDomain,
     getDesktopSharingFramerate,
     getDisplayName,
     getInMeetingStatus,
@@ -15,6 +14,7 @@ import {
     getPreferredCamera,
     getPreferredMic,
     getPreferredSpeaker,
+    getTenant,
     getWiredScreenshareInputLabel
 } from 'common/app-state';
 import { logger } from 'common/logger';
@@ -22,6 +22,7 @@ import { isValidMeetingName, isValidMeetingUrl } from 'common/utils';
 import { ROUTES } from 'common/routing';
 import { Loading } from 'common/ui';
 
+import { getDefaultMeetingDomain } from '../../app-state';
 import { KickedOverlay, MeetingFrame, MeetingStatus } from './../components';
 
 /**
@@ -49,7 +50,8 @@ export class Meeting extends React.Component {
         remoteControlServer: PropTypes.object,
         screenshareDevice: PropTypes.string,
         showKickedOverlay: PropTypes.bool,
-        showPasswordPrompt: PropTypes.bool
+        showPasswordPrompt: PropTypes.bool,
+        tenant: PropTypes.string
     };
 
     /**
@@ -196,8 +198,7 @@ export class Meeting extends React.Component {
         if (isValidMeetingUrl(locationParam)) {
             location = locationParam;
         } else if (isValidMeetingName(locationParam)) {
-            location
-                = `https://${this.props.defaultMeetingDomain}/${locationParam}`;
+            location = `https://${this.props.defaultMeetingDomain}/${locationParam}`;
         }
 
         return {
@@ -303,7 +304,8 @@ function mapStateToProps(state) {
         preferredCamera: getPreferredCamera(state),
         preferredMic: getPreferredMic(state),
         preferredSpeaker: getPreferredSpeaker(state),
-        screenshareDevice: getWiredScreenshareInputLabel(state)
+        screenshareDevice: getWiredScreenshareInputLabel(state),
+        tenant: getTenant(state)
     };
 }
 


### PR DESCRIPTION
If a tenant name is returned with the backend registration then it will be used to construct a URL in an ad-hoc meeting or if the 'location' query parameter is just a meeting name.