### PR TITLE
fix(meeting): hide meeting as it loads

### DIFF
--- a/spot-client/src/common/css/page-layouts/spot-tv/_meeting-view.scss
+++ b/spot-client/src/common/css/page-layouts/spot-tv/_meeting-view.scss
@@ -2,6 +2,12 @@
     height: 100vh;
     width: 100vw;
 
+    &.loading {
+        .meeting-frame {
+            opacity: 0;
+        }
+    }
+
     .loading-curtain,
     .meetingMouseHider {
         height: 100vh;

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -146,9 +146,12 @@ export class Meeting extends React.Component {
             showKickedOverlay,
             showPasswordPrompt
         } = this.props;
+        const {
+            meetingLoaded
+        } = this.state;
 
         return (
-            <div className = 'meeting-view'>
+            <div className = { `meeting-view ${meetingLoaded ? '' : 'loading'}` }>
                 <MeetingFrame
                     avatarUrl = { avatarUrl }
                     displayName = { displayName }
@@ -171,7 +174,7 @@ export class Meeting extends React.Component {
                     startWithScreenshare = { screenshare }
                     startWithVideoMuted = { startWithVideoMuted } />
                 {
-                    !this.state.meetingLoaded
+                    !meetingLoaded
                         && <div className = 'loading-curtain'>
                             <Loading />
                         </div>


### PR DESCRIPTION
Thereby hiding prompts to get user media.