### PR TITLE
feat: detect Spot TV conflict

### DIFF
--- a/spot-client/src/app.js
+++ b/spot-client/src/app.js
@@ -25,6 +25,7 @@ import {
 } from 'common/ui';
 import { Help, JoinCodeEntry, RemoteControl, ShareView } from 'spot-remote/ui';
 import {
+    Conflict,
     ExitElectron,
     Home,
     Meeting,
@@ -173,6 +174,9 @@ export class App extends React.Component {
                                  * Spot-TV specific routes.
                                  */
                             }
+                            <Route
+                                path = { ROUTES.CONFLICT }
+                                render = { this._renderConflictView } />
                             <SpotTvRestrictedRoute
                                 path = { ROUTES.MEETING }
                                 render = { this._renderMeetingView } />
@@ -281,6 +285,20 @@ export class App extends React.Component {
      */
     _onTouchStart() {
         /** No-op. */
+    }
+
+    /**
+     * Returns the Spot TV conflict view.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderConflictView() {
+        return (
+            <SpotView name = { 'conflict' }>
+                <Conflict />
+            </SpotView>
+        );
     }
 
     /**

--- a/spot-client/src/common/auto-update/AutoUpdateController.js
+++ b/spot-client/src/common/auto-update/AutoUpdateController.js
@@ -43,6 +43,7 @@ export const WEB_UPDATE_POLL_INTERVAL = 30000;
 const allowedRoutes = [];
 
 // Spot TV
+allowedRoutes.push(ROUTES.CONFLICT);
 allowedRoutes.push(ROUTES.SETUP);
 allowedRoutes.push(ROUTES.UNSUPPORTED_BROWSER);
 allowedRoutes.push(ROUTES.HOME);

--- a/spot-client/src/common/css/index.scss
+++ b/spot-client/src/common/css/index.scss
@@ -10,6 +10,7 @@
 @import './nav/nav.scss';
 @import './nav/nav-button.scss';
 @import './page-layouts/spot-tv/admin.scss';
+@import './page-layouts/spot-tv/conflict.scss';
 @import './page-layouts/spot-tv/meeting-view.scss';
 @import './page-layouts/spot-tv/setup-view.scss';
 @import './page-layouts/spot-tv/unsupported-browser.scss';

--- a/spot-client/src/common/css/page-layouts/spot-tv/_conflict.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_conflict.scss
@@ -1,0 +1,7 @@
+.conflict {
+    background-color: var(--container-bg-color);
+    border-radius: 5px;
+    font-size: $font-size-medium-plus;
+    padding: 32px 16px;
+    text-align: center;
+}

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -31,6 +31,7 @@
         "pleaseWait": "Please wait",
         "reconnecting": "Reconnecting",
         "setup": "Currently in setup.",
+        "tvConflict": "Please make sure another window is not open and try again.",
         "tvNotSupported": "Hosting {{ productName }} is not supported on the current browser.",
         "unexpectedError": "An unexpected error occurred.",
         "useChrome": "Please open {{ productName }} on Chrome desktop.",
@@ -44,6 +45,7 @@
         "go": "Join",
         "select": "Select",
         "next": "Next",
+        "retry": "Retry",
         "send": "Send",
         "skip": "Skip",
         "submit": "Submit"

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -31,7 +31,7 @@
         "pleaseWait": "Please wait",
         "reconnecting": "Reconnecting",
         "setup": "Currently in setup.",
-        "tvConflict": "Please make sure another window is not open and try again.",
+        "tvConflict": "An instance of {{ roomName }} is already open. Please close all other instances and try again.",
         "tvNotSupported": "Hosting {{ productName }} is not supported on the current browser.",
         "unexpectedError": "An unexpected error occurred.",
         "useChrome": "Please open {{ productName }} on Chrome desktop.",

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -8,6 +8,15 @@ import { getJitterDelay } from 'common/utils';
 import { IQ_NAMESPACES, IQ_TIMEOUT } from './constants';
 
 /**
+ * How long will the join MUC function retry on conflict error before giving up.
+ * The value must be bigger than the idle client connection timeout. It's currently set to 30 seconds for the worst case
+ * scenario.
+ *
+ * @type {number}
+ */
+const CONFLICT_TIMEOUT = 35000;
+
+/**
  * XML element name for spot status added to MUC presence.
  *
  * @type {string}
@@ -214,6 +223,8 @@ export default class XmppConnection extends Emitter {
         );
 
         const createJoinPromise = function () {
+            let firstConflictTimestamp;
+
             return new Promise((resolve, reject) => {
                 const { connection } = this.xmppConnection.xmpp;
 
@@ -229,6 +240,21 @@ export default class XmppConnection extends Emitter {
 
                     if (errors.length) {
                         const error = errors[0].children[0].tagName;
+
+                        if (error === 'conflict') {
+                            if (!firstConflictTimestamp) {
+                                firstConflictTimestamp = Date.now();
+                            }
+
+                            const timeSinceFirstConflict = Date.now() - firstConflictTimestamp;
+
+                            if (timeSinceFirstConflict <= CONFLICT_TIMEOUT) {
+                                logger.warn('Retry MUC join on conflict error', { timeSinceFirstConflict });
+                                setTimeout(() => this._joinMuc(roomLock), 5000);
+
+                                return true;
+                            }
+                        }
 
                         reject(error);
 
@@ -544,8 +570,7 @@ export default class XmppConnection extends Emitter {
 
         if ((error === 'connection.droppedError'
             || error === 'connection.otherError'
-            || error === 'item-not-found'
-            || error === 'conflict')
+            || error === 'item-not-found')
             && this._joinOptions.shouldAttemptReconnect()) {
             logger.warn('xmpp connection attempting silent reconnect', {
                 error,

--- a/spot-client/src/common/remote-control/xmpp-connection.js
+++ b/spot-client/src/common/remote-control/xmpp-connection.js
@@ -250,7 +250,7 @@ export default class XmppConnection extends Emitter {
 
                             if (timeSinceFirstConflict <= CONFLICT_TIMEOUT) {
                                 logger.warn('Retry MUC join on conflict error', { timeSinceFirstConflict });
-                                setTimeout(() => this._joinMuc(roomLock), 5000);
+                                this._conflictRetryTimeout = setTimeout(() => this._joinMuc(roomLock), 5000);
 
                                 return true;
                             }
@@ -345,6 +345,9 @@ export default class XmppConnection extends Emitter {
      * @returns {Promise}
      */
     destroy(event) {
+        clearTimeout(this._conflictRetryTimeout);
+        this._conflictRetryTimeout = undefined;
+
         const leavePromise = this.xmppConnection
             ? this.xmppConnection.disconnect(event)
             : Promise.resolve();

--- a/spot-client/src/common/routing/constants.js
+++ b/spot-client/src/common/routing/constants.js
@@ -12,5 +12,6 @@ export const ROUTES = {
     REMOTE_CONTROL: '/remote-control',
     SETUP: '/setup',
     SHARE: '/share',
+    CONFLICT: '/conflict',
     UNSUPPORTED_BROWSER: '/unsupported-browser'
 };

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -214,6 +214,7 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
          * @returns {Promise}
          */
         function onDisconnect(error) {
+            const isConflict = error === 'conflict';
             const isRecoverableError = remoteControlServer.isRecoverableRequestError(error);
             const usingPermanentPairingCode = Boolean(pairingCode);
             const canRecoverConnection = !usingPermanentPairingCode || isRecoverableError;
@@ -225,11 +226,12 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
              *
              * @type {boolean}
              */
-            const willRetry = (retry || initiallyConnected) && canRecoverConnection;
+            const willRetry = (retry || initiallyConnected) && canRecoverConnection && !isConflict;
 
             logger.error('Spot-TV disconnected from the remote control server.', {
                 error,
                 initiallyConnected,
+                isConflict,
                 isRecoverableError,
                 retry,
                 usingPermanentPairingCode,
@@ -239,6 +241,7 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
             dispatch(spotTvConnectionFailed({
                 error,
                 initiallyConnected,
+                isConflict,
                 isRecoverableError,
                 retry,
                 usingPermanentPairingCode,
@@ -274,7 +277,11 @@ export function createSpotTVRemoteControlConnection({ pairingCode, retry }) {
 
             removeEventHandlers();
 
-            throw error;
+            if (isConflict) {
+                history.push(ROUTES.CONFLICT);
+            } else {
+                throw error;
+            }
         }
 
         /**

--- a/spot-client/src/spot-tv/ui/views/Conflict.js
+++ b/spot-client/src/spot-tv/ui/views/Conflict.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+import { Button } from 'common/ui/components/button';
+import { history } from 'common/history';
+import { ROUTES } from 'common/routing';
+
+/**
+ * The conflict error page displayed when another Spot TV instance is already connected.
+ *
+ * @returns {ReactElement}
+ */
+export class Conflict extends React.Component {
+    static propTypes = {
+        t: PropTypes.func
+    };
+
+    /**
+     * Creates new instance.
+     *
+     * @param {Object} props - React component props.
+     */
+    constructor(props) {
+        super(props);
+
+        this._onRetry = this._onRetry.bind(this);
+    }
+
+    /**
+     * Called when the retry button is clicked.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onRetry() {
+        history.push(ROUTES.HOME);
+    }
+
+    /**
+     * Renders.
+     *
+     * @returns {ReactElement}
+     */
+    render() {
+        const { t } = this.props;
+
+        return (
+            <div
+                className = 'conflict'
+                data-qa-id = 'conflict-view' >
+                <div>{ t('appStatus.tvConflict') }</div>
+                <Button
+                    onClick = { this._onRetry }
+                    qaId = 'conflict-retry' >
+                    { t('buttons.retry') }
+                </Button>
+            </div>
+        );
+    }
+}
+
+export default withTranslation()(Conflict);

--- a/spot-client/src/spot-tv/ui/views/Conflict.js
+++ b/spot-client/src/spot-tv/ui/views/Conflict.js
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withTranslation } from 'react-i18next';
-import { Button } from 'common/ui/components/button';
+import { connect } from 'react-redux';
+
+import { getDisplayName } from 'common/app-state';
 import { history } from 'common/history';
 import { ROUTES } from 'common/routing';
+import { Button } from 'common/ui';
 
 /**
  * The conflict error page displayed when another Spot TV instance is already connected.
@@ -12,6 +15,7 @@ import { ROUTES } from 'common/routing';
  */
 export class Conflict extends React.Component {
     static propTypes = {
+        roomName: PropTypes.string,
         t: PropTypes.func
     };
 
@@ -42,13 +46,13 @@ export class Conflict extends React.Component {
      * @returns {ReactElement}
      */
     render() {
-        const { t } = this.props;
+        const { roomName, t } = this.props;
 
         return (
             <div
                 className = 'conflict'
                 data-qa-id = 'conflict-view' >
-                <div>{ t('appStatus.tvConflict') }</div>
+                <div>{ t('appStatus.tvConflict', { roomName }) }</div>
                 <Button
                     onClick = { this._onRetry }
                     qaId = 'conflict-retry' >
@@ -59,4 +63,17 @@ export class Conflict extends React.Component {
     }
 }
 
-export default withTranslation()(Conflict);
+/**
+ * Selects parts of the Redux state to pass in with the props of {@code Conflict}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state) {
+    return {
+        roomName: getDisplayName(state)
+    };
+}
+
+export default connect(mapStateToProps)(withTranslation()(Conflict));

--- a/spot-client/src/spot-tv/ui/views/index.js
+++ b/spot-client/src/spot-tv/ui/views/index.js
@@ -1,3 +1,4 @@
+export { default as Conflict } from './Conflict';
 export { default as Home } from './home';
 export { default as Meeting } from './meeting';
 export { default as OutlookOauth } from './outlook-oauth';

--- a/spot-webdriver/page-objects/calendar-page.js
+++ b/spot-webdriver/page-objects/calendar-page.js
@@ -54,7 +54,8 @@ class CalendarPage extends PageObject {
      *
      * @param {Map} [queryParams] - Query parameters to add to the URL.
      * @param {number} [visibilityWait] - Override for how long page load should
-     * wait for before reporting the page as having failed to load.
+     * wait for before reporting the page as having failed to load. If -1 is passed then the waiting part will be
+     * skipped.
      * @returns {void}
      */
     visit(queryParams, visibilityWait) {
@@ -69,7 +70,7 @@ class CalendarPage extends PageObject {
         }
 
         this.driver.url(calendarPageUrl);
-        this.waitForVisible(visibilityWait);
+        visibilityWait === -1 || this.waitForVisible(visibilityWait);
     }
 }
 

--- a/spot-webdriver/page-objects/conflict-page.js
+++ b/spot-webdriver/page-objects/conflict-page.js
@@ -1,0 +1,44 @@
+const PageObject = require('./page-object');
+
+const CONFLICT_VIEW = '[data-qa-id=conflict-view]';
+
+const RETRY_BUTTON = '[data-qa-id=conflict-retry';
+
+/**
+ * A page object for interacting with the conflict view of Spot-TV.
+ */
+class ConflictPage extends PageObject {
+    /**
+     * Initializes a new {@code CalendarPage} instance.
+     *
+     * @inheritdoc
+     */
+    constructor(driver) {
+        super(driver, CONFLICT_VIEW);
+    }
+
+    /**
+     * Clicks the retry button which makes the TV try to connect again.
+     *
+     * @returns {void}
+     */
+    clickRetry() {
+        this.select(RETRY_BUTTON).click();
+    }
+
+    /**
+     * Waits for this page object to be visible on the browser.
+     *
+     * Overrides the super method to provide default value based on the timeout defined in xmpp-connection logic for
+     * conflict detection. The value there is 35 seconds, so make it almost twice as that.
+     *
+     * @param {number} [timeout] - An override of the number of milliseconds to
+     * wait for the element to exist.
+     * @returns {void}
+     */
+    waitForVisible(timeout = 60000) {
+        super.waitForVisible(timeout);
+    }
+}
+
+module.exports = ConflictPage;

--- a/spot-webdriver/page-objects/conflict-page.js
+++ b/spot-webdriver/page-objects/conflict-page.js
@@ -9,7 +9,7 @@ const RETRY_BUTTON = '[data-qa-id=conflict-retry';
  */
 class ConflictPage extends PageObject {
     /**
-     * Initializes a new {@code CalendarPage} instance.
+     * Initializes a new {@code ConflictPage} instance.
      *
      * @inheritdoc
      */

--- a/spot-webdriver/specs/adhoc-meeting.spec.js
+++ b/spot-webdriver/specs/adhoc-meeting.spec.js
@@ -1,3 +1,4 @@
+const SpotSession = require('../user/spot-session');
 const spotSessionStore = require('../user/spotSessionStore');
 
 describe('Can start a meeting', () => {
@@ -30,7 +31,7 @@ describe('Can start a meeting', () => {
     });
 
     xit('and disconnects the remote on meeting end', () => {
-        if (!session.isBackendEnabled()) {
+        if (!SpotSession.isBackendEnabled()) {
             pending();
 
             return;

--- a/spot-webdriver/specs/share-mode.spec.js
+++ b/spot-webdriver/specs/share-mode.spec.js
@@ -1,3 +1,4 @@
+const SpotSession = require('../user/spot-session');
 const spotSessionStore = require('../user/spotSessionStore');
 
 describe('In share mode', () => {
@@ -42,7 +43,7 @@ describe('In share mode', () => {
     });
 
     xit('Spot-Remote is disconnected on share end', () => {
-        if (!session.isBackendEnabled()) {
+        if (!SpotSession.isBackendEnabled()) {
             pending();
 
             return;

--- a/spot-webdriver/specs/spot-tv-conflict.spec.js
+++ b/spot-webdriver/specs/spot-tv-conflict.spec.js
@@ -4,6 +4,12 @@ const SpotSession = require('../user/spot-session');
 
 describe('The Spot TV conflict detection logic', () => {
     it('should detect the conflict after timeout and allow to retry', () => {
+        if (!SpotSession.isBackendEnabled()) {
+            pending();
+
+            return;
+        }
+
         const spotTv1 = new SpotTV(spotBrowser);
         const spotTv2 = new SpotTV(remoteControlBrowser);
 

--- a/spot-webdriver/specs/spot-tv-conflict.spec.js
+++ b/spot-webdriver/specs/spot-tv-conflict.spec.js
@@ -1,0 +1,27 @@
+/* global remoteControlBrowser, spotBrowser */
+const SpotTV = require('../user/spot-tv-user');
+const SpotSession = require('../user/spot-session');
+
+describe('The Spot TV conflict detection logic', () => {
+    it('should detect the conflict after timeout and allow to retry', () => {
+        const spotTv1 = new SpotTV(spotBrowser);
+        const spotTv2 = new SpotTV(remoteControlBrowser);
+
+        const spotSession1 = new SpotSession(spotTv1, undefined);
+        const spotSession2 = new SpotSession(spotTv2, undefined);
+
+        spotSession1.startSpotTv();
+
+        spotSession2.startSpotTv(false);
+
+        const conflictPage = spotTv2.getConflictPage();
+
+        conflictPage.waitForVisible();
+
+        spotTv1.cleanup();
+
+        conflictPage.clickRetry();
+
+        spotTv2.getCalendarPage().waitForVisible();
+    });
+});

--- a/spot-webdriver/specs/spot-tv-reconnect.spec.js
+++ b/spot-webdriver/specs/spot-tv-reconnect.spec.js
@@ -1,3 +1,4 @@
+const SpotSession = require('../user/spot-session');
 const spotSessionStore = require('../user/spotSessionStore');
 
 describe('The reconnect logic', () => {
@@ -37,7 +38,7 @@ describe('The reconnect logic', () => {
 
     describe('when the internet goes offline', () => {
         it('in the backend mode Spot TV and permanent remote will both reconnect', () => {
-            if (!session.isBackendEnabled()) {
+            if (!SpotSession.isBackendEnabled()) {
                 pending();
 
                 return;
@@ -107,7 +108,7 @@ describe('The reconnect logic', () => {
 
     describe('when signaling goes offline', () => {
         it('does not disconnect while peer-to-peer connections are active', () => {
-            if (!session.isBackendEnabled()) {
+            if (!SpotSession.isBackendEnabled()) {
                 pending();
 
                 return;

--- a/spot-webdriver/specs/waiting-for-tv.spec.js
+++ b/spot-webdriver/specs/waiting-for-tv.spec.js
@@ -1,10 +1,11 @@
+const SpotSession = require('../user/spot-session');
 const spotSessionStore = require('../user/spotSessionStore');
 
 describe('The "waiting for the Spot TV to connect" message', () => {
     const session = spotSessionStore.createSession();
 
     it('should appear if no Spot TV and disappear when it connects', () => {
-        if (!session.isBackendEnabled()) {
+        if (!SpotSession.isBackendEnabled()) {
             pending();
 
             return;
@@ -29,7 +30,7 @@ describe('The "waiting for the Spot TV to connect" message', () => {
         waitingForSpotTvLabel.waitForHidden();
     });
     it('should appear if Spot TV disconnects while Spot Remote is disconnected', () => {
-        if (!session.isBackendEnabled()) {
+        if (!SpotSession.isBackendEnabled()) {
             pending();
 
             return;

--- a/spot-webdriver/user/spot-session.js
+++ b/spot-webdriver/user/spot-session.js
@@ -71,7 +71,7 @@ class SpotSession {
      *
      * @returns {boolean}
      */
-    isBackendEnabled() {
+    static isBackendEnabled() {
         return Boolean(constants.BACKEND_PAIRING_CODE);
     }
 

--- a/spot-webdriver/user/spot-session.js
+++ b/spot-webdriver/user/spot-session.js
@@ -145,15 +145,16 @@ class SpotSession {
     /**
      * Starts the Spot TV and opens the home page(calendar page).
      *
+     * @param {boolean} [skipWaitForVisible] - If set to {@code true} will not wait for the home page to be displayed.
      * @returns {void}
      */
-    startSpotTv() {
+    startSpotTv(skipWaitForVisible) {
         const calendarPage = this.spotTV.getCalendarPage();
         const queryParams = new Map();
 
         queryParams.set(QUERY_PARAM_TEST_PERMANENT_PAIRING_CODE, constants.BACKEND_PAIRING_CODE || '');
 
-        calendarPage.visit(queryParams, constants.MAX_PAGE_LOAD_WAIT);
+        calendarPage.visit(queryParams, skipWaitForVisible ? -1 : constants.MAX_PAGE_LOAD_WAIT);
     }
 
     /**

--- a/spot-webdriver/user/spot-tv-user.js
+++ b/spot-webdriver/user/spot-tv-user.js
@@ -1,5 +1,6 @@
 const AdminPage = require('../page-objects/admin-page');
 const CalendarPage = require('../page-objects/calendar-page');
+const ConflictPage = require('../page-objects/conflict-page');
 const MeetingPage = require('../page-objects/meeting-page');
 const SpotUser = require('./spot-user');
 
@@ -18,6 +19,7 @@ class SpotTV extends SpotUser {
 
         this.adminPage = new AdminPage(this.driver);
         this.calendarPage = new CalendarPage(this.driver);
+        this.conflictPage = new ConflictPage(this.driver);
         this.meetingPage = new MeetingPage(this.driver);
     }
 
@@ -39,6 +41,15 @@ class SpotTV extends SpotUser {
      */
     getCalendarPage() {
         return this.calendarPage;
+    }
+
+    /**
+     * Returns the conflict page.
+     *
+     * @returns {ConflictPage}
+     */
+    getConflictPage() {
+        return this.conflictPage;
     }
 
     /**


### PR DESCRIPTION
If Spot TV will fail to join the MUC with conflict error, for longer
than the max client idle timeout, it will mean that most likely another
Spot TV instance is already connected.

The conflict can not be detected instantly, because not gracefully
closed connections are cleaned up only after the idle timeout on
the server.