### PR TITLE
UI fixes for dial pad changes and ad-hoc narrow browser

### DIFF
--- a/spot-client/src/common/css/_dial-pad.scss
+++ b/spot-client/src/common/css/_dial-pad.scss
@@ -206,6 +206,7 @@
 
                 color: #1C2025;
                 flex: 1;
+                font-size: 15px;
             }
         }
     }

--- a/spot-client/src/common/css/_meeting-name-entry.scss
+++ b/spot-client/src/common/css/_meeting-name-entry.scss
@@ -24,6 +24,11 @@
 
     .input-with-default-domain {
         display: flex;
+        flex-direction: column;
+
+        @media #{$mq-mobile-l} {
+            flex-direction: row;
+        }
 
         .default-domain {
             /**

--- a/spot-client/src/common/css/page-layouts/_waiting-view.scss
+++ b/spot-client/src/common/css/page-layouts/_waiting-view.scss
@@ -4,7 +4,8 @@
     .waiting-sub-view {
         align-items: center;
         display: flex;
-        flex: 1;
+        flex-shrink: 0;
+        flex-grow: 1;
         justify-content: center;
     }
 

--- a/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
+++ b/spot-client/src/spot-remote/ui/components/dial-pad/StatelessDialPad.js
@@ -110,13 +110,6 @@ export default class StatelessDialPad extends React.Component {
                         value = { this.props.value } />
                 </div>
                 <div className = 'dial-pad-buttons'>
-                    {
-                        this.props.showCountryCodePicker && (
-                            <div ref = { this._countryCodePickerWrapperRef }>
-                                <CountryCodePicker onCountryCodeSelect = { this.props.onCountryCodeSelect } />
-                            </div>
-                        )
-                    }
                     <div className = 'row'>
                         { this._renderDialButton('1', '') }
                         { this._renderDialButton('2', 'ABC') }
@@ -160,6 +153,15 @@ export default class StatelessDialPad extends React.Component {
                             </button>
                         </div>
                     </div>
+                    {
+                        this.props.showCountryCodePicker && (
+                            <div
+                                className = 'country-code-picker-wrapper'
+                                ref = { this._countryCodePickerWrapperRef }>
+                                <CountryCodePicker onCountryCodeSelect = { this.props.onCountryCodeSelect } />
+                            </div>
+                        )
+                    }
                 </div>
             </form>
         );


### PR DESCRIPTION
Stack the domain on top of the input so it does not push the input to be hidden.
Issue:
![Screen Shot 2019-09-24 at 11 11 57 AM](https://user-images.githubusercontent.com/1243084/65540857-12625780-dec1-11e9-9767-a7f73d5e3b5f.png)
Proposed fix:
![Screen Shot 2019-09-24 at 11 26 31 AM](https://user-images.githubusercontent.com/1243084/65540722-d202d980-dec0-11e9-839b-87a4f5a1eb2c.png)

Fix the two issues here of the country picker placeholder being a larger size and the phone icon showing over the picker.
![Screen Shot 2019-09-24 at 10 37 24 AM](https://user-images.githubusercontent.com/1243084/65540818-02e30e80-dec1-11e9-9ddb-972d840945d6.png)

Fix issue with safari where the waiting view contents were getting squashed due to flex properties.
![Screen Shot 2019-09-24 at 11 11 07 AM](https://user-images.githubusercontent.com/1243084/65540917-2d34cc00-dec1-11e9-8a97-6d83111eab39.png)
