### PR TITLE
fix(zoom): prompt for password

### DIFF
--- a/spot-client/src/common/zoom/commands.js
+++ b/spot-client/src/common/zoom/commands.js
@@ -3,5 +3,6 @@ export default {
     JOIN: 'join',
     HANG_UP: 'hang-up',
     PING: 'ping',
+    SUBMIT_PASSWORD: 'submit-password',
     VIDEO_MUTE: 'video-mute'
 };

--- a/spot-client/src/common/zoom/errorCodes.js
+++ b/spot-client/src/common/zoom/errorCodes.js
@@ -1,0 +1,6 @@
+export default {
+    FAIL: 1,
+    ERROR_NOT_EXIST: 3001,
+    MEETING_NOT_START: 3008,
+    WRONG_MEETING_PASSWORD: 3004
+};

--- a/spot-client/src/common/zoom/index.js
+++ b/spot-client/src/common/zoom/index.js
@@ -1,2 +1,3 @@
 export { default as commands } from './commands';
+export { default as errorCodes } from './errorCodes';
 export { default as events } from './events';

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomIframeManager.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomIframeManager.js
@@ -133,6 +133,16 @@ export default class ZoomIframeManager {
     }
 
     /**
+     * Enters a password to be used to join a meeting.
+     *
+     * @param {string} password - The meeting password to use.
+     * @returns {void}
+     */
+    submitPassword(password) {
+        this._sendCommand(commands.SUBMIT_PASSWORD, { password });
+    }
+
+    /**
      * Callback invoked when the Zoom meeting sends a status update through
      * the iframe.
      *

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
@@ -6,7 +6,7 @@ import { getZoomConfiguration, setSpotTVState } from 'common/app-state';
 import { logger } from 'common/logger';
 import { COMMANDS, SERVICE_UPDATES } from 'common/remote-control';
 import { parseMeetingUrl } from 'common/utils';
-import { events } from 'common/zoom';
+import { errorCodes, events } from 'common/zoom';
 
 import { ApiHealthCheck } from '../ApiHealthCheck';
 import meetingFramePropTypes from '../meetingFramePropTypes';
@@ -155,6 +155,12 @@ export class ZoomMeetingFrame extends React.Component {
         case COMMANDS.SET_VIDEO_MUTE:
             this._zoomIframeManager.setVideoMute(data.mute);
             break;
+
+        case COMMANDS.SUBMIT_PASSWORD:
+            this.props.updateSpotTvState({ needPassword: false });
+            this._zoomIframeManager.submitPassword(data);
+
+            break;
         }
     }
 
@@ -187,21 +193,27 @@ export class ZoomMeetingFrame extends React.Component {
             // [1]: https://marketplace.zoom.us/docs/sdk/native-sdks/web/error-codes
             const zoomErrorCode = data?.error?.code;
 
-            if (zoomErrorCode === 1 || zoomErrorCode === 3001) {
-                // The error code 1 is defined as a general failure in [1], but according to the internets[2] and local
-                // testing it can happen is other cases as well including when trying to join invalid meeting ID.
+            if (zoomErrorCode === errorCodes.FAIL || zoomErrorCode === errorCodes.ERROR_NOT_EXIST) {
+                // The error code FAIL is defined as a general failure in [1], but according to the internets[2] and
+                // local testing it can happen is other cases as well including when trying to join invalid meeting ID.
                 // [2]: https://devforum.zoom.us/t/joining-fail-with-error-code-1/6417
+                logger.warn('Failed to join zoom meeting', { zoomErrorCode });
+
                 logger.log('Zoom meeting does not exist');
                 this.props.onMeetingLeave({
                     errorCode: 'meeting-not-found',
                     error: 'appEvents.meetingDoesNotExist'
                 });
-            } else if (zoomErrorCode === 3008) {
+            } else if (zoomErrorCode === errorCodes.MEETING_NOT_START) {
                 logger.log('Zoom meeting has not started');
                 this.props.onMeetingLeave({
                     errorCode: 'meeting-not-started',
                     error: 'appEvents.meetingNotStarted'
                 });
+            } else if (zoomErrorCode === errorCodes.WRONG_MEETING_PASSWORD) {
+                logger.log('password required');
+
+                this.props.updateSpotTvState({ needPassword: true });
             } else {
                 logger.warn('Failed to join zoom meeting', { zoomErrorCode });
                 this.props.onMeetingLeave({

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
@@ -197,8 +197,6 @@ export class ZoomMeetingFrame extends React.Component {
                 // The error code FAIL is defined as a general failure in [1], but according to the internets[2] and
                 // local testing it can happen is other cases as well including when trying to join invalid meeting ID.
                 // [2]: https://devforum.zoom.us/t/joining-fail-with-error-code-1/6417
-                logger.warn('Failed to join zoom meeting', { zoomErrorCode });
-
                 logger.log('Zoom meeting does not exist');
                 this.props.onMeetingLeave({
                     errorCode: 'meeting-not-found',

--- a/spot-client/src/zoom/iframe-api/IframeApi.js
+++ b/spot-client/src/zoom/iframe-api/IframeApi.js
@@ -76,6 +76,16 @@ export class IFrameApi {
 
             break;
         }
+
+        case commands.SUBMIT_PASSWORD: {
+            sdk.submitPassword(data.password)
+                .then(
+                    () => this._sendMessageToParent(events.MEETING_JOIN_SUCCEEDED),
+                    error => this._sendMessageToParent(events.MEETING_JOIN_FAILED, { error })
+                );
+            break;
+        }
+
         case commands.VIDEO_MUTE: {
             sdk.setVideoMute(data.mute);
             break;

--- a/spot-client/src/zoom/sdk/controllers/ModalController.js
+++ b/spot-client/src/zoom/sdk/controllers/ModalController.js
@@ -1,0 +1,42 @@
+/**
+ * Encapsulates interacting with the Zoom main modal.
+ */
+export default class ModalController {
+    static modalContentSelector = '.zm-modal .zm-modal-body-content .content';
+    static actionButtonsSelector = '.zm-modal-footer-default button'
+
+    /**
+     * Attempt to click a button on the modal to close it.
+     *
+     * @param {string} [dismissButtonText] - The string that displays on the
+     * button that should be clicked. Defaults to looking for "OK."
+     * @returns {void}
+     */
+    dismiss(dismissButtonText = 'OK') {
+        const modalButtons = document.querySelectorAll(ModalController.actionButtonsSelector);
+
+        Array.from(modalButtons).find(modalButton => {
+            if (modalButton.textContent === dismissButtonText) {
+                modalButton.click();
+
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Closes the modal informing specifically about needing a password to join
+     * the call. If not found, no modal will be dismissed.
+     *
+     * @returns {void}
+     */
+    dismissIncorrectPasswordModal() {
+        const modalText = document.querySelector(ModalController.modalContentSelector);
+
+        if (modalText && modalText.textContent === 'password wrong') {
+            this.dismiss();
+        }
+    }
+}

--- a/spot-client/src/zoom/sdk/controllers/index.js
+++ b/spot-client/src/zoom/sdk/controllers/index.js
@@ -1,3 +1,4 @@
 export { default as AudioMuteController } from './AudioMuteController';
 export { default as HangUpController } from './HangUpController';
+export { default as ModalController } from './ModalController';
 export { default as VideoMuteController } from './VideoMuteController';

--- a/spot-client/src/zoom/sdk/sdk.js
+++ b/spot-client/src/zoom/sdk/sdk.js
@@ -199,12 +199,10 @@ class Sdk {
      * @returns {void}
      */
     submitPassword(passWord) {
-        this._cachedJoinOptions = {
+        return this.joinMeeting({
             ...this._cachedJoinOptions,
             passWord
-        };
-
-        return this.joinMeeting(this._cachedJoinOptions);
+        });
     }
 
     /**

--- a/spot-client/src/zoom/sdk/sdk.js
+++ b/spot-client/src/zoom/sdk/sdk.js
@@ -4,10 +4,11 @@
 // into the codebase.
 const API_SECRET = process.env.DEV_ONLY_ZOOM_API_SECRET;
 
-import { events } from 'common/zoom';
+import { errorCodes, events } from 'common/zoom';
 import {
     AudioMuteController,
     HangUpController,
+    ModalController,
     VideoMuteController
 } from './controllers';
 
@@ -20,8 +21,11 @@ class Sdk {
      */
     constructor() {
         this._audioMuteController = null;
+        this._modalController = null;
         this._onStatusChange = null;
         this._videoMuteController = null;
+
+        this._cachedJoinOptions = {};
     }
 
     /**
@@ -65,6 +69,7 @@ class Sdk {
             this._audioMuteController = new AudioMuteController(muted => {
                 this._onStatusChange(events.AUDIO_MUTE_UPDATED, { muted });
             });
+            this._modalController = new ModalController();
             this._videoMuteController = new VideoMuteController(muted => {
                 this._onStatusChange(events.VIDEO_MUTE_UPDATED, { muted });
             });
@@ -93,6 +98,8 @@ class Sdk {
      * @returns {Promise}
      */
     joinMeeting(options) {
+        this._cachedJoinOptions = options;
+
         const {
             apiKey,
             meetingNumber,
@@ -144,9 +151,17 @@ class Sdk {
                         userEmail: '',
                         passWord,
                         success: res => resolve(res),
-                        error: res => reject({
-                            code: res.errorCode
-                        })
+                        error: ({ errorCode }) => {
+                            if (errorCode === errorCodes.WRONG_MEETING_PASSWORD) {
+                                setTimeout(() => {
+                                    this._modalController.dismissIncorrectPasswordModal();
+                                });
+                            }
+
+                            reject({
+                                code: errorCode
+                            });
+                        }
                     }
                 );
             })).then(() => {
@@ -175,6 +190,21 @@ class Sdk {
      */
     setVideoMute(mute) {
         this._videoMuteController.setMute(mute);
+    }
+
+    /**
+     * Tries to rejoin the meeting but with a password.
+     *
+     * @param {string} passWord - The password to use for joining the meeting.
+     * @returns {void}
+     */
+    submitPassword(passWord) {
+        this._cachedJoinOptions = {
+            ...this._cachedJoinOptions,
+            passWord
+        };
+
+        return this.joinMeeting(this._cachedJoinOptions);
     }
 
     /**


### PR DESCRIPTION
Note that the zoom's modal is being dismissed before any re-join call is made. Currently clicking "OK" dismisses the modal and leaves the page open, which may or may not be intentional on zoom's part. With the modal dismissed, join can be retried without a timeout error occurring.