### PR TITLE
fix(backend): return NOT_AUTHORIZED in special conditions

### DIFF
--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -94,11 +94,14 @@ function fetchWithRetry(fetchOptions, maxRetries = 3) {
                         requestId: requestOptions.headers.get('request-id')
                     });
 
-                    if (response.status === 401) {
+                    const { status: httpStatusCode } = response;
+
+                    if (httpStatusCode === 401
+                        || (httpStatusCode === 400 && json?.messageKey === 'pairing.code.not.found')) {
                         reject(errorConstants.NOT_AUTHORIZED);
 
                         return;
-                    } else if (response.status < 500 || response.status >= 600) {
+                    } else if (httpStatusCode < 500 || httpStatusCode >= 600) {
                         // Break the retry chain early
                         reject(errorConstants.REQUEST_FAILED);
 


### PR DESCRIPTION
On 400 status code and if 'pairing.code.not.found' messageKey is present it means that the pairing code is invalid.