### PR TITLE
fix(dial pad): use the least strict validation

### DIFF
--- a/spot-client/src/spot-remote/ui/components/dial-pad/dial-pad.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/dial-pad.js
@@ -1,4 +1,4 @@
-import { AsYouType } from 'libphonenumber-js/max';
+import { AsYouType } from 'libphonenumber-js';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -121,7 +121,7 @@ export class DialPad extends React.Component {
     _getPhoneNumber() {
         const phoneNumber = this._asYouType.getNumber();
 
-        return phoneNumber && phoneNumber.isValid() && phoneNumber.number;
+        return phoneNumber && phoneNumber.isPossible() && phoneNumber.number;
     }
 
     /**

--- a/spot-client/src/spot-remote/ui/utils/formatPhoneNumber.js
+++ b/spot-client/src/spot-remote/ui/utils/formatPhoneNumber.js
@@ -1,4 +1,4 @@
-import { parsePhoneNumberFromString } from 'libphonenumber-js/max';
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
 
 /**
  * Pretty prints given phone number. Will return a formatted text if a valid phone number string is given.


### PR DESCRIPTION
It is not recommended by the lib's author to use strict validation as it may easily get outdated and is already missing few numbers we need.

https://github.com/catamphetamine/libphonenumber-js/blob/master/README.md#using-phone-number-validation-feature