### PR TITLE
enable android webview for spot TV

### DIFF
--- a/spot-client/src/common/detection/detection.js
+++ b/spot-client/src/common/detection/detection.js
@@ -92,8 +92,8 @@ function _isIOSWebView() {
 export function isSupportedSpotTvBrowser() {
     const jitsiBrowserDetection = JitsiMeetJSProvider.get().util.browser;
 
-    return isDesktopBrowser()
-        && (jitsiBrowserDetection.isChrome() || jitsiBrowserDetection.isElectron());
+    return _isAndroidWebView() || (isDesktopBrowser()
+        && (jitsiBrowserDetection.isChrome() || jitsiBrowserDetection.isElectron()));
 }
 
 /**


### PR DESCRIPTION
Enable rendering Spot TV in Android WebViews for custom integrations