### PR TITLE
ref(XmppConnection): send Spot TV presence as single JSON string

### DIFF
--- a/spot-client/src/common/remote-control/XmppConnection.test.js
+++ b/spot-client/src/common/remote-control/XmppConnection.test.js
@@ -65,6 +65,46 @@ describe('XmppConnection', () => {
                     type: 'unavailable'
                 });
         });
+        it('transforms legacy MUC presence into a js object', () => {
+            const calendarArray = [ {
+                name: 'name1',
+                number: 123
+            }, {
+                name: 'name2',
+                number: 456
+            } ];
+
+            const presenceString = `
+                <presence
+                    from = "${IQ_FROM}"
+                    to = "${IQ_TO}"
+                    type = "unavailable">
+                    <videoMuted>true</videoMuted>
+                    <isSpot>true</isSpot>
+                    <calendar>${JSON.stringify(calendarArray)}</calendar>
+                </presence>
+            `;
+            const presenceIq = new DOMParser()
+                .parseFromString(presenceString, 'text/xml')
+                .documentElement;
+
+            const xmppConnection = new XmppConnection();
+
+            expect(xmppConnection.convertXMLPresenceToObject(presenceIq))
+                .toEqual({
+                    from: IQ_FROM,
+                    localUpdate: false,
+                    state: {
+                        isSpot: true,
+                        videoMuted: true,
+                        calendar: calendarArray
+                    },
+                    type: 'unavailable'
+                });
+
+            // Legacy handling is expected to be removed after 04/01/2020 @ 12:00am (UTC)
+            expect(Date.now()).toBeLessThan(1585699200000);
+        });
     });
     describe('convertXMLMessageToObject', () => {
         it('transforms an IQ into a js object', () => {

--- a/spot-client/src/common/remote-control/XmppConnection.test.js
+++ b/spot-client/src/common/remote-control/XmppConnection.test.js
@@ -33,14 +33,19 @@ describe('XmppConnection', () => {
     });
 
     describe('convertXMLPresenceToObject', () => {
-        it('transforms an IQ into a js object', () => {
+        it('transforms MUC presence into a js object', () => {
+            const spotStatus = JSON.stringify({
+                videoMuted: true,
+                isSpot: true
+            });
             const presenceString = `
                 <presence
                     from = "${IQ_FROM}"
                     to = "${IQ_TO}"
                     type = "unavailable">
-                    <videoMuted>true</videoMuted>
-                    <isSpot>true</isSpot>
+                    <spot-status xmlns="https://jitsi.org/spot">
+                        ${spotStatus}                    
+                    </spot-status>
                 </presence>
             `;
             const presenceIq = new DOMParser()

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -6,6 +6,18 @@ import { JitsiMeetJSProvider } from 'common/vendor';
 import { IQ_NAMESPACES, IQ_TIMEOUT } from './constants';
 
 /**
+ * XML element name for spot status added to MUC presence.
+ * @type {string}
+ */
+const SPOT_STATUS_ELEMENT_NAME = 'spot-status';
+
+/**
+ * XML namespace for Spot specific XML.
+ * @type {string}
+ */
+const SPOT_XMLNS = 'https://jitsi.org/spot';
+
+/**
  * Represents an XMPP connection to a prosody service.
  */
 export default class XmppConnection {
@@ -46,6 +58,8 @@ export default class XmppConnection {
         this._onCommand = this._onCommand.bind(this);
         this._onMessage = this._onMessage.bind(this);
         this._onPresence = this._onPresence.bind(this);
+
+        this._spotStatus = { };
     }
 
     /**
@@ -200,7 +214,7 @@ export default class XmppConnection {
             })
             .then(() => {
                 if (joinAsSpot) {
-                    this.updatePresence('isSpot', true);
+                    this.updateStatus({ isSpot: true });
                 }
             })
             .then(() => this._joinMuc(roomLock))
@@ -295,18 +309,6 @@ export default class XmppConnection {
     }
 
     /**
-     * Sets the presence status for a given type.
-     *
-     * @param {string} type - The present attribute to change.
-     * @param {string} value - The new value to associate with the presence
-     * attribute.
-     * @returns {void}
-     */
-    updatePresence(type, value) {
-        this.room && this.room.addToPresence(type, { value });
-    }
-
-    /**
      * Updates the current muc participant's status, which should notify other
      * participants of the update. This is a fire and forget call with no ack.
      *
@@ -316,15 +318,19 @@ export default class XmppConnection {
      * @returns {void}
      */
     updateStatus(newStatus = {}) {
-        Object.keys(newStatus).forEach(key => {
-            let valueToSend = newStatus[key];
+        this._spotStatus = {
+            ...this._spotStatus,
+            ...newStatus
+        };
 
-            if (typeof valueToSend !== 'string') {
-                valueToSend = JSON.stringify(valueToSend);
-            }
-
-            this.updatePresence(key, valueToSend);
-        });
+        this.room
+            && this.room.addToPresence(
+                SPOT_STATUS_ELEMENT_NAME, {
+                    value: JSON.stringify(this._spotStatus),
+                    attributes: {
+                        xmlns: SPOT_XMLNS
+                    }
+                });
 
         this._sendPresence();
     }
@@ -496,7 +502,7 @@ export default class XmppConnection {
 
         // Suppress any presence errors until the MUC is joined as those
         // initial presence errors are handled by the join flow instead.
-        if (parsedPresence.type === 'error' && !this._hasJoinedMuc) {
+        if (!parsedPresence || (parsedPresence.type === 'error' && !this._hasJoinedMuc)) {
             return true;
         }
 
@@ -647,7 +653,7 @@ export default class XmppConnection {
      * Converts a presence IQ into a plain JS object.
      *
      * @param {XML} presence - The presence to convert.
-     * @returns {Presence}
+     * @returns {?Presence}
      */
     convertXMLPresenceToObject(presence) {
         const from = presence.getAttribute('from');
@@ -657,21 +663,24 @@ export default class XmppConnection {
             type = 'join';
         }
 
+        const statusElement = presence.getElementsByTagNameNS('https://jitsi.org/spot', 'spot-status')[0];
+        let state;
+
+        try {
+            state = statusElement ? JSON.parse(statusElement.textContent) : { };
+        } catch (error) {
+            logger.error('Failed to parse presence', {
+                from,
+                type
+            });
+
+            return undefined;
+        }
+
         return {
             from,
             localUpdate: from === this.getRoomFullJid(),
-            state: Array.from(presence.children)
-                .reduce((acc, child) => {
-                    let value = child.textContent;
-
-                    if (value === 'true' || value === 'false') {
-                        value = value === 'true';
-                    }
-
-                    acc[child.tagName] = value;
-
-                    return acc;
-                }, {}),
+            state,
             type
         };
     }

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -246,17 +246,10 @@ function _onSpotTVStateChange({ dispatch }, data) {
 
     dispatch(setSpotTVState(newState));
 
-    if (updatedState.calendar) {
-        try {
-            const events = JSON.parse(updatedState.calendar);
+    if (Array.isArray(updatedState.calendar)) {
+        const events = updatedState.calendar;
 
-            dispatch(setCalendarEvents(events));
-        } catch (error) {
-            logger.error(
-                'Spot-Remote could not parse calendar events',
-                { error }
-            );
-        }
+        dispatch(setCalendarEvents(events));
     }
 }
 


### PR DESCRIPTION
Will stringify the entire Spot TV status object into single JSON string and put it in a custom XML element inside MUC presence. The status will come out of XMPPConnection as a ready to use JS object.