### PR TITLE
fix(dial): adjust sizing of dial pad

### DIFF
--- a/spot-client/src/common/css/_dial-pad.scss
+++ b/spot-client/src/common/css/_dial-pad.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
 
     .dial-pad-buttons {
-        padding: 17px 17px 0px;
+        padding: 17px 28px 0px;
 
         .row {
             display: flex;
@@ -14,27 +14,31 @@
     }
 
     .dial-button {
+        align-items: center;
         background-color: transparent;
         border: 1px solid white;
         border-radius: 50%;
         color: inherit;
         cursor: pointer;
         font-family: inherit;
-        font-size: inherit;
-        height: calc(#{$font-size-large} * 1.6);
-        line-height: 1;
+        height: 64px;
+        justify-content: center;
+        line-height: 32px;
         margin: 4px;
         padding: 0;
-        width: calc(#{$font-size-large} * 1.6);
+        width: 64px;
 
         .main {
-            display:block;
-            font-size: $font-size-medium-plus;
+            display: block;
+            font-size: 32px;
+            font-weight: 600;
         }
 
         .sub {
             color: var(--container-sub-content-font-color);
-            font-size: $font-size-x-small;
+            font-size: 10px;
+            font-weight: bold;
+            line-height: 14px;
         }
 
         .sub:empty:before {
@@ -42,9 +46,9 @@
             visibility: hidden;
         }
 
-        &.larger-sub .sub {
-            font-size: $font-size-medium;
-            line-height: $font-size-x-small;
+        .larger-sub .sub {
+            font-size: 12px;
+            line-height: 12px;
         }
 
         &.active,
@@ -55,7 +59,7 @@
 
     .dial-pad-footer {
         display: flex;
-        padding-bottom: 24px;
+        padding: 0 28px 24px;
         text-align: center;
         width: 100%;
 

--- a/spot-client/src/common/css/_mixins.scss
+++ b/spot-client/src/common/css/_mixins.scss
@@ -38,7 +38,7 @@
     width: 100%;
 
     .view-header {
-        padding: 2.6em;
+        padding: 1em;
         text-align: center;
     }
 }

--- a/spot-client/src/common/css/page-layouts/_waiting-view.scss
+++ b/spot-client/src/common/css/page-layouts/_waiting-view.scss
@@ -2,13 +2,17 @@
     @include spot-remote-view-layout;
 
     .waiting-sub-view {
+        align-items: center;
+        display: flex;
         flex: 1;
+        justify-content: center;
     }
 
     .meetings {
-        display: flex;
-        flex-direction: column;
         align-items: center;
+        display: flex;
+        flex: 1;
+        flex-direction: column;
 
         .meeting {
             padding: .8em 1.2em;
@@ -36,6 +40,8 @@
 
     .meeting-name-entry-view {
         @include centered-content;
+
+        flex: 1;
     }
 
     .share-select-view {

--- a/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
@@ -78,7 +78,7 @@ export default class StatelessDialPad extends React.Component {
                         { this._renderDialButton('9', 'WXYZ') }
                     </div>
                     <div className = 'row'>
-                        { this._renderDialButton('*') }
+                        { this._renderDialButton('＊') }
                         { this._renderZeroButton() }
                         { this._renderDialButton('#') }
                     </div>

--- a/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/waiting-for-call.js
@@ -16,7 +16,6 @@ import { CalendarToday, Call, ScreenShare, Videocam } from 'common/icons';
 import { logger } from 'common/logger';
 import {
     Clock,
-    RoomName,
     ScheduledMeetings
 } from 'common/ui';
 import { getRandomMeetingName } from 'common/utils';
@@ -94,7 +93,6 @@ class WaitingForCallView extends React.Component {
                         onUpdateAvailable = { this.props._onUpdateAvailable } /> }
                 <div className = 'view-header'>
                     <Clock />
-                    <RoomName />
                 </div>
                 <div className = 'waiting-sub-view'>
                     { this._getSubView() }


### PR DESCRIPTION
- Set dimensions to target ipad
- remove RoomName from header to make room
  for larger dial pad
- adjust waiting view contents to center of
  screen to account for removed padding from
  header to make space for dial pad; this
  mirrors work-in-progress styles

![Screen Shot 2019-09-16 at 2 15 01 PM](https://user-images.githubusercontent.com/1243084/64994144-bb3f0000-d88c-11e9-84aa-2138fc5bfc61.png)
![Screen Shot 2019-09-16 at 2 14 59 PM](https://user-images.githubusercontent.com/1243084/64994182-d4e04780-d88c-11e9-9bdc-66c419f7a819.png)
![Screen Shot 2019-09-16 at 2 14 56 PM](https://user-images.githubusercontent.com/1243084/64994169-cdb93980-d88c-11e9-840e-28615a0ab3d2.png)

