### PR TITLE
feat(meeting): temporary flag for zoom support

### DIFF
--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -269,7 +269,7 @@ export default {
         /**
          * Whether or not to display the UI for joining a Zoom meeting.
          */
-        ENABLE_ZOOM_MEETINGS: false,
+        ENABLE_ZOOM_MEETINGS: process.env.ENABLE_ZOOM_MEETINGS || false,
 
         /**
          * Spot-TV should kick temporary remotes after a successfully joined

--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -261,10 +261,15 @@ export default {
         DTMF_THROTTLE_RATE: 500,
 
         /**
-         * Whether or the note feature for inviting participants to a conference
+         * Whether or the not feature for inviting participants to a conference
          * is available.
          */
         ENABLE_INVITES: false,
+
+        /**
+         * Whether or not to display the UI for joining a Zoom meeting.
+         */
+        ENABLE_ZOOM_MEETINGS: false,
 
         /**
          * Spot-TV should kick temporary remotes after a successfully joined

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -281,6 +281,17 @@ export function shouldKickTemporaryRemotes(state) {
 }
 
 /**
+ * A selector which returns whether or not the feature flag for Spot-TV being
+ * able to join Zoom meetings is enabled.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function shouldTVDisplayZoom(state) {
+    return state.config.TEMPORARY_FEATURE_FLAGS.ENABLE_ZOOM_MEETINGS;
+}
+
+/**
  * A selector which returns whether or not to display on the remote an option
  * to invite people to a meeting.
  *

--- a/spot-client/src/common/app-state/spot-tv/reducer.js
+++ b/spot-client/src/common/app-state/spot-tv/reducer.js
@@ -15,6 +15,7 @@ const DEFAULT_STATE = {
     screensharing: false,
     screensharingType: undefined,
     spotId: undefined,
+    supportsZoom: false,
     tileView: false,
     videoMuted: true,
     view: undefined

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -92,3 +92,13 @@ export function isConnectedToSpot(state) {
 export function isVolumeControlSupported(state) {
     return Boolean(state.spotTv.electron);
 }
+
+/**
+ * A selector which returns whether or not the Spot-TV has Zoom meeting support.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function shouldRemoteDisplayZoom(state) {
+    return Boolean(state.spotTv.supportsZoom);
+}

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -47,16 +47,19 @@ if (queryParams.get('reset') === 'true') {
     clearPersistedState();
 }
 
+const configValues = setDefaultValues(window.JitsiMeetSpotConfig);
 const store = createStore(
     ReducerRegistry.combineReducers(reducers),
     {
         config: {
-            ...setDefaultValues(window.JitsiMeetSpotConfig)
+            ...configValues
         },
         spotTv: {
 
             // Will get overridden on Spot-Remote by Spot-TV updates.
-            electron: isElectron()
+            electron: isElectron(),
+
+            supportsZoom: configValues.TEMPORARY_FEATURE_FLAGS.ENABLE_ZOOM_MEETINGS
         },
         ...getPersistedState()
     },

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -62,6 +62,7 @@ const presenceToStore = [
     'screensharing',
     'screensharingType',
     'spotId',
+    'supportsZoom',
     'tenant',
     'tileView',
     'videoMuted',


### PR DESCRIPTION
So zoom-related code can be committed and tested
manually without exposing to users.