### PR TITLE
feat: log a message when Spot Remote joins

### DIFF
--- a/spot-client/src/common/remote-control/remoteControlServer.js
+++ b/spot-client/src/common/remote-control/remoteControlServer.js
@@ -315,6 +315,8 @@ export class RemoteControlServer extends BaseRemoteControlService {
         }
 
         if (type === 'join') {
+            logger.log('presence update of a Spot-Remote joining', { from });
+
             this.emit(
                 SERVICE_UPDATES.CLIENT_JOINED,
                 {


### PR DESCRIPTION
There's a message when spot remote leaves, but not when joins. Logging both makes debugging easier.