### PR TITLE
feat(electron): notarize Mac app

### DIFF
--- a/spot-electron/entitlements.mac.plist
+++ b/spot-electron/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/spot-electron/package-lock.json
+++ b/spot-electron/package-lock.json
@@ -1219,6 +1219,44 @@
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.8.tgz",
       "integrity": "sha512-B9+eJ8z3UbDnWEz+G33SIJvEDeKLznHEV4sCu6bR31KuOdp3dYN046QBWbLNsvKU+lzFI6eOi+xNCpNHZvatiw=="
     },
+    "electron-notarize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.1.1.tgz",
+      "integrity": "sha512-TpKfJcz4LXl5jiGvZTs5fbEx+wUFXV5u8voeG5WCHWfY/cdgdD8lDZIZRqLVOtR3VO+drgJ9aiSHIO9TYn/fKg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^8.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        }
+      }
+    },
     "electron-osx-sign": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz",

--- a/spot-electron/package.json
+++ b/spot-electron/package.json
@@ -1,11 +1,21 @@
 {
     "author": "Jitsi",
     "build": {
+        "afterSign": "scripts/notarize.js",
         "productName": "Spot",
         "appId": "org.jitsi.spot",
         "mac": {
             "category": "public.app-category.business",
-            "target": "default"
+            "entitlements": "entitlements.mac.plist",
+            "entitlementsInherit": "entitlements.mac.plist",
+            "gatekeeperAssess": false,
+            "hardenedRuntime": true,
+            "target": ["dmg", "zip"]
+        },
+        "publish": {
+            "provider": "github",
+            "private": false,
+            "publishAutoUpdate": true
         }
     },
     "description": "",
@@ -14,12 +24,16 @@
         "devtron": "1.4.0",
         "electron": "5.0.3",
         "electron-builder": "20.43.0",
+        "electron-notarize": "0.1.1",
         "electron-rebuild": "1.8.5",
         "eslint": "5.16.0",
         "eslint-config-jitsi": "github:jitsi/eslint-config-jitsi#1.0.1",
         "eslint-plugin-flowtype": "3.10.1",
         "eslint-plugin-import": "2.17.3",
         "eslint-plugin-jsdoc": "7.2.3"
+    },
+    "dmg": {
+        "sign": false
     },
     "license": "ISC",
     "main": "main.js",

--- a/spot-electron/scripts/notarize.js
+++ b/spot-electron/scripts/notarize.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const { notarize } = require('electron-notarize');
+
+exports.default = async function notarizing(context) {
+    const { electronPlatformName, appOutDir } = context;
+
+    if (electronPlatformName !== 'darwin') {
+        return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.info('Notarizing Mac app...');
+
+    const appName = context.packager.appInfo.productFilename;
+
+    return await notarize({
+        appBundleId: process.env.NOTARIZE_BUNDLE_ID,
+        appPath: `${appOutDir}/${appName}.app`,
+        appleId: process.env.NOTARIZE_APPLE_ID,
+        appleIdPassword: process.env.NOTARIZE_APPLE_ID_PASSWORD
+    });
+};


### PR DESCRIPTION
Adds the post build scrip which executes 'electron-notarize' to notarize the Mac app.