### PR TITLE
ref(backend): remove unused 'emitted' field

### DIFF
--- a/spot-client/src/common/backend/SpotBackendService.js
+++ b/spot-client/src/common/backend/SpotBackendService.js
@@ -191,12 +191,11 @@ export class SpotBackendService extends Emitter {
         logger.log('Refreshing access token...', { pairingCode });
 
         return refreshAccessToken(`${this.pairingServiceUrl}/regenerate`, registration)
-            .then(({ accessToken, emitted, expires, tenant }) => {
+            .then(({ accessToken, expires, tenant }) => {
                 // copy the fields to preserve the refresh token
                 const newRegistration = {
                     ...registration,
                     accessToken,
-                    emitted,
                     expires,
                     tenant
                 };

--- a/spot-client/src/common/backend/utils.js
+++ b/spot-client/src/common/backend/utils.js
@@ -11,15 +11,13 @@ import { errorConstants } from './constants';
  * has been emitted.
  * @param {string|number} expiresIn - A string with a number of milliseconds which is validity period of a token.
  * @returns {{
- *     emitted: number,
  *     expires: number
  * }}
  */
-function convertToEmittedAndExpires({ emitted, expiresIn }) {
+function convertToExpires({ emitted, expiresIn }) {
     const emittedMillis = Number(emitted);
 
     return {
-        emitted: emittedMillis,
         expires: emittedMillis + Number(expiresIn)
     };
 }
@@ -216,8 +214,6 @@ export function fetchCalendarEvents(serviceEndpointUrl, jwt) {
 
 /**
  * @typedef {Object} RemotePairingInfo - the short lived paring code.
- * @property {number} emitted - A date expressed in milliseconds since the epoch which indicates when
- * the pairing code has been emitted.
  * @property {number} expires - A date expressed in milliseconds since the epoch which indicates when
  * the pairing code will expire.
  * @property {string} remotePairingCode - A short lived remote pairing code to be used by Spot Remotes which connect
@@ -260,7 +256,7 @@ export function getRemotePairingCode(serviceEndpointUrl, jwt) {
 
         return {
             code,
-            ...convertToEmittedAndExpires(json)
+            ...convertToExpires(json)
         };
     });
 }
@@ -306,8 +302,6 @@ export function phoneAuthorize(serviceEndpointUrl, phoneNumber) {
 /**
  * @typedef {Object} RefreshTokenResponse
  * @property {string} accessToken - A new/refreshed access token.
- * @property {number} emitted - A date expressed in milliseconds since the epoch which indicate when
- * the token has been emitted.
  * @property {number} expires - A date expressed in milliseconds since the epoch which indicate when
  * the token will expire.
  * @property {string} [tenant] - A tenant name bound to specific customer for which Spot instance is being registered.
@@ -362,7 +356,7 @@ export function refreshAccessToken(serviceEndpointUrl, { accessToken, refreshTok
                 accessToken: newAccessToken,
                 refreshToken,
                 tenant,
-                ...convertToEmittedAndExpires(json)
+                ...convertToExpires(json)
             };
         });
 }
@@ -371,8 +365,6 @@ export function refreshAccessToken(serviceEndpointUrl, { accessToken, refreshTok
  * @typedef {Object} SpotRegistration
  * @property {string} accessToken - The authorization token to be used by a Spot TV
  * instance for accessing other services.
- * @property {number} emitted - A date expressed in milliseconds since the epoch which indicate when
- * the token has been emitted.
  * @property {string} [endpointId] - An endpoint ID assigned by the backend which is used to identify the device. It
  * should be persisted on the client side and used in future "register" requests.
  * @property {number} expires - A date expressed in milliseconds since the epoch which indicate when
@@ -430,7 +422,7 @@ export function registerDevice(serviceEndpointUrl, pairingCode, assignedEndpoint
                 endpointId,
                 refreshToken,
                 tenant,
-                ...convertToEmittedAndExpires(json)
+                ...convertToExpires(json)
             };
         });
 }

--- a/spot-client/src/common/backend/utils.test.js
+++ b/spot-client/src/common/backend/utils.test.js
@@ -115,7 +115,6 @@ describe('utils', () => {
             return utils.getRemotePairingCode(MOCK_SERVICE_ENDPOINT, MOCK_JWT)
                 .then(result => expect(result).toEqual({
                     code: MOCK_RESPONSE.code,
-                    emitted: 1,
                     expires: 3
                 }));
         });
@@ -216,7 +215,6 @@ describe('utils', () => {
             return utils.refreshAccessToken(MOCK_SERVICE_ENDPOINT, MOCK_TOKENS)
                 .then(result => expect(result).toEqual({
                     accessToken: MOCK_RESPONSE.accessToken,
-                    emitted: 1,
                     expires: 3,
                     refreshToken: MOCK_TOKENS.refreshToken,
                     tenant: MOCK_RESPONSE.tenant
@@ -282,7 +280,6 @@ describe('utils', () => {
             return utils.registerDevice(MOCK_SERVICE_ENDPOINT, MOCK_PAIRING_CODE)
                 .then(result => expect(result).toEqual({
                     accessToken: MOCK_RESPONSE.accessToken,
-                    emitted: 1,
                     expires: 3,
                     refreshToken: MOCK_RESPONSE.refreshToken,
                     tenant: MOCK_RESPONSE.tenant
@@ -298,7 +295,6 @@ describe('utils', () => {
             return utils.registerDevice(MOCK_SERVICE_ENDPOINT, MOCK_PAIRING_CODE)
                 .then(result => expect(result).toEqual({
                     accessToken: MOCK_RESPONSE.accessToken,
-                    emitted: 1,
                     expires: 3,
                     tenant: MOCK_RESPONSE.tenant
                 }));

--- a/spot-client/src/spot-tv/backend/SpotTVBackendService.test.js
+++ b/spot-client/src/spot-tv/backend/SpotTVBackendService.test.js
@@ -52,7 +52,6 @@ describe('SpotTvBackendService', () => {
             const MOCK_REGISTRATION = {
                 ...MOCK_RESPONSE,
                 pairingCode: MOCK_PAIRING_CODE,
-                expiresIn: undefined,
                 expires: MOCK_RESPONSE.emitted + MOCK_RESPONSE.expiresIn
             };
 


### PR DESCRIPTION
Once 'emitted' and 'expiresIn' gets converted to 'expires', then the 'emitted' field was never used for anything once the response gets outside of the util module.