### PR TITLE
feat(dtmf): add dial pad in call

### DIFF
--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -228,7 +228,8 @@ export default {
     TEMPORARY_FEATURE_FLAGS: {
         /**
          * Allow DTMF support to be hidden while waiting for the jitsi-meet side
-         * to be deployed and dial tone playing fixed.
+         * to be deployed and for a fix to be created for touch tones not
+         * being played over dial out.
          *
          * @type {boolean}
          */

--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -220,6 +220,22 @@ export default {
     },
 
     /**
+     * Configurations for services or features in flight so their behavior can
+     * be altered through config changes instead of code changes. The flags are
+     * intended to be removed once the desired behavior is finalized and ready
+     * to use.
+     */
+    TEMPORARY_FEATURE_FLAGS: {
+        /**
+         * Allow DTMF support to be hidden while waiting for the jitsi-meet side
+         * to be deployed and dial tone playing fixed.
+         *
+         * @type {boolean}
+         */
+        SHOW_DTMF: false
+    },
+
+    /**
      * Configuration object for loading the ultrasound library.
      */
     ULTRASOUND: {

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -237,3 +237,14 @@ export function getUpdateStartHour(state) {
 export function getUpdateEndHour(state) {
     return state.config.UPDATES.END_HOUR;
 }
+
+/**
+ * A selector which returns whether or not the feature flag for showing DTMF
+ * support is enabled or not.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function shouldShowDtmf(state) {
+    return state.config.TEMPORARY_FEATURE_FLAGS.SHOW_DTMF;
+}

--- a/spot-client/src/common/app-state/remote-control-service/actions.js
+++ b/spot-client/src/common/app-state/remote-control-service/actions.js
@@ -143,13 +143,13 @@ export function hangUp(skipFeedback) {
 }
 
 /**
- * Sends a command to Spot-TV to play the passed in dial tones.
+ * Sends a command to Spot-TV to play the passed in touch tones.
  *
  * @param {string} tones - The tones to play.
  * @returns {Function}
  */
-export function sendDialTones(tones) {
-    return () => remoteControlClient.sendDialTones(tones);
+export function sendTouchTones(tones) {
+    return () => remoteControlClient.sendTouchTones(tones);
 }
 
 /**

--- a/spot-client/src/common/app-state/remote-control-service/actions.js
+++ b/spot-client/src/common/app-state/remote-control-service/actions.js
@@ -143,6 +143,16 @@ export function hangUp(skipFeedback) {
 }
 
 /**
+ * Sends a command to Spot-TV to play the passed in dial tones.
+ *
+ * @param {string} tones - The tones to play.
+ * @returns {Function}
+ */
+export function sendDialTones(tones) {
+    return () => remoteControlClient.sendDialTones(tones);
+}
+
+/**
  * Sends a command to Spot-TV to change its audio mute setting.
  *
  * @param {boolean} mute - Whether to audio mute or audio unmute.

--- a/spot-client/src/common/icons/index.js
+++ b/spot-client/src/common/icons/index.js
@@ -4,6 +4,7 @@ export {
     CalendarToday,
     Call,
     CallEnd,
+    Dialpad,
     ExpandLess,
     ExpandMore,
     Feedback,

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -26,9 +26,9 @@ export const COMMANDS = {
     HANG_UP: 'hangup',
 
     /**
-     * Play dial tones into the meeting for an IVR to listen to.
+     * Play touch tones into the meeting for an IVR to listen to.
      */
-    SEND_DIAL_TONES: 'sendDialTones',
+    SEND_TOUCH_TONES: 'sendTouchTones',
 
     /**
      * Set audio mute on or off.

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -26,6 +26,11 @@ export const COMMANDS = {
     HANG_UP: 'hangup',
 
     /**
+     * Play dial tones into the meeting for an IVR to listen to.
+     */
+    SEND_DIAL_TONES: 'sendDialTones',
+
+    /**
      * Set audio mute on or off.
      */
     SET_AUDIO_MUTE: 'setAudioMute',

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -245,6 +245,23 @@ export class RemoteControlClient extends BaseRemoteControlService {
     }
 
     /**
+     * Requests a {@code RemoteControlServer} to send dial tones into a meeting.
+     * This is intended for interaction with an IVR requesting additional
+     * conference details for dialing in.
+     *
+     * @param {string} tones - The dial pad numbers to be submitted for playing
+     * tones.
+     * @returns {Promise} Resolves if the command has been acknowledged.
+     */
+    sendDialTones(tones) {
+        return this.xmppConnection.sendCommand(
+            this._getSpotId(),
+            COMMANDS.SEND_DIAL_TONES,
+            { tones }
+        );
+    }
+
+    /**
      * Requests a {@code RemoteControlServer} to change its audio mute status.
      *
      * @param {boolean} mute - Whether or not Spot should be audio muted.

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -245,7 +245,7 @@ export class RemoteControlClient extends BaseRemoteControlService {
     }
 
     /**
-     * Requests a {@code RemoteControlServer} to send dial tones into a meeting.
+     * Requests a {@code RemoteControlServer} to send touch tones into a meeting.
      * This is intended for interaction with an IVR requesting additional
      * conference details for dialing in.
      *
@@ -253,10 +253,10 @@ export class RemoteControlClient extends BaseRemoteControlService {
      * tones.
      * @returns {Promise} Resolves if the command has been acknowledged.
      */
-    sendDialTones(tones) {
+    sendTouchTones(tones) {
         return this.xmppConnection.sendCommand(
             this._getSpotId(),
-            COMMANDS.SEND_DIAL_TONES,
+            COMMANDS.SEND_TOUCH_TONES,
             { tones }
         );
     }

--- a/spot-client/src/spot-remote/ui/components/dtmf/DTMFButton.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/DTMFButton.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Dialpad } from 'common/icons';
+
+import { NavButton } from '../nav';
+
+/**
+ * A component for accessing the DTMF dial pad.
+ *
+ * @extends React.Component
+ */
+export default class DTMFButton extends React.Component {
+    static propTypes = {
+        onClick: PropTypes.func
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     */
+    render() {
+        return (
+            <NavButton
+                label = 'Dial Tones'
+                onClick = { this.props.onClick }>
+                <Dialpad />
+            </NavButton>
+        );
+    }
+}

--- a/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { sendDialTones } from 'common/app-state';
+import { sendTouchTones } from 'common/app-state';
 import { Modal } from 'common/ui';
 
 import { StatelessDialPad } from './../dial-pad';
 
 /**
- * Displays a dial pad for requesting dial tones to be played.
+ * Displays a dial pad for requesting touch tones to be played.
  *
  * @extends React.Component
  */
@@ -92,13 +92,14 @@ export class DTMFModal extends React.Component {
 function mapDispatchToProps(dispatch) {
     return {
         /**
-         * Plays the passed in string as dial tones.
+         * Plays the passed in string as touch tones.
          *
-         * @param {string} tones - The dial pad characters to play as dial tones.
+         * @param {string} tones - The dial pad characters to play as touch
+         * tones.
          * @returns {void}
          */
         onSendTones(tones) {
-            dispatch(sendDialTones(tones));
+            dispatch(sendTouchTones(tones));
         }
     };
 }

--- a/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
@@ -1,0 +1,106 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { sendDialTones } from 'common/app-state';
+import { Modal } from 'common/ui';
+
+import { StatelessDialPad } from './../dial-pad';
+
+/**
+ * Displays a dial pad for requesting dial tones to be played.
+ *
+ * @extends React.Component
+ */
+export class DTMFModal extends React.Component {
+    static propTypes = {
+        onClose: PropTypes.func,
+        onSendTones: PropTypes.func
+    };
+
+    /**
+     * Initializes a new {@code DTMFModal} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            value: ''
+        };
+
+        this._onChange = this._onChange.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <Modal onClose = { this.props.onClose }>
+                <div className = 'dtmf-modal'>
+                    <StatelessDialPad
+                        buttonText = 'Send'
+                        onChange = { this._onChange }
+                        onSubmit = { this._onSubmit }
+                        placeholderText = 'Enter Numbers'
+                        value = { this.state.value } />
+                </div>
+            </Modal>
+        );
+    }
+
+    /**
+     * Callback invoked to update the known entered number in the dial pad.
+     *
+     * @param {string} value - The new entered number.
+     * @private
+     * @returns {void}
+     */
+    _onChange(value) {
+        this.setState({ value });
+    }
+
+    /**
+     * Requests the entered number be played as tones.
+     *
+     * @param {*} _ - Meeting names details. Not used for the purpose of
+     * sending tones.
+     * @param {string} tones - The number to be played.
+     * @private
+     * @returns {void}
+     */
+    _onSubmit(_, tones) {
+        this.props.onSendTones(tones);
+        this.setState({ value: '' });
+    }
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        /**
+         * Plays the passed in string as dial tones.
+         *
+         * @param {string} tones - The dial pad characters to play as dial tones.
+         * @returns {void}
+         */
+        onSendTones(tones) {
+            dispatch(sendDialTones(tones));
+        }
+    };
+}
+
+export default connect(undefined, mapDispatchToProps)(DTMFModal);

--- a/spot-client/src/spot-remote/ui/components/dtmf/index.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/index.js
@@ -1,0 +1,2 @@
+export { default as DTMFButton } from './DTMFButton';
+export { default as DTMFModal } from './DTMFModal';

--- a/spot-client/src/spot-remote/ui/components/index.js
+++ b/spot-client/src/spot-remote/ui/components/index.js
@@ -1,4 +1,5 @@
 export * from './dial-pad';
+export * from './dtmf';
 export * from './electron-desktop-picker';
 export * from './kicked-notice';
 export * from './meeting-name-entry';

--- a/spot-client/src/spot-remote/ui/components/more/MoreModal.js
+++ b/spot-client/src/spot-remote/ui/components/more/MoreModal.js
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { hideModal, isVolumeControlSupported } from 'common/app-state';
+import {
+    hideModal,
+    isVolumeControlSupported,
+    shouldShowDtmf
+} from 'common/app-state';
 
 import { VolumeUp } from 'common/icons';
 import { Modal } from 'common/ui';
@@ -19,6 +23,7 @@ import VolumeModal from './VolumeModal';
 export class MoreModal extends React.Component {
     static propTypes = {
         onClose: PropTypes.func,
+        supportsDtmf: PropTypes.bool,
         supportsVolumeControl: PropTypes.bool
     };
 
@@ -59,7 +64,10 @@ export class MoreModal extends React.Component {
                 qaId = 'more-modal'>
                 <div className = 'more-modal'>
                     <TileViewButton />
-                    <DTMFButton onClick = { this._onShowDtmfModal } />
+                    {
+                        this.props.supportsDtmf
+                            && <DTMFButton onClick = { this._onShowDtmfModal } />
+                    }
                     {
                         this.props.supportsVolumeControl && (
                             <NavButton
@@ -114,6 +122,7 @@ export class MoreModal extends React.Component {
  */
 function mapStateToProps(state) {
     return {
+        supportsDtmf: shouldShowDtmf(state),
         supportsVolumeControl: isVolumeControlSupported(state)
     };
 }

--- a/spot-client/src/spot-remote/ui/components/more/MoreModal.js
+++ b/spot-client/src/spot-remote/ui/components/more/MoreModal.js
@@ -7,6 +7,7 @@ import { hideModal, isVolumeControlSupported } from 'common/app-state';
 import { VolumeUp } from 'common/icons';
 import { Modal } from 'common/ui';
 
+import { DTMFButton, DTMFModal } from './../dtmf';
 import { TileViewButton } from './../remote-control-menu';
 import { NavButton } from './../nav';
 
@@ -30,10 +31,12 @@ export class MoreModal extends React.Component {
         super(props);
 
         this.state = {
-            showVolumeModal: false
+            modalToDisplay: 'more'
         };
 
-        this._onToggleVolumeModal = this._onToggleVolumeModal.bind(this);
+        this._onShowMoreMenu = this._onShowMoreMenu.bind(this);
+        this._onShowDtmfModal = this._onShowDtmfModal.bind(this);
+        this._onShowVolumeMenu = this._onShowVolumeMenu.bind(this);
     }
 
     /**
@@ -43,11 +46,11 @@ export class MoreModal extends React.Component {
      * @returns {ReactElement}
      */
     render() {
-        if (this.state.showVolumeModal) {
-            return (
-                <VolumeModal
-                    onClose = { this._onToggleVolumeModal } />
-            );
+        switch (this.state.modalToDisplay) {
+        case 'volume':
+            return <VolumeModal onClose = { this._onShowMoreMenu } />;
+        case 'dtmf':
+            return <DTMFModal onClose = { this._onShowMoreMenu } />;
         }
 
         return (
@@ -56,11 +59,12 @@ export class MoreModal extends React.Component {
                 qaId = 'more-modal'>
                 <div className = 'more-modal'>
                     <TileViewButton />
+                    <DTMFButton onClick = { this._onShowDtmfModal } />
                     {
                         this.props.supportsVolumeControl && (
                             <NavButton
                                 label = 'Volume control'
-                                onClick = { this._onToggleVolumeModal }
+                                onClick = { this._onShowVolumeMenu }
                                 qaId = 'volume'>
                                 <VolumeUp />
                             </NavButton>
@@ -72,14 +76,31 @@ export class MoreModal extends React.Component {
     }
 
     /**
-     * Toggles the volume modal.
+     * Displays the DTMF modal.
      *
      * @returns {void}
      */
-    _onToggleVolumeModal() {
-        this.setState({
-            showVolumeModal: !this.state.showVolumeModal
-        });
+    _onShowDtmfModal() {
+        this.setState({ modalToDisplay: 'dtmf' });
+    }
+
+    /**
+     * Displays the default modal state, which has buttons to all features
+     * within {@code MoreModal}.
+     *
+     * @returns {void}
+     */
+    _onShowMoreMenu() {
+        this.setState({ modalToDisplay: 'more' });
+    }
+
+    /**
+     * Displays the volume modal.
+     *
+     * @returns {void}
+     */
+    _onShowVolumeMenu() {
+        this.setState({ modalToDisplay: 'volume' });
     }
 }
 

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -6,8 +6,7 @@ import {
     forceStopWirelessScreenshare,
     getInMeetingStatus,
     hangUp,
-    hideModal,
-    isVolumeControlSupported
+    hideModal
 } from 'common/app-state';
 import { CallEnd } from 'common/icons';
 import { LoadingIcon, Modal, RoomName } from 'common/ui';
@@ -24,7 +23,6 @@ import {
     NavContainer,
     PasswordPrompt,
     ScreenshareButton,
-    TileViewButton,
     VideoMuteButton
 } from '../../components';
 
@@ -43,8 +41,6 @@ export class InCall extends React.Component {
         onHangUp: PropTypes.func,
         onShowScreenshareModal: PropTypes.func,
         onSubmitPassword: PropTypes.func,
-        screensharingType: PropTypes.string,
-        showMoreButton: PropTypes.bool,
         showPasswordPrompt: PropTypes.bool
     };
 
@@ -71,7 +67,6 @@ export class InCall extends React.Component {
         const {
             inMeeting,
             kicked,
-            showMoreButton,
             showPasswordPrompt
         } = this.props;
 
@@ -109,7 +104,7 @@ export class InCall extends React.Component {
                     <AudioMuteButton />
                     <VideoMuteButton />
                     <ScreenshareButton />
-                    { showMoreButton ? <MoreButton /> : <TileViewButton /> }
+                    <MoreButton />
                     <NavButton
                         className = 'hangup'
                         label = 'Leave'
@@ -155,15 +150,12 @@ function mapStateToProps(state) {
     const {
         inMeeting,
         kicked,
-        needPassword,
-        screensharingType
+        needPassword
     } = getInMeetingStatus(state);
 
     return {
         inMeeting,
         kicked,
-        screensharingType,
-        showMoreButton: isVolumeControlSupported(state),
         showPasswordPrompt: needPassword
     };
 }

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -6,7 +6,9 @@ import {
     forceStopWirelessScreenshare,
     getInMeetingStatus,
     hangUp,
-    hideModal
+    hideModal,
+    isVolumeControlSupported,
+    shouldShowDtmf
 } from 'common/app-state';
 import { CallEnd } from 'common/icons';
 import { LoadingIcon, Modal, RoomName } from 'common/ui';
@@ -23,6 +25,7 @@ import {
     NavContainer,
     PasswordPrompt,
     ScreenshareButton,
+    TileViewButton,
     VideoMuteButton
 } from '../../components';
 
@@ -41,6 +44,7 @@ export class InCall extends React.Component {
         onHangUp: PropTypes.func,
         onShowScreenshareModal: PropTypes.func,
         onSubmitPassword: PropTypes.func,
+        showMoreButton: PropTypes.bool,
         showPasswordPrompt: PropTypes.bool
     };
 
@@ -67,6 +71,7 @@ export class InCall extends React.Component {
         const {
             inMeeting,
             kicked,
+            showMoreButton,
             showPasswordPrompt
         } = this.props;
 
@@ -104,7 +109,7 @@ export class InCall extends React.Component {
                     <AudioMuteButton />
                     <VideoMuteButton />
                     <ScreenshareButton />
-                    <MoreButton />
+                    { showMoreButton ? <MoreButton /> : <TileViewButton /> }
                     <NavButton
                         className = 'hangup'
                         label = 'Leave'
@@ -156,6 +161,7 @@ function mapStateToProps(state) {
     return {
         inMeeting,
         kicked,
+        showMoreButton: shouldShowDtmf(state) || isVolumeControlSupported(state),
         showPasswordPrompt: needPassword
     };
 }

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -359,6 +359,10 @@ export class MeetingFrame extends React.Component {
 
             break;
 
+        case COMMANDS.SEND_DIAL_TONES:
+            this._jitsiApi.executeCommand('sendTones', { tones: data.tones });
+            break;
+
         case COMMANDS.SET_AUDIO_MUTE:
             if (this._isAudioMuted !== data.mute) {
                 this._jitsiApi.executeCommand('toggleAudio');

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/meeting-frame.js
@@ -359,7 +359,7 @@ export class MeetingFrame extends React.Component {
 
             break;
 
-        case COMMANDS.SEND_DIAL_TONES:
+        case COMMANDS.SEND_TOUCH_TONES:
             this._jitsiApi.executeCommand('sendTones', { tones: data.tones });
             break;
 


### PR DESCRIPTION
- New RCS command for playing touch tones
- New DTMF button for opening the DTMF Modal, which shows a dial pad
~- New StatelessDialPad, which is a copy of DialPad, which does not store internal state of the entered phone number. Used so DTMFModal can clear the entered phone number after submit.~
~- Ended up moving screensharing start functionality into the screensharing button as a result of temporary period where the screensharing button was supposed to be in the More Modal.~

~I'll try to see about splitting out some of these commits. Regardless, these changes cannot be merged until DTMF is fixed on jitsi-meet and the changes have been deployed to all necessary environments.~ Done.