### PR TITLE
feat: display some debugging steps when waiting for spot-tv

### DIFF
--- a/spot-client/src/common/css/_variables.scss
+++ b/spot-client/src/common/css/_variables.scss
@@ -10,3 +10,4 @@ $font-size-x-small: 0.5em;
 $z-index-base: 0;
 $z-index-cover-base: 1;
 $z-index-foreground: 10;
+$z-index-above-all: 11;

--- a/spot-client/src/common/css/page-layouts/_feedback-view.scss
+++ b/spot-client/src/common/css/page-layouts/_feedback-view.scss
@@ -3,9 +3,12 @@
     cursor: pointer;
     position: fixed;
     right: 5px;
+    z-index: $z-index-foreground;
 }
 
-.app-feedback-overlay {
+.app-feedback-overlay.status-overlay {
+    z-index: $z-index-above-all;
+
     .feedback-form {
         margin-top: 5%
     }

--- a/spot-client/src/common/css/page-layouts/_status-overlay.scss
+++ b/spot-client/src/common/css/page-layouts/_status-overlay.scss
@@ -14,6 +14,7 @@
         border-radius: 5px;
         color: var(--container-sub-content-font-color);
         padding: 3em;
+        position: relative;
         margin-top: 3em;
         margin-left: auto;
         margin-right: auto;

--- a/spot-client/src/common/ui/components/background/Background.js
+++ b/spot-client/src/common/ui/components/background/Background.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { getBackgroundUrl } from 'common/app-state';
+
+/**
+ * Functional component for showing the configured background image URL with
+ *  a gradient.
+ *
+ * @param {Object} props - The read-only properties with which the new
+ * instance is to be initialized.
+ * @returns {ReactElement}
+ * */
+export function Background({ backgroundUrl }) {
+    let backgroundStyles;
+
+    if (backgroundUrl) {
+        backgroundStyles = {
+            backgroundImage: `url('${backgroundUrl}')`
+        };
+    }
+
+    const gradientStyle = `view-gradient ${backgroundStyles ? 'visible' : ''}`;
+
+    return (
+        <div
+            className = 'view-background-container'
+            style = { backgroundStyles }>
+            <div className = { gradientStyle } />
+        </div>
+    );
+}
+
+Background.propTypes = {
+    backgroundUrl: PropTypes.string
+};
+
+/**
+ * Selects parts of the Redux state to pass in with the props of {@code View}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        backgroundUrl: getBackgroundUrl(state)
+    };
+}
+
+export default connect(mapStateToProps)(Background);

--- a/spot-client/src/common/ui/components/background/index.js
+++ b/spot-client/src/common/ui/components/background/index.js
@@ -1,0 +1,1 @@
+export { default as Background } from './Background';

--- a/spot-client/src/common/ui/components/index.js
+++ b/spot-client/src/common/ui/components/index.js
@@ -1,3 +1,4 @@
+export * from './background';
 export * from './button';
 export * from './clock';
 export * from './code-input';

--- a/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
+++ b/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { Background } from './../background';
+
 /**
  * Displays a status message while covering the entire screen.
  *
@@ -11,6 +13,7 @@ import React from 'react';
 export function StatusOverlay(props) {
     return (
         <div className = 'status-overlay'>
+            { props.showBackground && <Background /> }
             <div className = 'status-overlay-text-frame'>
                 <h1>{ props.title }</h1>
                 <div className = 'status-overlay-text'>
@@ -23,5 +26,6 @@ export function StatusOverlay(props) {
 
 StatusOverlay.propTypes = {
     children: PropTypes.node,
+    showBackground: PropTypes.bool,
     title: PropTypes.string
 };

--- a/spot-client/src/common/ui/views/fatal-error.js
+++ b/spot-client/src/common/ui/views/fatal-error.js
@@ -40,9 +40,7 @@ export class FatalError extends React.Component {
      */
     render() {
         return (
-            <View
-                hideBackground = { true }
-                name = 'error'>
+            <View name = 'error'>
                 <StatusOverlay title = 'An unexpected error occurred'>
                     <div>We will redirect you to home in</div>
                     <Countdown

--- a/spot-client/src/common/ui/views/view.js
+++ b/spot-client/src/common/ui/views/view.js
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { getBackgroundUrl, isAnyModalOpen } from 'common/app-state';
+import { isAnyModalOpen } from 'common/app-state';
 import { logger } from 'common/logger';
 
+import { Background } from '../components';
 import { viewDisplayed } from '../actions';
 
 /**
@@ -15,10 +16,8 @@ import { viewDisplayed } from '../actions';
  */
 class View extends React.Component {
     static propTypes = {
-        backgroundUrl: PropTypes.string,
         children: PropTypes.node,
         dispatch: PropTypes.func,
-        hideBackground: PropTypes.bool,
         isAnyModalOpen: PropTypes.bool,
         name: PropTypes.string
     };
@@ -39,32 +38,13 @@ class View extends React.Component {
      * @inheritdoc
      */
     render() {
-        let backgroundStyles;
-
-        if (!this.props.hideBackground) {
-            const backgroundUrl = this.props.backgroundUrl;
-
-            if (backgroundUrl) {
-                backgroundStyles = {
-                    backgroundImage: `url('${backgroundUrl}')`
-                };
-            }
-        }
-
         const className = `view ${this.props.isAnyModalOpen ? 'modal-open' : ''}`;
-
-        const gradientStyle
-            = `view-gradient ${backgroundStyles ? 'visible' : ''}`;
 
         return (
             <div
                 className = { className }
                 data-qa-id = { `${this.props.name}-view` }>
-                <div
-                    className = 'view-background-container'
-                    style = { backgroundStyles }>
-                    <div className = { gradientStyle } />
-                </div>
+                <Background />
                 {
 
                     /**
@@ -94,7 +74,6 @@ class View extends React.Component {
  */
 function mapStateToProps(state) {
     return {
-        backgroundUrl: getBackgroundUrl(state),
         isAnyModalOpen: isAnyModalOpen(state)
     };
 }

--- a/spot-client/src/spot-remote/ui/components/index.js
+++ b/spot-client/src/spot-remote/ui/components/index.js
@@ -7,3 +7,4 @@ export * from './nav';
 export * from './password-prompt';
 export * from './remote-control-menu';
 export * from './screenshare';
+export * from './waiting-for-spot-tv';

--- a/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/WaitingForSpotTVOverlay.js
+++ b/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/WaitingForSpotTVOverlay.js
@@ -9,7 +9,9 @@ import { StatusOverlay } from 'common/ui';
  */
 export default function WaitingForSpotTVOverlay() {
     return (
-        <StatusOverlay title = 'Waiting for Spot-TV to connect'>
+        <StatusOverlay
+            showBackground = { true }
+            title = 'Waiting for Spot-TV to connect'>
             <div data-qa-id = 'waiting-for-spot-tv'>
                 Please make sure the associated Spot-TV is currently running<br />
                 and connected to the Internet.

--- a/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/WaitingForSpotTVOverlay.js
+++ b/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/WaitingForSpotTVOverlay.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { StatusOverlay } from 'common/ui';
+
+/**
+ * Informs that the Spot-TV may not be online.
+ *
+ * @returns {ReactElement}
+ */
+export default function WaitingForSpotTVOverlay() {
+    return (
+        <StatusOverlay title = 'Waiting for Spot-TV to connect'>
+            <div data-qa-id = 'waiting-for-spot-tv'>
+                Please make sure the associated Spot-TV is currently running<br />
+                and connected to the Internet.
+            </div>
+        </StatusOverlay>
+    );
+}

--- a/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/index.js
+++ b/spot-client/src/spot-remote/ui/components/waiting-for-spot-tv/index.js
@@ -1,0 +1,1 @@
+export { default as WaitingForSpotTVOverlay } from './WaitingForSpotTVOverlay';

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -11,9 +11,11 @@ import { LoadingIcon, View } from 'common/ui';
 
 import './../../analytics';
 
+import {
+    ElectronDesktopPickerModal,
+    WaitingForSpotTVOverlay
+} from './../components';
 import { withRemoteControl, withUltrasound } from './../loaders';
-import { ElectronDesktopPickerModal } from './../components/electron-desktop-picker';
-
 import { Feedback, InCall, WaitingForCall } from './remote-views';
 
 /**
@@ -64,7 +66,7 @@ export class RemoteControl extends React.PureComponent {
      */
     _getView() {
         if (!this.props.isConnectedToSpot) {
-            return <div data-qa-id = 'waiting-for-spot-tv'>Waiting for Spot TV to connect...</div>;
+            return <WaitingForSpotTVOverlay />;
         }
 
         switch (this.props.view) {

--- a/spot-client/src/spot-remote/ui/views/share/share.js
+++ b/spot-client/src/spot-remote/ui/views/share/share.js
@@ -20,7 +20,8 @@ import { getRandomMeetingName } from 'common/utils';
 import { exitShareMode } from './../../../app-state';
 
 import {
-    ElectronDesktopPickerModal
+    ElectronDesktopPickerModal,
+    WaitingForSpotTVOverlay
 } from './../../components';
 import { withRemoteControl } from './../../loaders';
 
@@ -122,7 +123,7 @@ export class Share extends React.PureComponent {
      */
     _renderSubView() {
         if (!this.props.isConnectedToSpot) {
-            return <div data-qa-id = 'waiting-for-spot-tv'>Waiting for Spot TV to connect...</div>;
+            return <WaitingForSpotTVOverlay />;
         } else if (this.props.isWirelessScreensharingPending) {
             return <LoadingIcon />;
         }


### PR DESCRIPTION
- Use the StatusOverlay styling to make message more visible
- Provide an explicit instructions to check if the Spot-TV
  is on
- Adjust z-indexes so feedback icon displays above the new
  status overlay

![Screen Shot 2019-09-03 at 10 56 56 AM](https://user-images.githubusercontent.com/1243084/64198042-57541a80-ce3c-11e9-9c13-7a716316d03e.png)