### PR TITLE
fix(webdriver): remote in-meeting root set to loaded element

### DIFF
--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -117,7 +117,9 @@ export class InCall extends React.Component {
         const { meetingName } = parseMeetingUrl(inMeeting);
 
         return (
-            <div className = 'in-call'>
+            <div
+                className = 'in-call'
+                data-qa-id = 'in-call'>
                 <div className = 'view-header'>
                     { invitedPhoneNumber && <div className = 'in-call-invited-phone'>{ invitedPhoneNumber }</div> }
                     <div className = { invitedPhoneNumber ? 'in-call-name-with-phone' : 'in-call-name' } >

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -7,7 +7,7 @@ const AUDIO_UNMUTE_BUTTON = '[data-qa-id=unmute-audio]';
 const HANG_UP_BUTTON = '[data-qa-id=hangup]';
 const MORE_BUTTON = '[data-qa-id=more]';
 const MORE_MODAL = '[data-qa-id=more-modal]';
-const REMOTE_CONTROL = '[data-qa-id=remoteControl-view]';
+const REMOTE_CONTROL = '[data-qa-id=in-call]';
 const SKIP_FEEDBACK_BUTTON = '[data-qa-id=skip-feedback]';
 const START_SHARE_BUTTON = '[data-qa-id=start-share]';
 const STOP_SHARE_BUTTON = '[data-qa-id=stop-share]';


### PR DESCRIPTION
A potential source of test failures is the remote
in-meeting page object using the in-call page's
root as an indicator that the page is displayed,
but the page could be displaying a loading icon.
So instead set the root to be the element that
displays after loading has completed.