### PR TITLE
fix(adhoc): prevent base url from wrapping

### DIFF
--- a/spot-client/src/common/css/_meeting-name-entry.scss
+++ b/spot-client/src/common/css/_meeting-name-entry.scss
@@ -36,6 +36,7 @@
             font-size: 16px;
             line-height: 1.1875em;
             padding: 6px 0 7px;
+            white-space: nowrap;
         }
     }
 


### PR DESCRIPTION
Issue
<img width="1278" alt="Screen Shot 2019-09-17 at 11 26 44 AM" src="https://user-images.githubusercontent.com/1243084/65068774-1da40900-d93e-11e9-85f7-37496afefb59.png">

With potential fix
<img width="1278" alt="Screen Shot 2019-09-17 at 11 26 40 AM" src="https://user-images.githubusercontent.com/1243084/65068781-24cb1700-d93e-11e9-8e3c-3c08ce8a0fd8.png">
