### PR TITLE
feat(dial pad): pretty format and validate phone numbers

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -9046,6 +9046,24 @@
             "from": "github:virtuacoplenny/quiet-js#lenny/rewrite",
             "dev": true
         },
+        "libphonenumber-js": {
+            "version": "1.7.24",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.24.tgz",
+            "integrity": "sha512-2+8rEz5mLHUqSFNedMcBcP1gb0KMjnOSxt+3me1bNgcyTreHL6M1dVds41rgvYN5XLcmZmMGLwGL2bOxpGoi1Q==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0",
+                "xml2js": "^0.4.17"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
         "linkify-it": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
@@ -14414,6 +14432,23 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.22",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+            "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+            "dev": true,
+            "requires": {
+                "sax": ">=0.6.0",
+                "util.promisify": "~1.0.0",
+                "xmlbuilder": "~11.0.0"
+            }
+        },
+        "xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true
         },
         "xmlcreate": {

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -49,6 +49,7 @@
         "jwt-decode": "2.2.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#a909e594868b17f0c72c85f2a231384f4cb1ea61",
         "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
+        "libphonenumber-js": "1.7.24",
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",

--- a/spot-client/src/spot-remote/ui/components/dial-pad/DialPad.test.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/DialPad.test.js
@@ -16,47 +16,103 @@ describe('DialPad', () => {
     });
 
     test('entering a number with a mouse', () => {
-        for (let i = 1; i < 4; i++) {
-            dialPad.find(`#dial-button-${i}`).simulate('mousedown');
-        }
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
 
-        expect(dialPad.find('input').instance().value).toBe('123');
+        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
+
+        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
+
+        expect(dialPad.find('input').instance().value).toBe('(222) 333-4444');
     });
 
     test('entering a number with touch', () => {
-        for (let i = 1; i < 4; i++) {
-            dialPad.find(`#dial-button-${i}`).simulate('touchstart');
-        }
+        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
 
-        expect(dialPad.find('input').instance().value).toBe('123');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+
+        expect(dialPad.find('input').instance().value).toBe('(222) 333-4444');
+    });
+
+    test('formats international phone numbers', () => {
+        // Long press on 0 to produce +
+        jest.useFakeTimers();
+        dialPad.find('#dial-button-0').simulate('mousedown');
+        jest.runAllTimers();
+
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${5}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${5}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
+
+        expect(dialPad.find('input').instance().value).toBe('+44 55 6666 7777');
     });
 
     test('deleting numbers', () => {
-        for (let i = 1; i < 4; i++) {
-            dialPad.find(`#dial-button-${i}`).simulate('mousedown');
-        }
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
+        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
 
         dialPad.find('.backspace').simulate('click');
-        expect(dialPad.find('input').instance().value).toBe('12');
+        expect(dialPad.find('input').instance().value).toBe('22');
 
         dialPad.find('.backspace').simulate('click');
-        expect(dialPad.find('input').instance().value).toBe('1');
+        expect(dialPad.find('input').instance().value).toBe('2');
 
         dialPad.find('.backspace').simulate('click');
         expect(dialPad.find('input').instance().value).toBe('');
     });
 
-    test('submitting the entered number', () => {
+    test('submitting a valid phone number in the E.164 format', () => {
+        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
+
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+
+        dialPad.find('button.call-button').simulate('click');
+
+        expect(submitCallback).toHaveBeenCalledWith(expect.any(String), '+12343334444');
+    });
+
+    test('not submitting the form if the phone number is invalid', () => {
         dialPad.find('#dial-button-1').simulate('mousedown');
         dialPad.find('button.call-button').simulate('click');
 
-        expect(submitCallback).toHaveBeenCalledWith(expect.any(String), '1');
-    });
-
-    test('submitting without a number', () => {
-        dialPad.find('button.call-button').simulate('click');
-
-        expect(submitCallback).toHaveBeenCalledWith(expect.any(String), '');
+        expect(submitCallback).not.toHaveBeenCalled();
     });
 
     test('replaces 0 with + on long press', () => {

--- a/spot-client/src/spot-remote/ui/components/dial-pad/DialPad.test.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/DialPad.test.js
@@ -15,36 +15,27 @@ describe('DialPad', () => {
         dialPad.unmount();
     });
 
+    /**
+     * Runs through the digits in given string and simulates events on corresponding dial pad keys.
+     *
+     * @param {string} phoneNumber - The phone number digits(only numbers) to type.
+     * @param {string} method - The method for pressing keys. Uses ' touchstart' by default.
+     * @returns {void}
+     */
+    function typePhoneNumber(phoneNumber, method = 'touchstart') {
+        for (const digit of phoneNumber) {
+            dialPad.find(`#dial-button-${digit}`).simulate(method);
+        }
+    }
+
     test('entering a number with a mouse', () => {
-        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${2}`).simulate('mousedown');
-
-        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${3}`).simulate('mousedown');
-
-        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
-        dialPad.find(`#dial-button-${4}`).simulate('mousedown');
+        typePhoneNumber('2223334444', 'mousedown');
 
         expect(dialPad.find('input').instance().value).toBe('(222) 333-4444');
     });
 
     test('entering a number with touch', () => {
-        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        typePhoneNumber('2223334444');
 
         expect(dialPad.find('input').instance().value).toBe('(222) 333-4444');
     });
@@ -55,21 +46,7 @@ describe('DialPad', () => {
         dialPad.find('#dial-button-0').simulate('mousedown');
         jest.runAllTimers();
 
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${5}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${5}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${6}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${7}`).simulate('touchstart');
+        typePhoneNumber('445566667777');
 
         expect(dialPad.find('input').instance().value).toBe('+44 55 6666 7777');
     });
@@ -90,18 +67,7 @@ describe('DialPad', () => {
     });
 
     test('submitting a valid phone number in the E.164 format', () => {
-        dialPad.find(`#dial-button-${2}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${3}`).simulate('touchstart');
-
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
-        dialPad.find(`#dial-button-${4}`).simulate('touchstart');
+        typePhoneNumber('2343334444');
 
         dialPad.find('button.call-button').simulate('click');
 

--- a/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Backspace, Call } from 'common/icons';
-import { getRandomMeetingName } from 'common/utils';
 
 import DialButton from './dial-button';
 import NumberInput from './NumberInput';
@@ -38,7 +37,7 @@ export default class StatelessDialPad extends React.Component {
 
         this._onDeleteLastCharacter = this._onDeleteLastCharacter.bind(this);
         this._onDialButtonClick = this._onDialButtonClick.bind(this);
-        this._onGoToCall = this._onGoToCall.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
         this._onInputChange = this._onInputChange.bind(this);
         this._onReplaceLastChar = this._onReplaceLastChar.bind(this);
         this._renderDialButton = this._renderDialButton.bind(this);
@@ -54,7 +53,7 @@ export default class StatelessDialPad extends React.Component {
         return (
             <form
                 className = 'dial-pad'
-                onSubmit = { this._onGoToCall }>
+                onSubmit = { this._onSubmit }>
                 <NumberInput
                     className = 'number-input'
                     gradientStart = 'center'
@@ -89,7 +88,7 @@ export default class StatelessDialPad extends React.Component {
                     <div className = 'dial-pad-footer-button'>
                         <button
                             className = 'call-button dial-button'
-                            onClick = { this._onGoToCall }
+                            onClick = { this._onSubmit }
                             type = 'submit'>
                             <Call />
                         </button>
@@ -130,21 +129,16 @@ export default class StatelessDialPad extends React.Component {
     }
 
     /**
-     * Callback invoked to enter a Jitsi-Meet meeting and invite the entered
-     * phone number.
+     * Callback invoked when the form's submit action is executed.
      *
-     * @param {Event} event - The form submission event to proceed to the a
-     * call and invite the entered phone number.
+     * @param {Event} event - The form submission event.
      * @private
      * @returns {void}
      */
-    _onGoToCall(event) {
+    _onSubmit(event) {
         event.preventDefault();
 
-        this.props.onSubmit(
-            getRandomMeetingName(),
-            this.props.value
-        );
+        this.props.onSubmit && this.props.onSubmit();
     }
 
     /**

--- a/spot-client/src/spot-remote/ui/components/dial-pad/dial-pad.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/dial-pad.js
@@ -1,6 +1,26 @@
+import { AsYouType } from 'libphonenumber-js';
+import PropTypes from 'prop-types';
 import React from 'react';
 
+import { logger } from 'common/logger';
+
+import { getRandomMeetingName } from 'common/utils';
+
 import StatelessDialPad from './StatelessDialPad';
+
+// eslint-disable-next-line jsdoc/require-description-complete-sentence
+/**
+ * Removes phone number formatting from given formatted string.
+ *
+ * Example:
+ * +1 (342) 543 6767 => +13425436767
+ *
+ * @param {string} formattedPhoneNumber - A pretty phone number string to be stripped of extra formatting.
+ * @returns {string}
+ */
+function removeFormatting(formattedPhoneNumber) {
+    return formattedPhoneNumber.replace(/[() -]/g, '');
+}
 
 /**
  * Displays numbers and an input for entering a phone number.
@@ -8,6 +28,10 @@ import StatelessDialPad from './StatelessDialPad';
  * @extends React.Component
  */
 export default class DialPad extends React.Component {
+    static propTypes = {
+        onSubmit: PropTypes.func
+    };
+
     /**
      * Initializes a new {@code DialPad} instance.
      *
@@ -18,10 +42,22 @@ export default class DialPad extends React.Component {
         super(props);
 
         this.state = {
-            value: ''
+            /**
+             * This state stores numbers/characters typed by the user on the dial pad.
+             */
+            typedValue: '',
+
+            /**
+             * This is the typed value formatted in to a phone number text with extra parenthesis, dashes and spaces
+             * which make the phone number easier to read. This is passed over to the dial pad to display.
+             */
+            formattedPhone: ''
         };
 
+        this._asYouType = new AsYouType('US');
+
         this._onChange = this._onChange.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
     }
 
     /**
@@ -33,10 +69,9 @@ export default class DialPad extends React.Component {
     render() {
         return (
             <StatelessDialPad
-                { ...this.props }
                 onChange = { this._onChange }
-                value = { this.state.value }
-                { ...this.props } />
+                onSubmit = { this._onSubmit }
+                value = { this.state.formattedPhone } />
         );
     }
 
@@ -48,6 +83,59 @@ export default class DialPad extends React.Component {
      * @returns {void}
      */
     _onChange(value) {
-        this.setState({ value });
+        let newTypedValue = value;
+
+        // A corner case for handling parenthesis deletion.
+        // value = (512
+        // this.state.formattedPhone = (512)
+        // When the state above occurs it means that user has removed the last parenthesis by editing the input field.
+        if (this.state.formattedPhone.replace(value, '') === ')') {
+            newTypedValue = newTypedValue.slice(0, -1);
+        }
+
+        this._setTypedValue(removeFormatting(newTypedValue));
+    }
+
+    /**
+     * Handles the submit action emitted by the {@link StatelessDialPad}.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onSubmit() {
+        const phoneNumber = this._asYouType.getNumber();
+
+        if (phoneNumber && phoneNumber.isValid()) {
+            this.props.onSubmit(
+                getRandomMeetingName(),
+                phoneNumber.number);
+        } else {
+            logger.log('Not a valid phone number', { inout: this.state.typedValue });
+        }
+    }
+
+    /**
+     * Updates the typed phone number state and produces pretty formatted phone number output that is to be displayed
+     * by the {@link StatelessDialPad}.
+     *
+     * @param {string} typedValue - A string which combines all characters typed in on the dial pad by the user.
+     * @private
+     * @returns {void}
+     */
+    _setTypedValue(typedValue) {
+        this._asYouType.reset();
+
+        let formattedPhone = this._asYouType.input(typedValue);
+
+        // If entered characters are removed by the "as you type" it means they do not add up to a valid phone number.
+        // In this case skip the formatting and display the typed value directly.
+        if (removeFormatting(formattedPhone) !== typedValue) {
+            formattedPhone = typedValue;
+        }
+
+        this.setState({
+            typedValue,
+            formattedPhone
+        });
     }
 }

--- a/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/DTMFModal.js
@@ -70,16 +70,13 @@ export class DTMFModal extends React.Component {
     /**
      * Requests the entered number be played as tones.
      *
-     * @param {*} _ - Meeting names details. Not used for the purpose of
-     * sending tones.
-     * @param {string} tones - The number to be played.
      * @private
      * @returns {void}
      */
-    _onSubmit(_, tones) {
+    _onSubmit() {
         logger.log('submitting touch tones');
 
-        this.props.onSendTones(tones);
+        this.props.onSendTones(this.state.value);
         this.setState({ value: '' });
     }
 }


### PR DESCRIPTION
Use libphonenumber-js to format the displayed phone number as it's being
typed. Also validates if the phone number is valid, before calling
the onSubmit callback.

Uses 'US' as a default country code for formatting and validation if no
country code is entered manually.

Modifies StatelessDialPad to not pass the value and only call onSubmit
callback when submit action is executed. It is not supposed to track
the state anyway and it is confusing whether to use the value given on
submit or the value that's been submitted last in the on change
callback.