### PR TITLE
ref(zoom): use a combined selector to calculate domain whitelist

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -10480,6 +10480,12 @@
                 "lodash": "^4.17.14"
             }
         },
+        "reselect": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+            "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+            "dev": true
+        },
         "resolve": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -71,6 +71,7 @@
         "react-router-dom": "5.1.0",
         "redux": "4.0.4",
         "redux-thunk": "2.3.0",
+        "reselect": "4.0.0",
         "sass-loader": "8.0.0",
         "string-replace-loader": "2.2.0",
         "strophe.js": "1.2.16",

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 /**
  * A selector which returns the name of an application to advertise which has
  * integration with Jitsi-Meet-Spot.
@@ -141,8 +143,34 @@ export function getLoggingEndpoint(state) {
 }
 
 /**
- * A selector which gets the list of meeting domains that are known to support
- * meetings on Jitsi-Meet deployments.
+ * A selector which gets the full list of domains which can be shown in the
+ * meeting view. The list is calculated based on not only on the explicit
+ * whitelist but other enabled features.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {string[]}
+ */
+export const getAllAllowedMeetingDomains = createSelector(
+    getMeetingDomainsWhitelist,
+    getJwtDomains,
+    isZoomEnabled,
+    (whitelistedDomains, jwtDomains, allowZoomDomains) => {
+        const explicitlyWhitelisted = [
+            ...whitelistedDomains,
+            ...jwtDomains
+        ];
+
+        if (allowZoomDomains) {
+            explicitlyWhitelisted.push('zoom.us');
+        }
+
+        return Array.from(new Set(explicitlyWhitelisted));
+    }
+);
+
+/**
+ * A selector which gets the list of meeting domains which are allowed to be
+ * joined as meetings.
  *
  * @param {Object} state - The Redux state.
  * @returns {string[]}

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -4,11 +4,10 @@ import {
     clearAllPairedRemotes,
     destroyConnection,
     getJoinCodeRefreshRate,
-    getMeetingDomainsWhitelist,
+    getAllAllowedMeetingDomains,
     getRemoteControlServerConfig,
     getSpotServicesConfig,
     getTemporaryRemoteIds,
-    isZoomEnabled,
     reconnectScheduleUpdate,
     removePairedRemote,
     setCustomerId,
@@ -537,9 +536,7 @@ export function updateSpotTVSource() {
 export function redirectToMeeting(meetingNameOrUrl, { invites, meetingDisplayName, screenshare, startWithVideoMuted }) {
     return (dispatch, getState) => {
         const state = getState();
-        const domainWhitelist = getMeetingDomainsWhitelist(state);
-
-        isZoomEnabled(state) && domainWhitelist.push('zoom.us');
+        const domainWhitelist = getAllAllowedMeetingDomains(state);
 
         let location;
 

--- a/spot-client/src/spot-tv/ui/loaders/withCalendar.js
+++ b/spot-client/src/spot-tv/ui/loaders/withCalendar.js
@@ -7,8 +7,7 @@ import {
     getCalendarEmail,
     getCalendarType,
     getJwt,
-    getJwtDomains,
-    getMeetingDomainsWhitelist,
+    getAllAllowedMeetingDomains,
     isSetupComplete,
     setCalendarEvents,
     setCalendarError
@@ -110,10 +109,7 @@ export class CalendarLoader extends AbstractLoader {
     _loadService() {
         calendarService.setConfig(
             this.props.calendarConfig,
-            [
-                ...this.props.meetingsDomainsWhitelist,
-                ...this.props.jwtDomains
-            ]
+            this.props.meetingsDomainsWhitelist
         );
 
         return calendarService.initialize(this.props.calendarType)
@@ -185,8 +181,7 @@ function mapStateToProps(state) {
                 && ((calendarType === calendarTypes.BACKEND && Boolean(jwt))
                         || Boolean(calendarEmail)),
         jwt,
-        jwtDomains: getJwtDomains(state),
-        meetingsDomainsWhitelist: getMeetingDomainsWhitelist(state)
+        meetingsDomainsWhitelist: getAllAllowedMeetingDomains(state)
     };
 }
 


### PR DESCRIPTION
This way multiple code paths can use the same logic to get
the full list of whitelisted domains,, which is now a generated
list due to zoom being whitelisted without being explicitly
specified as whitelisted in the config.

Reselect is brought in so that the generated array
of allowed domains can be memoized to avoid triggering
re-renders when the array is passed in as props.