### PR TITLE
feat(feedback): show feedback button outside of meeting

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -9,6 +9,8 @@ import { ROUTES } from 'common/routing';
 import {
     ErrorBoundary,
     FatalError,
+    FeedbackOpener,
+    FeedbackOverlay,
     IdleCursorDetector,
     ModalManager,
     Notifications
@@ -62,6 +64,11 @@ export class App extends React.Component {
         this._renderSetupView = this._renderSetupView.bind(this);
         this._renderUnsupportedBrowserView
             = this._renderUnsupportedBrowserView.bind(this);
+
+        this._renderHelpView = this._renderHelpView.bind(this);
+        this._renderShareView = this._renderShareView.bind(this);
+        this._renderJoinCodeEntry = this._renderJoinCodeEntry.bind(this);
+        this._renderRemoteControlView = this._renderRemoteControlView.bind(this);
     }
 
     /**
@@ -165,18 +172,19 @@ export class App extends React.Component {
                                  */
                             }
                             <Route
-                                component = { Help }
-                                path = { ROUTES.HELP } />
+                                path = { ROUTES.HELP }
+                                render = { this._renderHelpView } />
                             <Route
-                                component = { ShareView }
-                                path = { ROUTES.SHARE } />
+                                path = { ROUTES.SHARE }
+                                render = { this._renderShareView } />
                             <Route
-                                component = { RemoteControl }
-                                path = { ROUTES.REMOTE_CONTROL } />
-                            <Route component = { JoinCodeEntry } />
+                                path = { ROUTES.REMOTE_CONTROL }
+                                render = { this._renderRemoteControlView } />
+                            <Route render = { this._renderJoinCodeEntry } />
                         </Switch>
                     </div>
                     <ModalManager />
+                    <FeedbackOverlay />
                 </IdleCursorDetector>
             </ErrorBoundary>
         );
@@ -246,6 +254,16 @@ export class App extends React.Component {
     }
 
     /**
+     * Returns the Spot-Remote help view.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderHelpView() {
+        return this._renderSpotRemoteViewWithHelp(Help);
+    }
+
+    /**
      * Returns the Spot TV home (calendar) view.
      *
      * @private
@@ -253,6 +271,16 @@ export class App extends React.Component {
      */
     _renderHomeView() {
         return this._renderSpotViewWithRemoteControl(Home, 'home');
+    }
+
+    /**
+     * Returns the Spot-Remote join code entry view.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderJoinCodeEntry() {
+        return this._renderSpotRemoteViewWithHelp(JoinCodeEntry);
     }
 
     /**
@@ -276,6 +304,16 @@ export class App extends React.Component {
     }
 
     /**
+     * Returns the Spot-Remote remote control view.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderRemoteControlView() {
+        return this._renderSpotRemoteViewWithHelp(RemoteControl);
+    }
+
+    /**
      * Returns the Spot TV setup view.
      *
      * @private
@@ -285,7 +323,33 @@ export class App extends React.Component {
         return (
             <SpotView name = { 'setup' }>
                 <Setup />
+                <FeedbackOpener />
             </SpotView>
+        );
+    }
+
+    /**
+     * Returns the Spot-Remote share-only mode view.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderShareView() {
+        return this._renderSpotRemoteViewWithHelp(ShareView);
+    }
+
+    /**
+     * Helper for displaying a consistent view across Spot-Remote views.
+     *
+     * @param {Component} View - The Spot-Remove view component to show.
+     * @returns {ReactElement}
+     */
+    _renderSpotRemoteViewWithHelp(View) {
+        return (
+            <div>
+                <View />
+                <FeedbackOpener />
+            </div>
         );
     }
 

--- a/spot-client/src/common/app-state/feedback/actionTypes.js
+++ b/spot-client/src/common/app-state/feedback/actionTypes.js
@@ -1,0 +1,5 @@
+export const FEEDBACK_HIDE = 'FEEDBACK_HIDE';
+
+export const FEEDBACK_SHOW = 'FEEDBACK_SHOW';
+
+export const SUBMIT_FEEDBACK = 'SUBMIT_FEEDBACK';

--- a/spot-client/src/common/app-state/feedback/actions.js
+++ b/spot-client/src/common/app-state/feedback/actions.js
@@ -1,0 +1,57 @@
+import {
+    FEEDBACK_HIDE,
+    FEEDBACK_SHOW,
+    SUBMIT_FEEDBACK
+} from './actionTypes';
+
+/**
+ * Signals app feedback entry not to be shown.
+ *
+ * @returns {Object}
+ */
+export function hideFeedback() {
+    return {
+        type: FEEDBACK_HIDE
+    };
+}
+
+/**
+ * Signals app feedback entry to be shown.
+ *
+ * @returns {Object}
+ */
+export function showFeedback() {
+    return {
+        type: FEEDBACK_SHOW
+    };
+}
+
+/**
+ * The action dispatched when user submits the feedback or if idle timeout occurs (timeout === true)
+ * or if the user explicitly decides to not submit the feedback (skip === true and score === -1).
+ *
+ * @param {string} message - The feedback message as entered by the user.
+ * @param {boolean} requestedMoreInfo - Whether the UI has explicitly asked user for more details
+ * (which will be put into the message filed).
+ * @param {number} score - The score/stars submitted by the user (from 1 to 5 and -1 no selection).
+ * @param {boolean} timeout - Flag tells whether the action was triggered due to inactivity timeout
+ * (the user left the feedback dialog open for too long without taking any action).
+ * @returns {{
+ *     type: SUBMIT_FEEDBACK,
+ *     message: string,
+ *     requestedMoreInfo: boolean,
+ *     score: number,
+ *     skip: boolean,
+ *     timeout: boolean
+ * }}
+ */
+export function submitFeedback({ message, requestedMoreInfo, score, timeout }) {
+    return {
+        type: SUBMIT_FEEDBACK,
+        message,
+        requestedMoreInfo,
+        score,
+        skip: score === -1,
+        timeout
+    };
+}

--- a/spot-client/src/common/app-state/feedback/reducer.js
+++ b/spot-client/src/common/app-state/feedback/reducer.js
@@ -1,0 +1,35 @@
+import { FEEDBACK_HIDE, FEEDBACK_SHOW } from './actionTypes';
+
+const DEFAULT_STATE = {
+    show: false
+};
+
+/**
+ * A {@code Reducer} to update the current Redux state for the 'feedback'
+ * feature. The 'feedback' feature stores whether or not the app feedback
+ * entry overlay should be displayed.
+ *
+ * @param {Object} state - The current Redux state for the 'feedback' feature.
+ * @param {Object} action - The Redux state update payload.
+ * @returns {Object}
+ */
+const feedback = (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+    case FEEDBACK_HIDE:
+        return {
+            ...state,
+            show: false
+        };
+
+    case FEEDBACK_SHOW:
+        return {
+            ...state,
+            show: true
+        };
+
+    default:
+        return state;
+    }
+};
+
+export default feedback;

--- a/spot-client/src/common/app-state/feedback/selectors.js
+++ b/spot-client/src/common/app-state/feedback/selectors.js
@@ -1,0 +1,9 @@
+/**
+ * Returns whether or not the app feedback entry should be visible.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function isAppFeedbackShown(state) {
+    return state.feedback.show;
+}

--- a/spot-client/src/common/app-state/index.js
+++ b/spot-client/src/common/app-state/index.js
@@ -2,6 +2,7 @@ import bootstrap from './bootstrap/reducer';
 import calendars from './calendars/reducer';
 import config from './config/reducer';
 import deviceId from './device-id/reducer';
+import feedback from './feedback/reducer';
 import modal from './modal/reducer';
 import notifications from './notifications/reducer';
 import pairedRemotes from './paired-remotes/reducer';
@@ -15,6 +16,7 @@ const reducers = {
     calendars,
     config,
     deviceId,
+    feedback,
     modal,
     notifications,
     pairedRemotes,
@@ -30,6 +32,7 @@ export * from './api';
 export * from './bootstrap';
 export * from './calendars/actions';
 export * from './device-id';
+export * from './feedback/actions';
 export * from './modal/actions';
 export * from './notifications/actions';
 export * from './paired-remotes/actions';
@@ -41,6 +44,7 @@ export * from './spot-tv/action-types';
 export * from './wired-screenshare/actions';
 
 export * from './calendars/action-types';
+export * from './feedback/actionTypes';
 export * from './remote-control-service/actionTypes';
 
 export * from './calendars/constants';
@@ -48,6 +52,7 @@ export * from './remote-control-service/constants';
 
 export * from './calendars/selectors';
 export * from './config/selectors';
+export * from './feedback/selectors';
 export * from './notifications/selectors';
 export * from './paired-remotes/selectors';
 export * from './remote-control-service/selectors';

--- a/spot-client/src/common/css/_idle-cursor.scss
+++ b/spot-client/src/common/css/_idle-cursor.scss
@@ -12,4 +12,8 @@
     .meetingMouseHider {
         pointer-events: all;
     }
+
+    .home-feedback {
+        display: none;
+    }
 }

--- a/spot-client/src/common/css/page-layouts/_feedback-view.scss
+++ b/spot-client/src/common/css/page-layouts/_feedback-view.scss
@@ -1,3 +1,18 @@
+.feedback-opener {
+    bottom: 5px;
+    cursor: pointer;
+    position: fixed;
+    right: 5px;
+}
+
+.app-feedback-overlay {
+    justify-content: center;
+
+    .message-help {
+        display: none
+    }
+}
+
 .feedback-view {
     @include spot-remote-view-layout;
 

--- a/spot-client/src/common/css/page-layouts/_feedback-view.scss
+++ b/spot-client/src/common/css/page-layouts/_feedback-view.scss
@@ -6,7 +6,9 @@
 }
 
 .app-feedback-overlay {
-    justify-content: center;
+    .feedback-form {
+        margin-top: 5%
+    }
 
     .message-help {
         display: none

--- a/spot-client/src/common/css/page-layouts/_join-code-view.scss
+++ b/spot-client/src/common/css/page-layouts/_join-code-view.scss
@@ -68,7 +68,7 @@
     .help-icon {
         bottom: 5px;
         position: absolute;
-        right: 5px;
+        left: 5px;
 
         @media #{$mq-xxsmall} {
             font-size: 3.5em;

--- a/spot-client/src/common/icons/index.js
+++ b/spot-client/src/common/icons/index.js
@@ -6,6 +6,7 @@ export {
     CallEnd,
     ExpandLess,
     ExpandMore,
+    Feedback,
     Fullscreen,
     FullscreenExit,
     GridOff,

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -359,8 +359,10 @@ export class RemoteControlClient extends BaseRemoteControlService {
      * @returns {Promise} Resolves if the command has been acknowledged.
      */
     submitFeedback(feedback) {
-        return this.xmppConnection.sendCommand(
-            this._getSpotId(), COMMANDS.SUBMIT_FEEDBACK, feedback);
+        return this.xmppConnection
+            ? this.xmppConnection.sendCommand(
+                this._getSpotId(), COMMANDS.SUBMIT_FEEDBACK, feedback)
+            : Promise.reject('No server connection for feedback');
     }
 
     /**

--- a/spot-client/src/common/ui/components/feedback/FeedbackOpener.js
+++ b/spot-client/src/common/ui/components/feedback/FeedbackOpener.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Feedback } from 'common/icons';
+import { getCurrentView, showFeedback } from 'common/app-state';
+
+/**
+ * Functional component for showing a button that opens the feedback overlay.
+ *
+ * @param {Object} props - The read-only properties with which the new
+ * instance is to be initialized.
+ * @returns {ReactElement}
+ */
+export function FeedbackOpener(props) {
+    if (!props.show) {
+        return null;
+    }
+
+    return (
+        <div className = 'feedback-opener'>
+            <Feedback
+                className = 'feedback-opener-button'
+                onClick = { props.onClick } />
+        </div>
+    );
+}
+
+FeedbackOpener.propTypes = {
+    onClick: PropTypes.func,
+    show: PropTypes.bool
+};
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code FeedbackOpener}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        show: getCurrentView(state) !== 'feedback'
+    };
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        onClick() {
+            dispatch(showFeedback());
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FeedbackOpener);

--- a/spot-client/src/common/ui/components/feedback/FeedbackOverlay.js
+++ b/spot-client/src/common/ui/components/feedback/FeedbackOverlay.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import {
+    hideFeedback,
+    isAppFeedbackShown,
+    submitFeedback
+} from 'common/app-state';
+
+import { FeedbackForm } from './FeedbackForm';
+
+/**
+ * A functional component for showing app feedback entry while covering the
+ * application.
+ *
+ * @param {Object} props - The read-only properties with which the new
+ * instance is to be initialized.
+ * @returns {ReactElement}
+ */
+export function FeedbackOverlay(props) {
+    if (!props.displayFeedback) {
+        return null;
+    }
+
+    return (
+        <div className = 'feedback-view status-overlay app-feedback-overlay'>
+            <div className = 'feedback-form'>
+                <FeedbackForm
+                    commentOnly = { true }
+                    disableInactivityTimer = { true }
+                    onSkip = { props.onCancelFeedback }
+                    onSubmitFeedback = { props.onSubmitFeedback } />
+            </div>
+        </div>
+    );
+}
+
+FeedbackOverlay.propTypes = {
+    displayFeedback: PropTypes.bool,
+    onCancelFeedback: PropTypes.func,
+    onSubmitFeedback: PropTypes.func
+};
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code AutoReload}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        displayFeedback: isAppFeedbackShown(state)
+    };
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        onCancelFeedback() {
+            dispatch(hideFeedback());
+        },
+
+        onSubmitFeedback(feedback) {
+            dispatch(submitFeedback(feedback));
+            dispatch(hideFeedback());
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FeedbackOverlay);

--- a/spot-client/src/common/ui/components/feedback/index.js
+++ b/spot-client/src/common/ui/components/feedback/index.js
@@ -1,0 +1,3 @@
+export { default as FeedbackForm } from './FeedbackForm';
+export { default as FeedbackOpener } from './FeedbackOpener';
+export { default as FeedbackOverlay } from './FeedbackOverlay';

--- a/spot-client/src/common/ui/components/index.js
+++ b/spot-client/src/common/ui/components/index.js
@@ -3,6 +3,7 @@ export * from './clock';
 export * from './code-input';
 export * from './countdown';
 export * from './error-boundary';
+export * from './feedback';
 export * from './idle-cursor-detector';
 export * from './input';
 export * from './loading-icon';

--- a/spot-client/src/spot-remote/analytics/middleware.js
+++ b/spot-client/src/spot-remote/analytics/middleware.js
@@ -1,7 +1,6 @@
 import {
     analytics,
     eventStatusSuffixes,
-    feedbackEvents,
     inCallEvents,
     joinCodeEvents,
     meetingJoinEvents
@@ -27,7 +26,6 @@ import {
     SPOT_REMOTE_JOIN_CODE_VALID,
     SPOT_REMOTE_WILL_VALIDATE_JOIN_CODE
 } from './../app-state';
-import { SUBMIT_FEEDBACK } from './../remote-control';
 import { shareModeEvents } from '../../common/analytics';
 
 const requestStateToEventSuffix = {
@@ -118,10 +116,7 @@ MiddlewareRegistry.register(() => next => action => {
 
         break;
     }
-    case SUBMIT_FEEDBACK: {
-        _submitFeedback(action);
-        break;
-    }
+
     case SPOT_REMOTE_WILL_VALIDATE_JOIN_CODE: {
         if (action.shareMode) {
             analytics.updateProperty('share-mode', true);
@@ -156,29 +151,4 @@ MiddlewareRegistry.register(() => next => action => {
  */
 function isPendingAsyncAction(action) {
     return action.requestState === asyncActionRequestStates.PENDING;
-}
-
-/**
- * Sends analytics events for the {@link SUBMIT_FEEDBACK} action.
- *
- * @param {Object} action - The {@link SUBMIT_FEEDBACK} action.
- * @private
- * @returns {void}
- */
-function _submitFeedback(action) {
-    const {
-        message,
-        requestedMoreInfo,
-        score,
-        skip,
-        timeout
-    } = action;
-
-    analytics.log(
-        skip ? feedbackEvents.SKIP : feedbackEvents.SUBMIT, {
-            message,
-            requestedMoreInfo,
-            score,
-            timeout
-        });
 }

--- a/spot-client/src/spot-remote/remote-control/action-types.js
+++ b/spot-client/src/spot-remote/remote-control/action-types.js
@@ -4,10 +4,3 @@
  * @type {string}
  */
 export const ADJUST_VOLUME = 'ADJUST_VOLUME';
-
-/**
- * The constant type for the submit feedback action. See action's method description for more info.
- *
- * @type {string}
- */
-export const SUBMIT_FEEDBACK = 'SUBMIT_FEEDBACK';

--- a/spot-client/src/spot-remote/remote-control/actions.js
+++ b/spot-client/src/spot-remote/remote-control/actions.js
@@ -1,4 +1,4 @@
-import { ADJUST_VOLUME, SUBMIT_FEEDBACK } from './action-types';
+import { ADJUST_VOLUME } from './action-types';
 
 /**
  * Action to be dispatched when the volume of the spot instance should be adjusted up or down. This
@@ -14,35 +14,5 @@ export function adjustVolume(direction) {
     return {
         type: ADJUST_VOLUME,
         direction
-    };
-}
-
-/**
- * The action dispatched when user submits the feedback or if idle timeout occurs (timeout === true)
- * or if the user explicitly decides to not submit the feedback (skip === true and score === -1).
- *
- * @param {string} message - The feedback message as entered by the user.
- * @param {boolean} requestedMoreInfo - Whether the UI has explicitly asked user for more details
- * (which will be put into the message filed).
- * @param {number} score - The score/stars submitted by the user (from 1 to 5 and -1 no selection).
- * @param {boolean} timeout - Flag tells whether the action was triggered due to inactivity timeout
- * (the user left the feedback dialog open for too long without taking any action).
- * @returns {{
- *     type: SUBMIT_FEEDBACK,
- *     message: string,
- *     requestedMoreInfo: boolean,
- *     score: number,
- *     skip: boolean,
- *     timeout: boolean
- * }}
- */
-export function submitFeedback({ message, requestedMoreInfo, score, timeout }) {
-    return {
-        type: SUBMIT_FEEDBACK,
-        message,
-        requestedMoreInfo,
-        score,
-        skip: score === -1,
-        timeout
     };
 }

--- a/spot-client/src/spot-remote/remote-control/middleware.js
+++ b/spot-client/src/spot-remote/remote-control/middleware.js
@@ -1,9 +1,10 @@
+import { SUBMIT_FEEDBACK, isSpot } from 'common/app-state';
 import { MiddlewareRegistry } from 'common/redux';
 import { remoteControlClient } from 'common/remote-control';
 
-import { ADJUST_VOLUME, SUBMIT_FEEDBACK } from './action-types';
+import { ADJUST_VOLUME } from './action-types';
 
-MiddlewareRegistry.register(() => next => action => {
+MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
@@ -11,10 +12,12 @@ MiddlewareRegistry.register(() => next => action => {
         remoteControlClient.adjustVolume(action.direction);
         break;
     case SUBMIT_FEEDBACK: {
-        remoteControlClient.submitFeedback({
-            score: action.score,
-            message: action.message
-        });
+        if (!isSpot(store.getState())) {
+            remoteControlClient.submitFeedback({
+                score: action.score,
+                message: action.message
+            });
+        }
         break;
     }
     }

--- a/spot-client/src/spot-remote/ui/components/remote-control-menu/index.js
+++ b/spot-client/src/spot-remote/ui/components/remote-control-menu/index.js
@@ -1,4 +1,3 @@
-export { default as FeedbackForm } from './feedback-form';
 export { default as MenuButton } from './menu-button';
 export { default as TileViewButton } from './TileViewButton';
 export { default as VolumeButton } from './volume-button';

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import {
     addNotification,
@@ -399,4 +400,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(JoinCodeEntry);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(JoinCodeEntry));

--- a/spot-client/src/spot-remote/ui/views/remote-views/feedback.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/feedback.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { Clock, RoomName } from 'common/ui';
-
-import { FeedbackForm } from './../../components';
+import { Clock, FeedbackForm, RoomName } from 'common/ui';
 
 /**
  * A view for Spot-Remote that displays a feedback form for a meeting that has

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -84,6 +84,7 @@ export class MeetingFrame extends React.Component {
         bindAll(this, [
             '_onAudioMuteChange',
             '_onFeedbackPromptDisplayed',
+            '_onFeedbackSubmitted',
             '_onFilmstripDisplayChanged',
             '_onMeetingCommand',
             '_onMeetingJoined',
@@ -162,7 +163,7 @@ export class MeetingFrame extends React.Component {
         this._jitsiApi.addListener(
             'cameraError', this._onReportDeviceError);
         this._jitsiApi.addListener(
-            'feedbackSubmitted', this.props.onMeetingLeave);
+            'feedbackSubmitted', this._onFeedbackSubmitted);
         this._jitsiApi.addListener(
             'feedbackPromptDisplayed', this._onFeedbackPromptDisplayed);
         this._jitsiApi.addListener(
@@ -312,6 +313,20 @@ export class MeetingFrame extends React.Component {
         this._isAudioMuted = muted;
 
         this.props.updateSpotTvState({ audioMuted: muted });
+    }
+
+    /**
+     * Callback invoked when feedback has been sent successfully through the
+     * iFrame api. Will invoke a callback to signify meeting leave if the
+     * iFrame is showing feedback, as it would at the end of a call.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onFeedbackSubmitted() {
+        if (this.state.feedbackDisplayed) {
+            this.props.onMeetingLeave();
+        }
     }
 
     /**

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -15,7 +15,7 @@ import { AutoUpdateChecker } from 'common/auto-update';
 import { getPermanentPairingCode, isBackendEnabled } from 'common/backend';
 import { COMMANDS, SERVICE_UPDATES } from 'common/remote-control';
 import { ROUTES } from 'common/routing';
-import { Clock, LoadingIcon, ScheduledMeetings } from 'common/ui';
+import { Clock, LoadingIcon, ScheduledMeetings, FeedbackOpener } from 'common/ui';
 import { getRandomMeetingName } from 'common/utils';
 
 import { updateSpotTVSource } from '../../app-state';
@@ -126,6 +126,9 @@ export class Home extends React.Component {
                 <div className = 'admin-toolbar'>
                     <FullscreenToggle />
                     <SettingsButton />
+                </div>
+                <div className = 'home-feedback'>
+                    <FeedbackOpener />
                 </div>
             </WiredScreenshareChangeListener>
         );


### PR DESCRIPTION
feat(feedback): show feedback button outside of meeting

- Wrap all Spot-Remote route displaying to show the
  global feedback button.
- Create a global feedback button for Spot-Remote and
  Spot-TV (setup only) to use.
- Move feedback analytics to shared middleware as
  now both TV and Remote can send feedback.
- New redux state for controlling app feedback display.
  Call feedback display has not been changed.
- Move Feedback components into common and modify
   so the star rating can be skipped automatically.

![Screen Shot 2019-08-28 at 3 10 04 PM](https://user-images.githubusercontent.com/1243084/63896093-f1801280-c9a5-11e9-8f08-a7aec9ba3e93.png)
![Screen Shot 2019-08-28 at 3 01 00 PM](https://user-images.githubusercontent.com/1243084/63896096-f3e26c80-c9a5-11e9-9934-bf4e1468cf78.png)
![Screen Shot 2019-08-28 at 3 00 47 PM](https://user-images.githubusercontent.com/1243084/63896105-f8a72080-c9a5-11e9-80ed-1edb95a78a11.png)