### PR TITLE
ios: add (another) Bluetooth usage purpose to Info.plist

### DIFF
--- a/spot-controller/ios/spot-controller/Info.plist
+++ b/spot-controller/ios/spot-controller/Info.plist
@@ -45,6 +45,8 @@
 	<string>Detect nearby meeting devices</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Detect nearby meeting devices</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Detect nearby meeting devices</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>


### PR DESCRIPTION
Fixes this error:

ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSBluetoothAlwaysUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. Learn more (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy).
