### PR TITLE
chore(config): set DTMF_THROTTLE_RATE to 500ms

### DIFF
--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -250,7 +250,7 @@ export default {
          *
          * @type {number}
          */
-        DTMF_THROTTLE_RATE: 250,
+        DTMF_THROTTLE_RATE: 500,
 
         /**
          * Whether or the note feature for inviting participants to a conference


### PR DESCRIPTION
The default time for DTMF tone and pause are 200ms which comes to
the total of 400ms required to finish one sequence. It's been observed
that 3 consecutive tones work better with 500ms than 250ms.