### PR TITLE
fix(webdriver): disconnect xmpp before simulating TV close

### DIFF
--- a/spot-webdriver/user/spot-user.js
+++ b/spot-webdriver/user/spot-user.js
@@ -92,6 +92,7 @@ class SpotUser {
      * @returns {void}
      */
     stop() {
+        this.disconnectRemoteControlService();
         this.driver.url('about:blank');
     }
 }


### PR DESCRIPTION
This way there is explicit cleanup of the MUC and the
remote is less likely to encountere race conditions,
like item-not-found errors when trying to connect
to the TV immediately after the TV browser has
navigated away from spot.