### PR TITLE
fix(meeting): enqueue touch tones

### DIFF
--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -243,6 +243,16 @@ export default {
      */
     TEMPORARY_FEATURE_FLAGS: {
         /**
+         * A temporary workaround to touch tones playing too close to each other
+         * and being interpreted as one tone. The value is the minimum pause
+         * duration between each tone played. Setting this value to a falsy
+         * value will disable throttling. Set to a negative number will disable.
+         *
+         * @type {number}
+         */
+        DTMF_THROTTLE_RATE: 250,
+
+        /**
          * Whether or the note feature for inviting participants to a conference
          * is available.
          */
@@ -250,7 +260,7 @@ export default {
 
         /**
          * Spot-TV should kick temporary remotes after a successfully joined
-         * meeting has neded.
+         * meeting has needed.
          *
          * @type {boolean}
          */

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -89,6 +89,16 @@ export function getDesktopSharingFramerate(state) {
 }
 
 /**
+ * A selector which returns the pause interval between playing DTMF.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {number}
+ */
+export function getDtmfThrottleRate(state) {
+    return state.config.TEMPORARY_FEATURE_FLAGS.DTMF_THROTTLE_RATE;
+}
+
+/**
  * A selector which returns the URL for loading the Jitsi Meet External Api.
  *
  * @param {Object} state - The Redux state.
@@ -258,7 +268,6 @@ export function getUpdateEndHour(state) {
 export function shouldKickTemporaryRemotes(state) {
     return state.config.TEMPORARY_FEATURE_FLAGS.KICK_TEMPORARY_REMOTES;
 }
-
 
 /**
  * A selector which returns whether or not to display on the remote an option

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -7,6 +7,7 @@ import {
     getAvatarUrl,
     getDesktopSharingFramerate,
     getDisplayName,
+    getDtmfThrottleRate,
     getInMeetingStatus,
     getJitsiAppName,
     getJwt,
@@ -48,6 +49,7 @@ export class Meeting extends React.Component {
         defaultMeetingDomain: PropTypes.string,
         disconnectAllTemporaryRemotes: PropTypes.func,
         displayName: PropTypes.string,
+        dtmfThrottleRate: PropTypes.number,
         history: PropTypes.object,
         jitsiAppName: PropTypes.string,
         jwt: PropTypes.string,
@@ -135,6 +137,7 @@ export class Meeting extends React.Component {
         const {
             avatarUrl,
             displayName,
+            dtmfThrottleRate,
             jitsiAppName,
             jwt,
             maxDesktopSharingFramerate,
@@ -153,6 +156,7 @@ export class Meeting extends React.Component {
                 <MeetingFrame
                     avatarUrl = { avatarUrl }
                     displayName = { displayName }
+                    dtmfThrottleRate = { dtmfThrottleRate }
                     invites = { invites }
                     jitsiAppName = { jitsiAppName }
                     jwt = { this._useJwt ? jwt : undefined }
@@ -325,6 +329,7 @@ function mapStateToProps(state) {
         avatarUrl: getAvatarUrl(state),
         defaultMeetingDomain: getDefaultMeetingDomain(state),
         displayName: getDisplayName(state),
+        dtmfThrottleRate: getDtmfThrottleRate(state),
         jitsiAppName: getJitsiAppName(state),
         jwt: getJwt(state),
         jwtDomains: getJwtDomains(state),


### PR DESCRIPTION
As a workaround to prevent voximplaint from
registering two consective same numbers as
being one number.

This is intended to be a temporary workaround.
This limiting should be handled on the ljm
side and voximplant side.