### PR TITLE
feat(zoom): pass error to spot-client to be logged

### DIFF
--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
@@ -239,7 +239,10 @@ export class ZoomMeetingFrame extends AbstractMeetingFrame {
                     waitingForMeetingStart: false
                 });
             } else {
-                logger.warn('Failed to join zoom meeting', { zoomErrorCode });
+                logger.warn('Failed to join zoom meeting', {
+                    data,
+                    zoomErrorCode
+                });
                 this._onMeetingLeave({
                     errorCode: 'failed-to-join',
                     error: 'appEvents.meetingJoinFailed'

--- a/spot-client/src/zoom/iframe-api/IframeApi.js
+++ b/spot-client/src/zoom/iframe-api/IframeApi.js
@@ -136,6 +136,19 @@ export class IFrameApi {
      * @returns {void}
      */
     _sendMessageToParent(type, data = {}) {
+        // Special case for Error as it  doesn't convert to JSON auto magically
+        if (data.error && (data.error.message || data.error.stack)) {
+            this._transport.sendEvent({
+                type,
+                data: {
+                    error: {
+                        message: data.error.message,
+                        stack: data.error.stack
+                    }
+                }
+            });
+        }
+
         this._transport.sendEvent({
             type,
             data


### PR DESCRIPTION
If promise is reject it sends back message with an empty 'error' field. Try to store 'message' and 'stack' of an Error and pass it over to the spot parent window to be logged.