### PR TITLE
ref(spot-electron/app menu): use dynamic product name

### DIFF
--- a/spot-electron/src/application-menu/applicationmenu.js
+++ b/spot-electron/src/application-menu/applicationmenu.js
@@ -1,8 +1,8 @@
-const { Menu } = require('electron');
+const { app, Menu } = require('electron');
 const isDev = require('electron-is-dev');
 const process = require('process');
 
-const { productName } = require('../../package.json');
+const productName = app.getName();
 
 /**
  * Generates the configuration for the menu items to display in the app toolbar.


### PR DESCRIPTION
If product name is overridden on build time then app.getName() method should be used instead of reading from the package.json directly.