### PR TITLE
fix(spot tv state): always specify full set of presence key

### DIFF
--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -40,9 +40,9 @@ import {
 /**
  * Presence attributes from Spot-TV to store in redux.
  *
- * @type {Set}
+ * @type {Array}
  */
-const presenceToStore = new Set([
+const presenceToStore = [
     'audioMuted',
     'electron',
     'inMeeting',
@@ -58,7 +58,7 @@ const presenceToStore = new Set([
     'videoMuted',
     'view',
     'wiredScreensharingEnabled'
-]);
+];
 
 /**
  * An array which stores all listeners bound to the the remote control service.
@@ -256,11 +256,9 @@ function _onSpotTVStateChange({ dispatch }, data) {
     const newState = {};
     const { updatedState } = data;
 
-    Object.keys(updatedState).forEach(key => {
-        if (presenceToStore.has(key)) {
-            newState[key] = updatedState[key];
-        }
-    });
+    for (const presenceKey of presenceToStore) {
+        newState[presenceKey] = updatedState[presenceKey];
+    }
 
     dispatch(setSpotTVState(newState));
 


### PR DESCRIPTION
New method of serializing tv state to and from JSON does not transport empty or undefined keys. I don't know why exactly, but don't really feel like looking into that. Specify full set of keys on every update by going through the whole list of presence attributes to insert 'undefined' if no value is present.