### PR TITLE
fix(adhoc): explain how to enter custom tenant via placeholder

### DIFF
--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -1,6 +1,7 @@
 {
     "adhoc": {
-        "enterName": "Enter a meeting name",
+        "enterName": "Enter a meeting name.",
+        "enterNameWithTenant": "Enter a meeting name. Enter \"/\" to specify a custom tenant.",
         "label": "Join a meeting",
         "meetNow": "Join with ID"
     },

--- a/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { withTranslation } from 'react-i18next';
 
 import { logger } from 'common/logger';
 import { getRandomMeetingName } from 'common/utils';
@@ -16,7 +17,7 @@ import MeetingNameEntry from './MeetingNameEntry';
 export class SelfFillingNameEntry extends React.Component {
     static defaultProps = {
         animationRevealRate: 100,
-        animationStartDelay: 5000
+        animationStartDelay: 6000
     };
 
     static propTypes = {
@@ -24,6 +25,7 @@ export class SelfFillingNameEntry extends React.Component {
         animationStartDelay: PropTypes.number,
         domain: PropTypes.string,
         onSubmit: PropTypes.func,
+        t: PropTypes.func,
         tenant: PropTypes.string
     };
 
@@ -99,6 +101,14 @@ export class SelfFillingNameEntry extends React.Component {
      * @returns {ReactElement}
      */
     render() {
+        let placeholder = '';
+
+        if (this.state.animatingPlaceholder) {
+            placeholder = this.state.animatingPlaceholder;
+        } else if (this.props.tenant) {
+            placeholder = this.props.t('adhoc.enterNameWithTenant');
+        }
+
         return (
             <MeetingNameEntry
                 domain = { this._getDomainToDisplay() }
@@ -106,7 +116,7 @@ export class SelfFillingNameEntry extends React.Component {
                 onBlur = { this._onBlur }
                 onChange = { this._onChange }
                 onSubmit = { this._onSubmit }
-                placeholder = { this.state.animatingPlaceholder } />
+                placeholder = { placeholder } />
         );
     }
 
@@ -256,4 +266,4 @@ export class SelfFillingNameEntry extends React.Component {
     }
 }
 
-export default SelfFillingNameEntry;
+export default withTranslation()(SelfFillingNameEntry);

--- a/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.test.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
+import { mockT } from 'common/test-mocks';
 import * as utils from 'common/utils';
 
 jest.mock('common/utils', () => {
@@ -26,7 +27,9 @@ describe('SelfFillingNameEntry', () => {
         onSubmitCallback = jest.fn();
 
         selfFillingNameEntry = mount(
-            <SelfFillingNameEntry onSubmit = { onSubmitCallback } />
+            <SelfFillingNameEntry
+                onSubmit = { onSubmitCallback }
+                t = { mockT } />
         );
     });
 


### PR DESCRIPTION
With tenant, the placeholder says to enter / for a custom tenant.
<img width="1545" alt="Screen Shot 2019-12-07 at 12 59 08 PM" src="https://user-images.githubusercontent.com/1243084/70380553-f2ec9f80-18f1-11ea-8699-81d457c36acf.png">

Without a tenant the placeholder remains the same.
<img width="1545" alt="Screen Shot 2019-12-07 at 1 01 04 PM" src="https://user-images.githubusercontent.com/1243084/70380554-f54ef980-18f1-11ea-8ddf-0474cbf96ac7.png">
