### PR TITLE
feat(iOS): add Crashlytics

### DIFF
--- a/spot-controller/ios/Podfile
+++ b/spot-controller/ios/Podfile
@@ -5,6 +5,10 @@ workspace 'spot-controller'
 target 'spot-controller' do
   project 'spot-controller.xcodeproj'
 
+  pod 'Crashlytics', '~> 3.12.0'
+  pod 'Fabric', '~> 1.9.0'
+  pod 'Firebase/Core', '~> 5.18.0'
+
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
       'Core',
           'CxxBridge',
@@ -31,6 +35,6 @@ target 'spot-controller' do
   pod 'ReactNativeBeaconsManager', :path => '../node_modules/react-native-beacons-manager'
   pod 'react-native-keep-awake', :path => '../node_modules/react-native-keep-awake'
   pod 'react-native-webview', :path => '../node_modules/react-native-webview'
-  
+
 
 end

--- a/spot-controller/ios/Podfile.lock
+++ b/spot-controller/ios/Podfile.lock
@@ -1,11 +1,63 @@
 PODS:
   - boost-for-react-native (1.63.0)
+  - Crashlytics (3.12.0):
+    - Fabric (~> 1.9.0)
   - DoubleConversion (1.1.6)
+  - Fabric (1.9.0)
+  - Firebase/Core (5.18.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 5.7.0)
+  - Firebase/CoreOnly (5.18.0):
+    - FirebaseCore (= 5.3.1)
+  - FirebaseAnalytics (5.7.0):
+    - FirebaseCore (~> 5.3)
+    - FirebaseInstanceID (~> 3.6)
+    - GoogleAppMeasurement (= 5.7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
+    - GoogleUtilities/Network (~> 5.2)
+    - "GoogleUtilities/NSData+zlib (~> 5.2)"
+    - nanopb (~> 0.3)
+  - FirebaseCore (5.3.1):
+    - GoogleUtilities/Logger (~> 5.2)
+  - FirebaseInstanceID (3.8.1):
+    - FirebaseCore (~> 5.2)
+    - GoogleUtilities/Environment (~> 5.2)
+    - GoogleUtilities/UserDefaults (~> 5.2)
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
     - glog
   - glog (0.3.5)
+  - GoogleAppMeasurement (5.7.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
+    - GoogleUtilities/Network (~> 5.2)
+    - "GoogleUtilities/NSData+zlib (~> 5.2)"
+    - nanopb (~> 0.3)
+  - GoogleUtilities/AppDelegateSwizzler (5.8.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (5.8.0)
+  - GoogleUtilities/Logger (5.8.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (5.8.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (5.8.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (5.8.0)"
+  - GoogleUtilities/Reachability (5.8.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (5.8.0):
+    - GoogleUtilities/Logger
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
   - React (0.59.9):
     - React/Core (= 0.59.9)
   - react-native-keep-awake (4.0.0):
@@ -70,7 +122,10 @@ PODS:
   - yoga (0.59.9.React)
 
 DEPENDENCIES:
+  - Crashlytics (~> 3.12.0)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
+  - Fabric (~> 1.9.0)
+  - Firebase/Core (~> 5.18.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - react-native-keep-awake (from `../node_modules/react-native-keep-awake`)
@@ -94,6 +149,15 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - boost-for-react-native
+    - Crashlytics
+    - Fabric
+    - Firebase
+    - FirebaseAnalytics
+    - FirebaseCore
+    - FirebaseInstanceID
+    - GoogleAppMeasurement
+    - GoogleUtilities
+    - nanopb
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -119,9 +183,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  Crashlytics: 07fb167b1694128c1c9a5a5cc319b0e9c3ca0933
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
+  Fabric: f988e33c97f08930a413e08123064d2e5f68d655
+  Firebase: 02f3281965c075426141a0ce1277e9de6649cab9
+  FirebaseAnalytics: 23851fe602c872130a2c5c55040b302120346cc2
+  FirebaseCore: 52f851b30e11360f1e67cf04b1edfebf0a47a2d3
+  FirebaseInstanceID: a122b0c258720cf250551bb2bedf48c699f80d90
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
+  GoogleAppMeasurement: 6cf307834da065863f9faf4c0de0a936d81dd832
+  GoogleUtilities: 04fce34bcd5620c1ee76fb79172105c74a4df335
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   React: a86b92f00edbe1873a63e4a212c29b7a7ad5224f
   react-native-keep-awake: eba3137546b10003361b37c761f6c429b59814ae
   react-native-webview: 048135293d160a64d329e11d52d0128c67942813
@@ -130,6 +203,6 @@ SPEC CHECKSUMS:
   RNSVG: 0eb087cfb5d7937be93c45b163b26352a647e681
   yoga: 03ff42a6f223fb88deeaed60249020d80c3091ee
 
-PODFILE CHECKSUM: 3aeee74166d0c02512992ecda68ee564a1bc65ed
+PODFILE CHECKSUM: a93e823490e3d9193aeb18b82f2c003e728738e4
 
 COCOAPODS: 1.7.2

--- a/spot-controller/ios/spot-controller.xcodeproj/project.pbxproj
+++ b/spot-controller/ios/spot-controller.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		E566902923034808000D1DF7 /* AppInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E566902823034808000D1DF7 /* AppInfo.m */; };
+		E5C8CCD2233D404800366113 /* FIRUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E5C8CCD1233D404800366113 /* FIRUtilities.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +211,8 @@
 		A58A9A976A5180AC6EE989D0 /* Pods-spot-controller.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-spot-controller.release.xcconfig"; path = "Pods/Target Support Files/Pods-spot-controller/Pods-spot-controller.release.xcconfig"; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		E566902823034808000D1DF7 /* AppInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppInfo.m; path = "spot-controller/AppInfo.m"; sourceTree = "<group>"; };
+		E5C8CCBA233D404800366113 /* FIRUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FIRUtilities.h; path = "spot-controller/FIRUtilities.h"; sourceTree = "<group>"; };
+		E5C8CCD1233D404800366113 /* FIRUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRUtilities.m; path = "spot-controller/FIRUtilities.m"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -306,6 +309,8 @@
 		13B07FAE1A68108700A75B9A /* spot-controller */ = {
 			isa = PBXGroup;
 			children = (
+				E5C8CCBA233D404800366113 /* FIRUtilities.h */,
+				E5C8CCD1233D404800366113 /* FIRUtilities.m */,
 				0E934677222F35F50005B4A5 /* spot-controller.entitlements */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -451,6 +456,8 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				E5C8CCD3233D413600366113 /* Copy Google Plist file */,
+				E53702F623395009009D0141 /* Setup Fabric */,
 			);
 			buildRules = (
 			);
@@ -793,6 +800,42 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		E53702F623395009009D0141 /* Setup Fabric */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Setup Fabric";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${PODS_ROOT}/Fabric/run\n";
+		};
+		E5C8CCD3233D413600366113 /* Copy Google Plist file */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Google Plist file";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "GOOGLE_PLIST_NAME=\"GoogleService-Info.plist\"\nGOOGLE_PLIST=\"$PROJECT_DIR/$GOOGLE_PLIST_NAME\"\nBUILD_APP_DIR=\"$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app\"\n\necho \"GOOGLE PLIST= ${GOOGLE_PLIST} BUILD DIR= ${BUILD_APP_DIR}\"\n\nif [[ -f $GOOGLE_PLIST ]]; then\n    echo \"COPY GOOGLE PLIST\"\n    cp $GOOGLE_PLIST \"$BUILD_APP_DIR/$GOOGLE_PLIST_NAME\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -809,6 +852,7 @@
 			files = (
 				E566902923034808000D1DF7 /* AppInfo.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				E5C8CCD2233D404800366113 /* FIRUtilities.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/spot-controller/ios/spot-controller/AppDelegate.m
+++ b/spot-controller/ios/spot-controller/AppDelegate.m
@@ -6,15 +6,25 @@
  */
 
 #import "AppDelegate.h"
+#import "FIRUtilities.h"
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTPushNotificationManager.h>
 #import <React/RCTRootView.h>
 
+@import Firebase;
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  // Initialize Crashlytics and Firebase if a valid GoogleService-Info.plist file was provided.
+  if ([FIRUtilities appContainsRealServiceInfoPlist]) {
+    [FIRApp configure];
+    NSLog(@"Enabling Crashlytics");
+    [Fabric with:@[[Crashlytics class]]];
+  }
+
   NSURL *jsCodeLocation;
 
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];

--- a/spot-controller/ios/spot-controller/FIRUtilities.h
+++ b/spot-controller/ios/spot-controller/FIRUtilities.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copy pasted from [1] and extracted only the Crashlytics related methods.
+// If any changes are needed make sure to sync both places.
+// [1]: https://github.com/jitsi/jitsi-meet/blob/master/ios/app/src/FIRUtilities.h
+
+#import <Foundation/Foundation.h>
+
+@interface FIRUtilities : NSObject
+
++ (BOOL)appContainsRealServiceInfoPlist;
+
+@end

--- a/spot-controller/ios/spot-controller/FIRUtilities.m
+++ b/spot-controller/ios/spot-controller/FIRUtilities.m
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copy pasted from [1] and extracted only the Crashlytics related methods.
+// If any changes are needed make sure to sync both places.
+// [1]: https://github.com/jitsi/jitsi-meet/blob/master/ios/app/src/FIRUtilities.h
+
+
+#import "FIRUtilities.h"
+
+// Plist file name.
+NSString *const kGoogleServiceInfoFileName = @"GoogleService-Info";
+// Plist file type.
+NSString *const kGoogleServiceInfoFileType = @"plist";
+NSString *const kGoogleAppIDPlistKey = @"GOOGLE_APP_ID";
+
+
+@implementation FIRUtilities
+
++ (BOOL)appContainsRealServiceInfoPlist {
+  static BOOL containsRealServiceInfoPlist = NO;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSBundle *bundle = [NSBundle mainBundle];
+    containsRealServiceInfoPlist = [self containsRealServiceInfoPlistInBundle:bundle];
+  });
+  return containsRealServiceInfoPlist;
+}
+
++ (BOOL)containsRealServiceInfoPlistInBundle:(NSBundle *)bundle {
+  NSString *bundlePath = bundle.bundlePath;
+  if (!bundlePath.length) {
+    return NO;
+  }
+  
+  NSString *plistFilePath = [bundle pathForResource:kGoogleServiceInfoFileName
+                                             ofType:kGoogleServiceInfoFileType];
+  if (!plistFilePath.length) {
+    return NO;
+  }
+  
+  NSDictionary *plist = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
+  if (!plist) {
+    return NO;
+  }
+  
+  // Perform a very naive validation by checking to see if the plist has the dummy google app id
+  NSString *googleAppID = plist[kGoogleAppIDPlistKey];
+  if (!googleAppID.length) {
+    return NO;
+  }
+  
+  return YES;
+}
+
+@end


### PR DESCRIPTION
The GoogleService-Info.plist file must be placed in spot-controller/ios dir in order to enable Crashlytics reporting.