### PR TITLE
fix(Spot Remote): waiting for TV to connect appear to often

### DIFF
--- a/spot-client/src/common/remote-control/BaseRemoteControlService.js
+++ b/spot-client/src/common/remote-control/BaseRemoteControlService.js
@@ -30,14 +30,6 @@ export class BaseRemoteControlService extends Emitter {
 
         this._onDisconnect = this._onDisconnect.bind(this);
 
-        window.addEventListener(
-            'beforeunload',
-            event => {
-                this.disconnect(event)
-                    .catch(() => { /* swallow unload errors from bubbling up */ });
-            }
-        );
-
         /**
          * A peer-to-peer direct signaling channel. Once established will be used to send/receive remote control
          * commands.

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -33,7 +33,10 @@ import {
     loadScript,
     setPersistedState
 } from 'common/utils';
+
+import { disconnectFromSpotTV } from 'spot-remote/app-state';
 import { ExternalApiSubscriber } from 'spot-remote/external-api';
+import { disconnectSpotTvRemoteControl } from './spot-tv/app-state';
 
 import App from './app';
 
@@ -97,6 +100,16 @@ const analyticsAppKey = getAnalyticsAppKey(reduxState);
 if (analyticsAppKey) {
     analytics.addHandler(new SegmentHandler(deviceId, analyticsAppKey));
 }
+
+window.addEventListener(
+    'beforeunload',
+    event => {
+        store.dispatch(disconnectSpotTvRemoteControl(event)).catch(error => {
+            console.error('Failed to disconnect Spot TV on unload', error);
+        });
+        store.dispatch(disconnectFromSpotTV(event));
+    }
+);
 
 // eslint-disable-next-line max-params
 window.onerror = (message, url, lineNo, columnNo, error) => {

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -34,9 +34,7 @@ import {
     setPersistedState
 } from 'common/utils';
 
-import { disconnectFromSpotTV } from 'spot-remote/app-state';
 import { ExternalApiSubscriber } from 'spot-remote/external-api';
-import { disconnectSpotTvRemoteControl } from './spot-tv/app-state';
 
 import App from './app';
 
@@ -100,19 +98,6 @@ const analyticsAppKey = getAnalyticsAppKey(reduxState);
 if (analyticsAppKey) {
     analytics.addHandler(new SegmentHandler(deviceId, analyticsAppKey));
 }
-
-// FIXME move to actions
-window.addEventListener(
-    'beforeunload',
-    event => {
-        store.dispatch(disconnectSpotTvRemoteControl(event)).catch(error => {
-            logger.error('Failed to disconnect Spot TV on beforeunload', error);
-        });
-        store.dispatch(disconnectFromSpotTV(event)).catch(error => {
-            logger.error('Failed to disconnect Spot Remote on beforeunload', error);
-        });
-    }
-);
 
 // eslint-disable-next-line max-params
 window.onerror = (message, url, lineNo, columnNo, error) => {

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -101,13 +101,16 @@ if (analyticsAppKey) {
     analytics.addHandler(new SegmentHandler(deviceId, analyticsAppKey));
 }
 
+// FIXME move to actions
 window.addEventListener(
     'beforeunload',
     event => {
         store.dispatch(disconnectSpotTvRemoteControl(event)).catch(error => {
-            console.error('Failed to disconnect Spot TV on unload', error);
+            logger.error('Failed to disconnect Spot TV on beforeunload', error);
         });
-        store.dispatch(disconnectFromSpotTV(event));
+        store.dispatch(disconnectFromSpotTV(event)).catch(error => {
+            logger.error('Failed to disconnect Spot Remote on beforeunload', error);
+        });
     }
 );
 

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -221,6 +221,14 @@ export function connectToSpotTV(joinCode, shareMode) {
                 SERVICE_UPDATES.UNRECOVERABLE_DISCONNECT,
                 onDisconnect));
 
+        const onBeforeUnloadHandler = event => dispatch(disconnectFromSpotTV(event));
+
+        window.addEventListener('beforeunload', onBeforeUnloadHandler);
+
+        rcsListeners.push(() => {
+            window.removeEventListener('beforeunload', onBeforeUnloadHandler);
+        });
+
         return doConnect();
     };
 }

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -288,13 +288,10 @@ export function disconnectFromSpotTV(event) {
         _clearSubscriptions();
 
         dispatch(destroyConnection());
-
-        remoteControlClient.disconnect(event).catch(error => {
-            logger.error('Failed to disconnect Spot Remote', { error });
-        });
-
         dispatch(setCalendarEvents([]));
         dispatch(clearSpotTVState());
+
+        return remoteControlClient.disconnect(event);
     };
 }
 

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -280,13 +280,18 @@ function _onSpotTVStateChange({ dispatch }, data) {
 /**
  * Stops any connection to a Spot-TV and clears redux state about the Spot-TV.
  *
+ * @param {Object} [event] - Optionally, the event which triggered the necessity to disconnect.
  * @returns {Function}
  */
-export function disconnectFromSpotTV() {
+export function disconnectFromSpotTV(event) {
     return dispatch => {
         _clearSubscriptions();
 
-        remoteControlClient.disconnect();
+        dispatch(destroyConnection());
+
+        remoteControlClient.disconnect(event).catch(error => {
+            logger.error('Failed to disconnect Spot Remote', { error });
+        });
 
         dispatch(setCalendarEvents([]));
         dispatch(clearSpotTVState());

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -5,7 +5,8 @@ import { connect } from 'react-redux';
 import {
     getCalendarEvents,
     getCurrentView,
-    isConnectedToSpot
+    isConnectedToSpot,
+    isConnectionEstablished
 } from 'common/app-state';
 import { logger } from 'common/logger';
 import { LoadingIcon, View } from 'common/ui';
@@ -31,6 +32,7 @@ export class RemoteControl extends React.PureComponent {
         events: PropTypes.array,
         history: PropTypes.object,
         isConnectedToSpot: PropTypes.bool,
+        isConnectionEstablished: PropTypes.bool,
         view: PropTypes.string
     };
 
@@ -68,7 +70,7 @@ export class RemoteControl extends React.PureComponent {
      * @returns {ReactElement}
      */
     _getView() {
-        if (!this.props.isConnectedToSpot) {
+        if (this.props.isConnectionEstablished && !this.props.isConnectedToSpot) {
             logger.log('remote-control show waiting for Spot TV');
 
             return <WaitingForSpotTVOverlay />;
@@ -108,6 +110,7 @@ function mapStateToProps(state) {
     return {
         events: getCalendarEvents(state),
         view: getCurrentView(state),
+        isConnectionEstablished: isConnectionEstablished(state),
         isConnectedToSpot: isConnectedToSpot(state)
     };
 }

--- a/spot-client/src/spot-remote/ui/views/remote-control.js
+++ b/spot-client/src/spot-remote/ui/views/remote-control.js
@@ -31,8 +31,7 @@ export class RemoteControl extends React.PureComponent {
     static propTypes = {
         events: PropTypes.array,
         history: PropTypes.object,
-        isConnectedToSpot: PropTypes.bool,
-        isConnectionEstablished: PropTypes.bool,
+        isWaitingForSpotTV: PropTypes.bool,
         view: PropTypes.string
     };
 
@@ -70,7 +69,7 @@ export class RemoteControl extends React.PureComponent {
      * @returns {ReactElement}
      */
     _getView() {
-        if (this.props.isConnectionEstablished && !this.props.isConnectedToSpot) {
+        if (this.props.isWaitingForSpotTV) {
             logger.log('remote-control show waiting for Spot TV');
 
             return <WaitingForSpotTVOverlay />;
@@ -110,8 +109,7 @@ function mapStateToProps(state) {
     return {
         events: getCalendarEvents(state),
         view: getCurrentView(state),
-        isConnectionEstablished: isConnectionEstablished(state),
-        isConnectedToSpot: isConnectedToSpot(state)
+        isWaitingForSpotTV: isConnectionEstablished(state) && !isConnectedToSpot(state)
     };
 }
 

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -339,15 +339,16 @@ export function disconnectAllTemporaryRemotes() {
 /**
  * The action kills the Spot TV remote control service connection if one exists.
  *
+ * @param {Object} [event] - Optionally, the event which triggered the necessity to disconnect.
  * @returns {Function}
  */
-export function disconnectSpotTvRemoteControl() {
+export function disconnectSpotTvRemoteControl(event) {
     return () => {
         if (!remoteControlServer.hasConnection()) {
             return Promise.resolve();
         }
 
-        return remoteControlServer.disconnect();
+        return remoteControlServer.disconnect(event);
     };
 }
 


### PR DESCRIPTION
Moves the before unload handler to index where 'destroyConnection' action can be dispatched before starting the disconnect. This allows to combine 'isConnectionEstablished' selector for the waiting for spot TV message condition(because it clears the connection established state).