### PR TITLE
feat(integrations): include pushing the image in build script

### DIFF
--- a/spot-integrations-service/README.md
+++ b/spot-integrations-service/README.md
@@ -7,5 +7,6 @@ A backend service for signing Zoom meeting numbers with an api secret and api ke
 1. `npm start`
 
 ## Building
-1. `./scripts/build.sh IMAGE_NAME`
-1. Run the image to test. For example: `docker run -p 3789:3789 -p 2112:2112 -e API_PORT=3789 -e METRICS_PORT=2112 -e ZOOM_API_SECRET=API_SECRET IMAGE_NAME`
+1. Generate an image name. Can use the example script in the monorepo: `./../scripts/get-spot-client-build-tag.sh`
+1. `./scripts/build.sh IMAGE_NAME`. Note that the created image name will include the docker repo.
+1. Run the image to test. For example: `docker run -p 3789:3789 -p 2112:2112 -e API_PORT=3789 -e METRICS_PORT=2112 -e ZOOM_API_SECRET=API_SECRET DOCKER_REPO:IMAGE_NAME`

--- a/spot-integrations-service/scripts/build.sh
+++ b/spot-integrations-service/scripts/build.sh
@@ -9,4 +9,8 @@ if [ -z "$TAG" ]; then
     exit 1
 fi
 
-docker build -t $TAG .
+DOCKER_REPO=103425057857.dkr.ecr.us-west-2.amazonaws.com/jitsi/spot-integrations-service
+
+$(aws ecr get-login --no-include-email)
+docker build -t $DOCKER_REPO:$TAG .
+docker push $DOCKER_REPO:$TAG


### PR DESCRIPTION
This mirrors the build process for spot-client.