### PR TITLE
ref(home): create new /tv route

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { Route, Switch, withRouter } from 'react-router-dom';
+import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 
 import { apiMessageReceived, getSpotClientVersion, setBootstrapComplete } from 'common/app-state';
 import { logger } from 'common/logger';
@@ -158,6 +158,9 @@ export class App extends React.Component {
                                 path = { ROUTES.SETUP }
                                 render = { this._renderSetupView }
                                 requireSetup = { false } />
+                            <Redirect
+                                from = { ROUTES.OLD_HOME }
+                                to = { ROUTES.HOME } />
                             <SpotTvRestrictedRoute
                                 path = { ROUTES.HOME }
                                 render = { this._renderHomeView } />

--- a/spot-client/src/common/routing/constants.js
+++ b/spot-client/src/common/routing/constants.js
@@ -4,9 +4,10 @@
 export const ROUTES = {
     CODE: '/',
     HELP: '/help',
-    HOME: '/spot',
+    HOME: '/tv',
     LOADING: '/loading',
     MEETING: '/meeting',
+    OLD_HOME: '/spot',
     OUTLOOK_OAUTH: '/oauth',
     REMOTE_CONTROL: '/remote-control',
     SETUP: '/setup',

--- a/spot-electron/config.js
+++ b/spot-electron/config.js
@@ -16,7 +16,7 @@ module.exports = {
     /**
      * The default URL to connect to.
      */
-    defaultSpotURL: process.env.SPOT_URL || 'https://spot.jitsi.net/spot',
+    defaultSpotURL: process.env.SPOT_URL || 'https://spot.jitsi.net/tv',
 
     /**
      * The details of the spash screen, if any.

--- a/spot-webdriver/constants/index.js
+++ b/spot-webdriver/constants/index.js
@@ -49,5 +49,5 @@ module.exports = {
     /**
      * The direct URL to visit to for a browser to act as a Spot-TV.
      */
-    SPOT_URL: `${TEST_SERVER_URL}/spot`
+    SPOT_URL: `${TEST_SERVER_URL}/tv`
 };


### PR DESCRIPTION
To avoid another user-facing reference
to "spot"

spot-electron changes are not backwards compatible but also it's not released.