### PR TITLE
ref(dial pad): detect the country even if no + was entered

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -7840,9 +7840,9 @@
             "dev": true
         },
         "libphonenumber-js": {
-            "version": "1.7.25",
-            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.25.tgz",
-            "integrity": "sha512-WlmFl3xSR0oGH0+ZGtEbcNgo6h7JUyYaRmGWlddrkEFmPjAULRur2KZzmNWQSBfD0LhUdnKYhwIi2MnB7gswWw==",
+            "version": "1.7.26",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.26.tgz",
+            "integrity": "sha512-23y9szw5sCrko0i4bO+jv6B3fFJkr0+bZ/5DLyY7TxBDJ04ACw+obdOdR3d2aOwbnOW+eevcgt8HqYgvjrfD/A==",
             "dev": true,
             "requires": {
                 "minimist": "^1.2.0",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -52,7 +52,7 @@
         "jwt-decode": "2.2.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#a909e594868b17f0c72c85f2a231384f4cb1ea61",
         "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
-        "libphonenumber-js": "1.7.25",
+        "libphonenumber-js": "1.7.26",
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",


### PR DESCRIPTION
Improves country detection by using the parse function which detects country specific syntax. For example 00{country code} or 011{country code} in the US.