### PR TITLE
ref(config): remove temporary KICK_TEMPORARY_REMOTES flag

### DIFF
--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -264,15 +264,7 @@ export default {
          * Whether or the note feature for inviting participants to a conference
          * is available.
          */
-        ENABLE_INVITES: false,
-
-        /**
-         * Spot-TV should kick temporary remotes after a successfully joined
-         * meeting has needed.
-         *
-         * @type {boolean}
-         */
-        KICK_TEMPORARY_REMOTES: false
+        ENABLE_INVITES: false
     },
 
     /**

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -270,17 +270,6 @@ export function getUpdateEndHour(state) {
 }
 
 /**
- * A selector which returns whether or not the feature flag for Spot-TV kicking
- * out temporary remotes at the end of meeting is enabled or not.
- *
- * @param {Object} state - The Redux state.
- * @returns {boolean}
- */
-export function shouldKickTemporaryRemotes(state) {
-    return state.config.TEMPORARY_FEATURE_FLAGS.KICK_TEMPORARY_REMOTES;
-}
-
-/**
  * A selector which returns whether or not to display on the remote an option
  * to invite people to a meeting.
  *

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -18,7 +18,6 @@ import {
     getPreferredSpeaker,
     getWiredScreenshareInputLabel,
     leaveMeetingWithError,
-    shouldKickTemporaryRemotes,
     storePhoneNumberFromInvites
 } from 'common/app-state';
 import { isBackendEnabled } from 'common/backend';
@@ -336,8 +335,7 @@ function mapStateToProps(state) {
         maxDesktopSharingFramerate,
         meetingJoinTimeout: getMeetingJoinTimeout(state),
         minDesktopSharingFramerate,
-        kickTemporaryRemotesOnMeetingEnd: shouldKickTemporaryRemotes(state)
-            && isBackendEnabled(state),
+        kickTemporaryRemotesOnMeetingEnd: isBackendEnabled(state),
         showKickedOverlay: kicked,
         showPasswordPrompt: needPassword,
         preferredCamera: getPreferredCamera(state),


### PR DESCRIPTION
It was used to disable the feature while the prosody
changes weren't vetted or deployed. Now the changes
have been tested and are the norm.