### PR TITLE
feat(meeting): add a button to cancel a meeting join in progress

### DIFF
--- a/spot-client/src/common/css/_conference-status-notice.scss
+++ b/spot-client/src/common/css/_conference-status-notice.scss
@@ -1,4 +1,4 @@
-.kicked-notice {
+.conference-status-notice {
     align-items: center;
     display: flex;
     flex-direction: column;

--- a/spot-client/src/common/css/index.scss
+++ b/spot-client/src/common/css/index.scss
@@ -27,6 +27,7 @@
 @import './button.scss';
 @import './clock.scss';
 @import './code-entry.scss';
+@import './conference-status-notice.scss';
 @import './desktop-picker.scss';
 @import './dial-pad.scss';
 @import './electron.scss';
@@ -35,7 +36,6 @@
 @import './idle-cursor.scss';
 @import './input.scss';
 @import './join_info.scss';
-@import './kicked_notice.scss';
 @import './loading-icon';
 @import './meeting.scss';
 @import './meeting-name-entry.scss';

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -71,7 +71,8 @@
         "howToEnterPassword": "You can use the remote control device to submit a password.",
         "kicked": "You have been removed from the conference.",
         "password": "Password",
-        "passwordRequired": "Password required to join."
+        "passwordRequired": "Password required to join.",
+        "slowJoin": "The conference is taking a while to join. Cancel?"
     },
     "countdown": {
         "timeLeft": "{{ count }} second",

--- a/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
+++ b/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+
+import { Button } from 'common/ui';
+
+/**
+ * Displays a prompt to immediately stop trying to join a meeting.
+ */
+export class CancelMeetingPrompt extends React.Component {
+    static propTypes = {
+        onSubmit: PropTypes.func,
+        t: PropTypes.func
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { onSubmit, t } = this.props;
+
+        return (
+            <div className = 'kicked-notice'>
+                <div className = 'cta'>{ t('conferenceStatus.slowJoin') }</div>
+                <Button onClick = { onSubmit }>
+                    { t('buttons.cancel') }
+                </Button>
+            </div>
+        );
+    }
+}
+
+export default withTranslation()(CancelMeetingPrompt);

--- a/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
+++ b/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
@@ -23,7 +23,7 @@ export class CancelMeetingPrompt extends React.Component {
         const { onSubmit, t } = this.props;
 
         return (
-            <div className = 'kicked-notice'>
+            <div className = 'conference-status-notice'>
                 <div className = 'cta'>{ t('conferenceStatus.slowJoin') }</div>
                 <Button
                     onClick = { onSubmit }

--- a/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
+++ b/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/CancelMeetingPrompt.js
@@ -25,7 +25,9 @@ export class CancelMeetingPrompt extends React.Component {
         return (
             <div className = 'kicked-notice'>
                 <div className = 'cta'>{ t('conferenceStatus.slowJoin') }</div>
-                <Button onClick = { onSubmit }>
+                <Button
+                    onClick = { onSubmit }
+                    qaId = 'cancel-meeting'>
                     { t('buttons.cancel') }
                 </Button>
             </div>

--- a/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/index.js
+++ b/spot-client/src/spot-remote/ui/components/cancel-meeting-prompt/index.js
@@ -1,0 +1,1 @@
+export { default as CancelMeetingPrompt } from './CancelMeetingPrompt';

--- a/spot-client/src/spot-remote/ui/components/index.js
+++ b/spot-client/src/spot-remote/ui/components/index.js
@@ -1,3 +1,4 @@
+export * from './cancel-meeting-prompt';
 export * from './dial-pad';
 export * from './dtmf';
 export * from './electron-desktop-picker';

--- a/spot-client/src/spot-remote/ui/components/kicked-notice/KickedNotice.js
+++ b/spot-client/src/spot-remote/ui/components/kicked-notice/KickedNotice.js
@@ -25,7 +25,7 @@ export class KickedNotice extends React.Component {
         const { onSubmit, t } = this.props;
 
         return (
-            <div className = 'kicked-notice'>
+            <div className = 'conference-status-notice'>
                 <div className = 'cta'>{ t('conferenceStatus.kicked') }</div>
                 <Button onClick = { onSubmit }>{ t('buttons.continue') }</Button>
             </div>

--- a/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
+++ b/spot-webdriver/page-objects/spot-remote-in-meeting-page.js
@@ -4,6 +4,7 @@ const ScreensharePicker = require('./screenshare-picker');
 
 const AUDIO_MUTE_BUTTON = '[data-qa-id=mute-audio]';
 const AUDIO_UNMUTE_BUTTON = '[data-qa-id=unmute-audio]';
+const CANCEL_MEETING_BUTTON = '[data-qa-id=cancel-meeting]';
 const HANG_UP_BUTTON = '[data-qa-id=hangup]';
 const MORE_BUTTON = '[data-qa-id=more]';
 const MORE_MODAL = '[data-qa-id=more-modal]';
@@ -30,6 +31,16 @@ class SpotRemoteInMeetingPage extends PageObject {
         super(driver, REMOTE_CONTROL);
 
         this.screensharePicker = new ScreensharePicker(this.driver);
+    }
+
+    /**
+     * Exits a meeting that is taking a while to load.
+     *
+     * @returns {void}
+     */
+    cancelMeetingJoin() {
+        this.waitForCancelMeetingToDisplay();
+        this.select(CANCEL_MEETING_BUTTON).click();
     }
 
     /**
@@ -212,6 +223,15 @@ class SpotRemoteInMeetingPage extends PageObject {
                 offStateSelector: AUDIO_MUTE_BUTTON,
                 waitTime: constants.REMOTE_COMMAND_WAIT
             });
+    }
+
+    /**
+     * Waits for the button to display which aborts a meeting join attempting.
+     *
+     * @returns {void}
+     */
+    waitForCancelMeetingToDisplay() {
+        this.waitForElementDisplayed(CANCEL_MEETING_BUTTON, 20000);
     }
 
     /**

--- a/spot-webdriver/specs/adhoc-meeting.spec.js
+++ b/spot-webdriver/specs/adhoc-meeting.spec.js
@@ -19,6 +19,8 @@ describe('Can start a meeting', () => {
         const spotRemote = session.getSpotRemote();
         const inMeetingPage = spotRemote.getInMeetingPage();
 
+        // Go to an invalid meeting url to prevent any meeting loaded confirmation
+        // from firing and to make the cancel button display.
         session.joinMeeting('https://meet.jit.si');
 
         inMeetingPage.waitForCancelMeetingToDisplay();

--- a/spot-webdriver/specs/adhoc-meeting.spec.js
+++ b/spot-webdriver/specs/adhoc-meeting.spec.js
@@ -14,6 +14,19 @@ describe('Can start a meeting', () => {
         expect(spotTV.getMeetingName()).toBe(testMeetingName);
     });
 
+    it('and cancel join', () => {
+        const spotTV = session.getSpotTV();
+        const spotRemote = session.getSpotRemote();
+        const inMeetingPage = spotRemote.getInMeetingPage();
+
+        session.joinMeeting('https://meet.jit.si');
+
+        inMeetingPage.waitForCancelMeetingToDisplay();
+        inMeetingPage.cancelMeetingJoin();
+
+        spotTV.getCalendarPage().waitForVisible();
+    });
+
     xit('and disconnects the remote on meeting end', () => {
         if (!session.isBackendEnabled()) {
             pending();


### PR DESCRIPTION
So if there is a slow join the user can immediately stop the
join.

PR-URL JIT-3413

<img width="1202" alt="Screen Shot 2019-11-04 at 3 23 59 PM" src="https://user-images.githubusercontent.com/1243084/68166634-cbcc3800-ff17-11e9-9b1b-ff52f9144a8c.png">