### PR TITLE
Optimize for simpler backgrounds

### DIFF
--- a/spot-client/index.html
+++ b/spot-client/index.html
@@ -5,7 +5,7 @@
     <meta name = "viewport" content = "width=device-width, initial-scale=1.0">
     <style>
         body {
-            background-color: rgb(7, 71, 166);
+            background-color: #1C2025;
         }
     </style>
 </head>

--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -12,6 +12,7 @@ import {
 import { logger } from 'common/logger';
 import { ROUTES } from 'common/routing';
 import {
+    Background,
     ErrorBoundary,
     FatalError,
     FeedbackOpener,
@@ -147,7 +148,7 @@ export class App extends React.Component {
                 <IdleCursorDetector
                     onCursorIdleChange = { this._onCursorIdleChange }>
                     <div className = { rootClassName }>
-
+                        <Background />
                         <Notifications />
                         <Switch>
                             {

--- a/spot-client/src/common/css/_background.scss
+++ b/spot-client/src/common/css/_background.scss
@@ -1,7 +1,10 @@
 
 .view-background-container {
-    background-position: center;
-    background-size: cover;
+    /**
+     * !important to override inline styles for setting the dynamic background.
+     */
+    background-position: center !important;
+    background-size: cover !important;
     flex-grow: 1;
     height: 100vh;
     opacity: 0.3;
@@ -13,7 +16,7 @@
 
 .view-gradient {
     align-items: center;
-    background-image: linear-gradient(180deg, rgba(28, 32, 37, 0) 0%, #1C2025 100%);
+    background-image: linear-gradient(180deg, rgba(28, 32, 37, 0) 0%, var(--backdrop-color) 100%);
     background-size: cover;
     display: flex;
     flex-grow: 1;

--- a/spot-client/src/common/css/_background.scss
+++ b/spot-client/src/common/css/_background.scss
@@ -1,0 +1,23 @@
+
+.view-background-container {
+    background-position: center;
+    background-size: cover;
+    flex-grow: 1;
+    height: 100vh;
+    opacity: 0.3;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100vw;
+}
+
+.view-gradient {
+    align-items: center;
+    background-image: linear-gradient(180deg, rgba(28, 32, 37, 0) 0%, #1C2025 100%);
+    background-size: cover;
+    display: flex;
+    flex-grow: 1;
+    min-height: 100vh;
+    justify-content: center;
+    width: 100%;
+}

--- a/spot-client/src/common/css/_code-entry.scss
+++ b/spot-client/src/common/css/_code-entry.scss
@@ -14,9 +14,9 @@
          */
         box-sizing: initial;
 
-        background-color: var(--container-bg-color);
-        border: 1px solid var(--container-sub-content-font-color);
-        border-radius: 5px;
+        background: rgba(255, 255, 255, 0.2);
+        border: 2px solid #FFFFFF;
+        border-radius: 4px;
         color: var(--container-content-font-color);
         font-size: $font-size-x-large;
         height: calc(#{$font-size-x-large} * 0.7);
@@ -27,8 +27,9 @@
         width: calc(#{$font-size-x-large} * 0.5);
 
         &.focused {
-            border-color: var(--active);
-            box-shadow: 0px 0px 0px 5px var(--active);
+            background: rgba(2, 98, 182, 0.4);
+            border: 2px solid #0376DA;
+            box-shadow: 0px 0px 0px 5px #0376DA;
 
             /**
              * Set appearance none because the boxes are in a form and mobile

--- a/spot-client/src/common/css/_dial-pad.scss
+++ b/spot-client/src/common/css/_dial-pad.scss
@@ -228,6 +228,10 @@
 }
 
 .dtmf-modal {
+    .dial-pad {
+        background-color: transparent;
+    }
+
     .country-search-trigger,
     .dial-pad-footer {
         display: none;

--- a/spot-client/src/common/css/_home-view.scss
+++ b/spot-client/src/common/css/_home-view.scss
@@ -46,8 +46,12 @@
         }
     }
 
+    .calendar-content {
+        border-top: var(--separator-border);
+        border-bottom: var(--separator-border);
+    }
+
     .no-events-message {
-        background-color: var(--container-content-bg-color);
         color: var(--container-sub-content-font-color);
         padding: 3em;
         text-align: center;

--- a/spot-client/src/common/css/_meeting-name-entry.scss
+++ b/spot-client/src/common/css/_meeting-name-entry.scss
@@ -1,8 +1,8 @@
 .meeting-name-entry {
-    background-color: var(--container-content-bg-color);
+    background-color: var(--container-bg-color);
     border-radius: 5px;
     display: flex;
-    padding: 1.2em 2.5em;
+    padding: 20px;
     width: 80%;
 
     @media #{$mq-laptop} {

--- a/spot-client/src/common/css/_meeting.scss
+++ b/spot-client/src/common/css/_meeting.scss
@@ -1,5 +1,5 @@
 .meeting {
-    background-color: var(--container-content-bg-color);
+    background-color: var(--container-bg-color);
     cursor: pointer;
     display: flex;
 

--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -16,7 +16,9 @@
     }
 
     .modal-content {
-        background-color: var(--container-content-bg-color-no-opacity);
+        background:  var(--container-bg-color-fallback);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
         height: 100%;
         max-height: 100vh;
         overflow: auto;
@@ -29,6 +31,14 @@
             height: auto;
             margin: 50px;
             width: unset;
+        }
+
+        .fallback-background {
+            height: 100%;
+            width: 100%;
+            opacity: 0.9;
+            position: absolute;
+            top: 0;
         }
 
         .close {
@@ -48,12 +58,16 @@
 }
 
 .modal-content {
-    background-color: var(--modal-bg-color);
+    background-color: var(--container-bg-color);
     border-radius: 5px;
     display: flex;
     justify-content: center;
-    padding: 40px;
+    padding: 40px 20px;
     max-height: calc(100vh - 40px);
     min-height: 300px;
     width: 100%;
+
+    & > *:last-child {
+        position: relative;
+    }
 }

--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -5,10 +5,15 @@
 .screenshare-select {
     @include centered-content;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: center;
     min-width: 360px;
+    padding: 0 20px;
     text-align: center;
     width: 100%;
+
+    @media #{$mq-tablet} {
+        justify-content: space-between;
+    }
 
     .options {
         display: flex;

--- a/spot-client/src/common/css/_temp.scss
+++ b/spot-client/src/common/css/_temp.scss
@@ -101,16 +101,6 @@ body.using-mouse :focus {
   width: 100%;
 }
 
-.view-background-container {
-    background-position: center;
-    background-size: cover;
-    height: 100vh;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    width: 100vw;
-}
-
 .view-content-container {
     height: 100vh;
     overflow: auto;
@@ -123,20 +113,6 @@ body.using-mouse :focus {
         justify-content: center;
         min-height: 100vh;
     }
-}
-
-.view-gradient {
-  align-items: center;
-  background-size: cover;
-  display: flex;
-  min-height: 100vh;
-  justify-content: center;
-  width: 100%;
-}
-
-.view-gradient.visible {
-  background-image: linear-gradient(to bottom, #020f1b, rgba(0, 0, 0, 0) 30%), linear-gradient(to bottom, rgba(2, 15, 27, 0) 50%, #020f1b);
-  flex-grow: 1;
 }
 
 .app {

--- a/spot-client/src/common/css/_theme-variables.scss
+++ b/spot-client/src/common/css/_theme-variables.scss
@@ -1,6 +1,7 @@
 :root {
     --active: rgba(37, 138, 255, 0.9);
 
+    --backdrop-color: #1C2025;
     --button-color: rgba(37, 138, 255);
     --button-active-color: #0074e0;
     --button-opaque: rgba(0, 0, 0, 0.5);
@@ -9,7 +10,8 @@
     --call-button-active: #005C3A;
     --code-font: 'Roboto mono';
 
-    --container-bg-color: rgba(42, 58, 75, 0.7);
+    --container-bg-color: rgba(28, 32, 37, 0.5);
+    --container-bg-color-fallback: rgba(28, 32, 37, 1);
     --container-content-bg-color: rgba(42, 58, 75, 0.9);
     --container-content-bg-color-no-opacity: rgb(42, 58, 75);
     --container-content-font-color: #ffffff;
@@ -29,6 +31,7 @@
     --select-background-color:rgb(82, 97, 118);
     --secondary-link-color: #8fc3f0;
     --secondary-white: #d1dbe8;
+    --separator-border: 1px solid rgba(255, 255, 255, .2);
 
     --mic-preview-active-background-color: rgba(39, 119, 235, 1);
     --mic-preview-background-color: rgba(250, 250, 250, 0.38);

--- a/spot-client/src/common/css/index.scss
+++ b/spot-client/src/common/css/index.scss
@@ -23,6 +23,7 @@
 @import './page-layouts/waiting-view.scss';
 
 @import './admin-toolbar.scss';
+@import './background.scss';
 @import './button.scss';
 @import './clock.scss';
 @import './code-entry.scss';

--- a/spot-client/src/common/css/page-layouts/_feedback-view.scss
+++ b/spot-client/src/common/css/page-layouts/_feedback-view.scss
@@ -7,7 +7,12 @@
 }
 
 .app-feedback-overlay.status-overlay {
+    background: #1C2025;
     z-index: $z-index-above-all;
+
+    * {
+        z-index: $z-index-above-all;
+    }
 
     .feedback-form {
         margin-top: 5%

--- a/spot-client/src/common/css/page-layouts/_share.scss
+++ b/spot-client/src/common/css/page-layouts/_share.scss
@@ -13,7 +13,6 @@
         margin: 50px 0;
 
         .selection {
-            background-color: var(--container-content-bg-color);
             border-radius: 5px;
 
             .nav-button {

--- a/spot-client/src/common/css/page-layouts/_status-overlay.scss
+++ b/spot-client/src/common/css/page-layouts/_status-overlay.scss
@@ -1,10 +1,5 @@
 .status-overlay {
-    background: rgb(27, 38, 56);
-
-    &.transparent {
-        background: none;
-    }
-
+    background: var(--backdrop-color);
     height: 100vh;
     left: 0;
     position: absolute;
@@ -15,7 +10,7 @@
     .status-overlay-text-frame {
         display: block;
         width: 55%;
-        background-color: var(--container-content-bg-color);
+        background-color: var(--container-bg-color);
         border-radius: 5px;
         color: var(--container-sub-content-font-color);
         padding: 3em;

--- a/spot-client/src/common/css/page-layouts/_status-overlay.scss
+++ b/spot-client/src/common/css/page-layouts/_status-overlay.scss
@@ -1,5 +1,10 @@
 .status-overlay {
     background: rgb(27, 38, 56);
+
+    &.transparent {
+        background: none;
+    }
+
     height: 100vh;
     left: 0;
     position: absolute;

--- a/spot-client/src/common/css/page-layouts/spot-tv/_admin.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_admin.scss
@@ -1,6 +1,6 @@
 .admin-entry {
     align-items: center;
-    background-color: var(--container-content-bg-color);
+    border-top: var(--separator-border);
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -17,5 +17,9 @@
 
     .pairing-code {
         @include join-code;
+    }
+
+    &:last-child {
+        border-bottom: var(--separator-border);
     }
 }

--- a/spot-client/src/common/css/page-layouts/spot-tv/_setup-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_setup-view.scss
@@ -48,6 +48,7 @@
     .columns {
         display: flex;
         margin-top: 10px;
+        padding: 0 20px;
 
         .column {
             display: flex;

--- a/spot-client/src/common/ui/components/background/Background.js
+++ b/spot-client/src/common/ui/components/background/Background.js
@@ -16,7 +16,7 @@ export function Background({ backgroundUrl }) {
 
     if (backgroundUrl) {
         backgroundStyles = {
-            background: `linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0) 89%), url('${backgroundUrl}')`
+            background: `linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0) 100%), url('${backgroundUrl}')`
         };
     }
 

--- a/spot-client/src/common/ui/components/background/Background.js
+++ b/spot-client/src/common/ui/components/background/Background.js
@@ -16,17 +16,15 @@ export function Background({ backgroundUrl }) {
 
     if (backgroundUrl) {
         backgroundStyles = {
-            backgroundImage: `url('${backgroundUrl}')`
+            background: `linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0) 89%), url('${backgroundUrl}')`
         };
     }
-
-    const gradientStyle = `view-gradient ${backgroundStyles ? 'visible' : ''}`;
 
     return (
         <div
             className = 'view-background-container'
             style = { backgroundStyles }>
-            <div className = { gradientStyle } />
+            <div className = 'view-gradient' />
         </div>
     );
 }

--- a/spot-client/src/common/ui/components/feedback/FeedbackOverlay.js
+++ b/spot-client/src/common/ui/components/feedback/FeedbackOverlay.js
@@ -9,6 +9,8 @@ import {
     submitFeedback
 } from 'common/app-state';
 
+import { Background } from '../background';
+
 import { FeedbackForm } from './FeedbackForm';
 
 /**
@@ -26,6 +28,7 @@ export function FeedbackOverlay(props) {
 
     return (
         <div className = 'feedback-view status-overlay app-feedback-overlay'>
+            <Background />
             <div className = 'feedback-form'>
                 <FeedbackForm
                     commentOnly = { true }

--- a/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
+++ b/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Background } from './../background';
-
 /**
  * Displays a status message while covering the entire screen.
  *
@@ -12,8 +10,7 @@ import { Background } from './../background';
  */
 export function StatusOverlay(props) {
     return (
-        <div className = 'status-overlay'>
-            { props.showBackground && <Background /> }
+        <div className = { `status-overlay ${props.showBackground ? 'transparent' : ''}` }>
             <div className = 'status-overlay-text-frame'>
                 <h1>{ props.title }</h1>
                 <div className = 'status-overlay-text'>

--- a/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
+++ b/spot-client/src/common/ui/components/status-overlay/StatusOverlay.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { Background } from '../background';
+
 /**
  * Displays a status message while covering the entire screen.
  *
@@ -10,7 +12,8 @@ import React from 'react';
  */
 export function StatusOverlay(props) {
     return (
-        <div className = { `status-overlay ${props.showBackground ? 'transparent' : ''}` }>
+        <div className = 'status-overlay'>
+            <Background />
             <div className = 'status-overlay-text-frame'>
                 <h1>{ props.title }</h1>
                 <div className = 'status-overlay-text'>

--- a/spot-client/src/common/ui/views/view.js
+++ b/spot-client/src/common/ui/views/view.js
@@ -44,7 +44,6 @@ class View extends React.Component {
             <div
                 className = { className }
                 data-qa-id = { `${this.props.name}-view` }>
-                <Background />
                 {
 
                     /**

--- a/spot-client/src/common/ui/views/view.js
+++ b/spot-client/src/common/ui/views/view.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { isAnyModalOpen } from 'common/app-state';
 import { logger } from 'common/logger';
 
-import { Background } from '../components';
 import { viewDisplayed } from '../actions';
 
 /**

--- a/spot-client/src/spot-remote/ui/components/dtmf/DTMFButton.js
+++ b/spot-client/src/spot-remote/ui/components/dtmf/DTMFButton.js
@@ -14,7 +14,7 @@ import { NavButton } from '../nav';
 export class DTMFButton extends React.Component {
     static propTypes = {
         onClick: PropTypes.func,
-        t: PropTypes.funcs
+        t: PropTypes.func
     };
 
     /**

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/KickedOverlay.test.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/KickedOverlay.test.js
@@ -1,5 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 
 import { mockT } from 'common/test-mocks';
 
@@ -10,11 +12,14 @@ describe('KickedOverlay', () => {
         jest.useFakeTimers();
 
         const callback = jest.fn();
+        const store = createStore((state = { config: {} }) => state);
 
         mount(
-            <KickedOverlay
-                onRedirect = { callback }
-                t = { mockT } />
+            <Provider store = { store }>
+                <KickedOverlay
+                    onRedirect = { callback }
+                    t = { mockT } />
+            </Provider>
         );
 
         jest.runAllTimers();

--- a/spot-client/src/spot-tv/ui/views/home.js
+++ b/spot-client/src/spot-tv/ui/views/home.js
@@ -118,7 +118,9 @@ export class Home extends React.Component {
                     <div className = 'room-name'>
                         { spotRoomName && <div>{ spotRoomName }</div> }
                     </div>
-                    { this._getCalendarEventsView() }
+                    <div className = 'calendar-content'>
+                        { this._getCalendarEventsView() }
+                    </div>
                     {
                         _isSetupComplete
                             && <div className = 'spot-home-footer'>


### PR DESCRIPTION
Note: per designs there are a lot more gradients applied to the background, which will make other configured backgrounds look kind of dark. If needed, I can add some variables for branding some of these values.

<img width="1300" alt="Screen Shot 2019-10-14 at 10 11 06 AM" src="https://user-images.githubusercontent.com/1243084/66769978-56ff6400-ee6b-11e9-8f5a-02c66e820acd.png">
<img width="1300" alt="Screen Shot 2019-10-14 at 10 12 43 AM" src="https://user-images.githubusercontent.com/1243084/66769985-5cf54500-ee6b-11e9-8f87-d6edab3699cf.png">
<img width="1300" alt="Screen Shot 2019-10-14 at 10 12 48 AM" src="https://user-images.githubusercontent.com/1243084/66769988-5f579f00-ee6b-11e9-872c-c5d4002656c9.png">
<img width="1300" alt="Screen Shot 2019-10-14 at 10 12 49 AM" src="https://user-images.githubusercontent.com/1243084/66769993-61216280-ee6b-11e9-937c-da70cc9dc7e7.png">
<img width="1300" alt="Screen Shot 2019-10-14 at 10 12 53 AM" src="https://user-images.githubusercontent.com/1243084/66769999-62eb2600-ee6b-11e9-97e8-a639165c6ccf.png">
<img width="1300" alt="Screen Shot 2019-10-14 at 10 13 12 AM" src="https://user-images.githubusercontent.com/1243084/66770005-654d8000-ee6b-11e9-8075-8ffe41ac03cb.png">
