### PR TITLE
JIT-3074: new screenshare type picker designs

### DIFF
--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -64,7 +64,7 @@
     justify-content: center;
     padding: 40px 20px;
     max-height: calc(100vh - 40px);
-    min-height: 300px;
+    min-height: 256px;
     width: 100%;
 
     & > *:last-child {

--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -7,16 +7,36 @@
     flex-direction: column;
     justify-content: center;
     min-width: 360px;
-    padding: 0 20px;
     text-align: center;
     width: 100%;
+
+    @media #{$mq-tablet} {
+        width: 450px;
+    }
+
+    @media #{$mq-laptop-l} {
+        width: 500px;
+    }
+
+    .title {
+        padding: 20px 0px;
+    }
+
+    .content {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        justify-content: center;
+    }
 
     @media #{$mq-tablet} {
         justify-content: space-between;
     }
 
     .options {
+        align-items: center;
         display: flex;
+        flex: 1;
         justify-content: space-around;
         width: 100%;
     }
@@ -31,23 +51,33 @@
 
     .cta-button {
         display: block;
-        font-size: $font-size-small;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 10px;
-        padding: 0.3em 1em;
+        font-size: 12px;
+    }
+
+    .footer,
+    .share-url {
+        align-items: center;
+        display: flex;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+        height: 80px;
+        justify-content: center;
+        width: 100%;
     }
 
     .share-url {
-        color: var(--secondary-link-color);
-        font-size: $font-size-medium-plus;
-        font-weight: bold;
-        margin-top: 1em;
+        font-size: 24px;
+        font-weight: 600;
+        line-height: 32px;
     }
 
-    .subtitle {
-        font-size: $font-size-small;
+    .sub-description {
+        font-size: 12px;;
         margin-top: 10px;
+    }
+
+    .description {
+        font-size: 15px;
+        line-height: 24px;
     }
 }
 
@@ -57,4 +87,7 @@
     height: 16px;
     border: solid 2px #ffffff;
     background-color: #31b76a;
+}
+.modal.screenshare .modal-content {
+    padding: 0;
 }

--- a/spot-client/src/common/css/_screenshare.scss
+++ b/spot-client/src/common/css/_screenshare.scss
@@ -11,26 +11,18 @@
     width: 100%;
 
     @media #{$mq-tablet} {
-        width: 450px;
-    }
-
-    @media #{$mq-laptop-l} {
         width: 500px;
     }
 
     .title {
+        font-size: 19px;
         padding: 20px 0px;
     }
 
     .content {
         display: flex;
-        flex: 1;
         flex-direction: column;
         justify-content: center;
-    }
-
-    @media #{$mq-tablet} {
-        justify-content: space-between;
     }
 
     .options {
@@ -51,33 +43,37 @@
 
     .cta-button {
         display: block;
-        font-size: 12px;
+        font-size: 19px;
     }
 
     .footer,
     .share-url {
         align-items: center;
         display: flex;
-        border-top: 1px solid rgba(255, 255, 255, 0.2);
-        height: 80px;
+        padding: 24px;
         justify-content: center;
         width: 100%;
     }
 
+    .with-share-url {
+        flex: 1;
+    }
+
     .share-url {
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
         font-size: 24px;
         font-weight: 600;
         line-height: 32px;
     }
 
     .sub-description {
-        font-size: 12px;;
+        font-size: 15px;
+        line-height: 24px;
         margin-top: 10px;
     }
 
     .description {
-        font-size: 15px;
-        line-height: 24px;
+        font-size: 19px;
     }
 }
 

--- a/spot-client/src/common/css/page-layouts/_share.scss
+++ b/spot-client/src/common/css/page-layouts/_share.scss
@@ -8,7 +8,8 @@
     flex-direction: column;
     justify-content: center;
 
-    .title {
+    .title,
+    .description {
         font-size: $font-size-large;
         text-align: center;
     }

--- a/spot-client/src/common/css/page-layouts/_waiting-view.scss
+++ b/spot-client/src/common/css/page-layouts/_waiting-view.scss
@@ -58,6 +58,7 @@
         @include centered-content;
         align-items: initial;
         margin: auto;
+        padding: 0;
         width: 100%;
 
         @media #{$mq-tablet} {

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -114,7 +114,6 @@
         "startManual": "If sharing doesn't start automatically click start sharing below.",
         "stopSharing": "Stop sharing",
         "stopWired": "To stop sharing content unplug the cable or click stop sharing.",
-        "stopWireless": "You can stop the wireless sharing below.",
         "windowType": "Window",
         "wired": "HDMI screensharing",
         "wireless": "Wireless screensharing"

--- a/spot-client/src/common/ui/components/modal/Modal.js
+++ b/spot-client/src/common/ui/components/modal/Modal.js
@@ -29,6 +29,7 @@ export default class Modal extends React.PureComponent {
                 data-qa-id = { this.props.qaId }>
                 <div className = 'modal-shroud' />
                 <div className = 'modal-content'>
+                    { this.props.children }
                     { onClose && <button
                         className = 'close'
                         data-qa-id = 'modal-close'
@@ -36,7 +37,6 @@ export default class Modal extends React.PureComponent {
                         type = 'button'>
                         x
                     </button> }
-                    { this.props.children }
                 </div>
             </div>
         );

--- a/spot-client/src/spot-remote/ui/components/more/VolumeModal.js
+++ b/spot-client/src/spot-remote/ui/components/more/VolumeModal.js
@@ -24,12 +24,6 @@ export class VolumeModal extends React.Component {
             <div className = 'modal'>
                 <div className = 'modal-shroud' />
                 <div className = 'modal-content'>
-                    <button
-                        className = 'close'
-                        onClick = { this.props.onClose }
-                        type = 'button'>
-                        x
-                    </button>
                     <div className = 'volume-modal'>
                         <VolumeButton type = 'up' />
                         <span>
@@ -37,6 +31,12 @@ export class VolumeModal extends React.Component {
                         </span>
                         <VolumeButton type = 'down' />
                     </div>
+                    <button
+                        className = 'close'
+                        onClick = { this.props.onClose }
+                        type = 'button'>
+                        x
+                    </button>
                 </div>
             </div>
         );

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreenshareModal.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreenshareModal.js
@@ -50,7 +50,9 @@ export class ScreenshareModal extends React.Component {
      */
     render() {
         return (
-            <Modal onClose = { this.props.onHideModal }>
+            <Modal
+                onClose = { this.props.onHideModal }
+                rootClassName = 'screenshare'>
                 <ScreensharePicker
                     onStartWiredScreenshare
                         = { this.props.onStartWiredScreenshare }

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -245,7 +245,7 @@ export class ScreensharePicker extends React.Component {
         let ctaTitle;
 
         if (isWirelessScreensharing) {
-            ctaTitle = 'screenshare.stopWireless';
+            ctaTitle = null;
         } else if (screensharingType === 'device') {
             ctaTitle = 'screenshare.stopWired';
         } else {
@@ -261,13 +261,13 @@ export class ScreensharePicker extends React.Component {
                     <div className = 'description'>
                         { t('screenshare.isSharing') }
                     </div>
-                    <div className = 'sub-description'>
+                    { ctaTitle && <div className = 'sub-description'>
                         { t(ctaTitle) }
-                    </div>
+                    </div> }
                 </div>
                 <div className = 'footer'>
                     <Button
-                        appearance = 'subtle-danger'
+                        appearance = 'subtle'
                         className = 'cta-button'
                         onClick = { onStopScreensharing }
                         qaId = 'stop-share-button'>
@@ -290,7 +290,7 @@ export class ScreensharePicker extends React.Component {
 
         return (
             <>
-                <div className = 'content'>
+                <div className = 'content with-share-url'>
                     <div className = 'icon'>
                         <i className = 'material-icons'>
                             wireless_screen_share

--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreensharePicker.js
@@ -208,10 +208,10 @@ export class ScreensharePicker extends React.Component {
                     <div className = 'icon'>
                         <i className = 'material-icons'>wired_screen_share</i>
                     </div>
-                    <div className = 'title'>
+                    <div className = 'description'>
                         { t('screenshare.plugWired') }
                     </div>
-                    <div className = 'subtitle'>
+                    <div className = 'sub-description'>
                         { t('screenshare.startManual') }
                     </div>
                 </div>
@@ -258,10 +258,10 @@ export class ScreensharePicker extends React.Component {
                     <div className = 'icon'>
                         <i className = 'material-icons'>{ icon }</i>
                     </div>
-                    <div className = 'title'>
+                    <div className = 'description'>
                         { t('screenshare.isSharing') }
                     </div>
-                    <div className = 'subtitle'>
+                    <div className = 'sub-description'>
                         { t(ctaTitle) }
                     </div>
                 </div>
@@ -296,13 +296,13 @@ export class ScreensharePicker extends React.Component {
                             wireless_screen_share
                         </i>
                     </div>
-                    <div className = 'title'>
+                    <div className = 'description'>
                         { t('screenshare.howToWireless') }
                     </div>
-                    <div className = 'share-url'>
-                        { `${shareDomain || windowHandler.getBaseUrl()}/` }
-                        <RemoteJoinCode />
-                    </div>
+                </div>
+                <div className = 'share-url'>
+                    { `${shareDomain || windowHandler.getBaseUrl()}/` }
+                    <RemoteJoinCode />
                 </div>
             </>
         );


### PR DESCRIPTION
<img width="1110" alt="Screen Shot 2019-10-29 at 9 31 07 AM" src="https://user-images.githubusercontent.com/1243084/67788338-5ea83680-fa2f-11e9-8087-d6d8d2cfa205.png">
<img width="1110" alt="Screen Shot 2019-10-29 at 9 31 10 AM" src="https://user-images.githubusercontent.com/1243084/67788361-6962cb80-fa2f-11e9-8e25-ef4d39e64617.png">

<img width="1110" alt="Screen Shot 2019-10-29 at 9 30 45 AM" src="https://user-images.githubusercontent.com/1243084/67788253-3ddfe100-fa2f-11e9-8af1-06baad45c59b.png">


<img width="1110" alt="Screen Shot 2019-10-29 at 9 30 53 AM" src="https://user-images.githubusercontent.com/1243084/67788226-33254c00-fa2f-11e9-8fc5-512f3983f587.png">
<img width="1110" alt="Screen Shot 2019-10-29 at 9 30 42 AM" src="https://user-images.githubusercontent.com/1243084/67788166-0ffa9c80-fa2f-11e9-9646-c75e2698e078.png">

<img width="1110" alt="Screen Shot 2019-10-29 at 9 30 47 AM" src="https://user-images.githubusercontent.com/1243084/67788243-39b3c380-fa2f-11e9-94e9-0cd40f4daf16.png">
