### PR TITLE
ref: auto whitelist zoom domain if enabled

### DIFF
--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -145,7 +145,7 @@ export function getLoggingEndpoint(state) {
  * meetings on Jitsi-Meet deployments.
  *
  * @param {Object} state - The Redux state.
- * @returns {Object}
+ * @returns {string[]}
  */
 export function getMeetingDomainsWhitelist(state) {
     return state.config.MEETING_DOMAINS_WHITELIST;

--- a/spot-client/src/common/utils/meeting.js
+++ b/spot-client/src/common/utils/meeting.js
@@ -12,7 +12,7 @@ import { parseURIString } from 'js-utils/uri';
 export function findWhitelistedMeetingUrl(fieldsToSearch, knownDomains) {
     const linkTerminatorPattern = '[^\\s<>$]';
     const urlRegExp
-        = `http(s)?://(${knownDomains.join('|')})/${linkTerminatorPattern}+`;
+        = `http(s)?://(.*\\.)?(${knownDomains.join('|')})/${linkTerminatorPattern}+`;
 
     // Exclude static because jitsi meeting events may include urls to the
     // dial in info page, hosted in the static directory.

--- a/spot-client/src/common/utils/meeting.test.js
+++ b/spot-client/src/common/utils/meeting.test.js
@@ -14,6 +14,42 @@ describe('meeting utils', () => {
             expect(findWhitelistedMeetingUrl(fields, knownDomains)).toEqual(meetingUrl);
         });
 
+        it('handles parent domain corner cases', () => {
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://alpha.beta.meet.jit.si/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual('https://alpha.beta.meet.jit.si/m');
+
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://beta.meet.jit.si/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual('https://beta.meet.jit.si/m');
+
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://meet.jit.si/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual('https://meet.jit.si/m');
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://meet.jit.si/m' ],
+                [ 'si' ]))
+                .toEqual('https://meet.jit.si/m');
+
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://1meet.jit.si/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual(undefined);
+
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://meet.jit1.si/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual(undefined);
+
+            expect(findWhitelistedMeetingUrl(
+                [ 'https://meet.jit.si1/m' ],
+                [ 'meet.jit.si' ]))
+                .toEqual(undefined);
+        });
+
         it('can match vanity urls', () => {
             const meetingUrl = 'https://lenny.jitsi.net/testmeeting';
             const fields = [
@@ -21,7 +57,7 @@ describe('meeting utils', () => {
                 `alternative testing meeting url at ${meetingUrl}`,
                 'agenda is to talk about work'
             ];
-            const knownDomains = [ '.*jitsi.net' ];
+            const knownDomains = [ 'jitsi.net' ];
 
             expect(findWhitelistedMeetingUrl(fields, knownDomains)).toEqual(meetingUrl);
         });

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -8,6 +8,7 @@ import {
     getRemoteControlServerConfig,
     getSpotServicesConfig,
     getTemporaryRemoteIds,
+    isZoomEnabled,
     reconnectScheduleUpdate,
     removePairedRemote,
     setCustomerId,
@@ -535,12 +536,17 @@ export function updateSpotTVSource() {
  */
 export function redirectToMeeting(meetingNameOrUrl, { invites, meetingDisplayName, screenshare, startWithVideoMuted }) {
     return (dispatch, getState) => {
+        const state = getState();
+        const domainWhitelist = getMeetingDomainsWhitelist(state);
+
+        isZoomEnabled(state) && domainWhitelist.push('zoom.us');
+
         let location;
 
-        if (isValidMeetingUrl(meetingNameOrUrl, getMeetingDomainsWhitelist(getState()))) {
+        if (isValidMeetingUrl(meetingNameOrUrl, domainWhitelist)) {
             location = meetingNameOrUrl;
         } else if (isValidMeetingName(meetingNameOrUrl)) {
-            location = `https://${getDefaultMeetingDomain(getState())}/${meetingNameOrUrl}`;
+            location = `https://${getDefaultMeetingDomain(state)}/${meetingNameOrUrl}`;
         } else {
             logger.error(`redirectToMeeting - invalid meeting URL: ${meetingNameOrUrl}`);
 

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/MeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/MeetingFrame.js
@@ -1,8 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
-import { isZoomEnabled } from 'common/app-state';
 import { isZoomMeetingUrl } from 'common/utils';
 
 import AbstractMeetingFrame from './AbstractMeetingFrame';
@@ -16,10 +13,7 @@ import { ZoomMeetingFrame } from './ZoomMeetingFrame';
  * @extends React.Component
  */
 export class MeetingFrame extends Component {
-    static propTypes = {
-        ...AbstractMeetingFrame.propTypes,
-        allowZoomMeetings: PropTypes.bool
-    };
+    static propTypes = AbstractMeetingFrame.propTypes;
 
     /**
      * Implements React's {@link Component#render()}.
@@ -28,30 +22,12 @@ export class MeetingFrame extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const {
-            allowZoomMeetings,
-            ...otherProps
-        } = this.props;
-
-        if (allowZoomMeetings && isZoomMeetingUrl(otherProps.meetingUrl)) {
-            return <ZoomMeetingFrame { ...otherProps } />;
+        if (isZoomMeetingUrl(this.props.meetingUrl)) {
+            return <ZoomMeetingFrame { ...this.props } />;
         }
 
-        return <JitsiMeetingFrame { ...otherProps } />;
+        return <JitsiMeetingFrame { ...this.props } />;
     }
 }
 
-/**
- * Selects parts of the Redux state to pass in with the props of {@code MeetingFrame}.
- *
- * @param {Object} state - The Redux state.
- * @private
- * @returns {Object}
- */
-function mapStateToProps(state) {
-    return {
-        allowZoomMeetings: isZoomEnabled(state)
-    };
-}
-
-export default connect(mapStateToProps)(MeetingFrame);
+export default MeetingFrame;


### PR DESCRIPTION
Automagically includes 'zoom.us' domain if zoom is enabled. Check for zoom enabled only on the redirect to meeting action, because it's earlier and seems to be the gate for the TV to join a meeting.