### PR TITLE
fix(zoom): pass JWT to integrations service 

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -10480,6 +10480,12 @@
                 "lodash": "^4.17.14"
             }
         },
+        "reselect": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+            "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+            "dev": true
+        },
         "resolve": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -71,6 +71,7 @@
         "react-router-dom": "5.1.0",
         "redux": "4.0.4",
         "redux-thunk": "2.3.0",
+        "reselect": "4.0.0",
         "sass-loader": "8.0.0",
         "string-replace-loader": "2.2.0",
         "strophe.js": "1.2.16",

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -127,9 +127,32 @@ export function getJoinCodeRefreshRate(state) {
  * @param {Object} state - The Redux state.
  * @returns {Array<string>}
  */
-export function getJwtDomains(state) {
+function _getConfiguredJwtDomains(state) {
     return state.config.SPOT_SERVICES.jwtDomains;
 }
+
+/**
+ * A selector which returns domains for which the backend-provided JWT is valid.
+ * Injects Zoom support if Zoom support is enabled.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {Array<string>}
+ */
+export const getJwtDomains = createSelector(
+    _getConfiguredJwtDomains,
+    isZoomEnabled,
+    (configuredJwtDomains, allowZoomDomains) => {
+        const explicitlyWhitelisted = [
+            ...configuredJwtDomains
+        ];
+
+        if (allowZoomDomains) {
+            explicitlyWhitelisted.push('zoom.us');
+        }
+
+        return Array.from(new Set(explicitlyWhitelisted));
+    }
+);
 
 /**
 * A selector which returns a unique id used for identifying the current client
@@ -152,7 +175,7 @@ export function getLoggingEndpoint(state) {
  */
 export const getAllAllowedMeetingDomains = createSelector(
     getMeetingDomainsWhitelist,
-    getJwtDomains,
+    _getConfiguredJwtDomains,
     isZoomEnabled,
     (whitelistedDomains, jwtDomains, allowZoomDomains) => {
         const explicitlyWhitelisted = [

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 /**
  * A selector which returns the name of an application to advertise which has
  * integration with Jitsi-Meet-Spot.
@@ -141,8 +143,34 @@ export function getLoggingEndpoint(state) {
 }
 
 /**
- * A selector which gets the list of meeting domains that are known to support
- * meetings on Jitsi-Meet deployments.
+ * A selector which gets the full list of domains which can be shown in the
+ * meeting view. The list is calculated based on not only on the explicit
+ * whitelist but other enabled features.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {string[]}
+ */
+export const getAllAllowedMeetingDomains = createSelector(
+    getMeetingDomainsWhitelist,
+    getJwtDomains,
+    isZoomEnabled,
+    (whitelistedDomains, jwtDomains, allowZoomDomains) => {
+        const explicitlyWhitelisted = [
+            ...whitelistedDomains,
+            ...jwtDomains
+        ];
+
+        if (allowZoomDomains) {
+            explicitlyWhitelisted.push('zoom.us');
+        }
+
+        return Array.from(new Set(explicitlyWhitelisted));
+    }
+);
+
+/**
+ * A selector which gets the list of meeting domains which are allowed to be
+ * joined as meetings.
  *
  * @param {Object} state - The Redux state.
  * @returns {string[]}

--- a/spot-client/src/spot-tv/app-state/actions.js
+++ b/spot-client/src/spot-tv/app-state/actions.js
@@ -4,11 +4,10 @@ import {
     clearAllPairedRemotes,
     destroyConnection,
     getJoinCodeRefreshRate,
-    getMeetingDomainsWhitelist,
+    getAllAllowedMeetingDomains,
     getRemoteControlServerConfig,
     getSpotServicesConfig,
     getTemporaryRemoteIds,
-    isZoomEnabled,
     reconnectScheduleUpdate,
     removePairedRemote,
     setCustomerId,
@@ -537,9 +536,7 @@ export function updateSpotTVSource() {
 export function redirectToMeeting(meetingNameOrUrl, { invites, meetingDisplayName, screenshare, startWithVideoMuted }) {
     return (dispatch, getState) => {
         const state = getState();
-        const domainWhitelist = getMeetingDomainsWhitelist(state);
-
-        isZoomEnabled(state) && domainWhitelist.push('zoom.us');
+        const domainWhitelist = getAllAllowedMeetingDomains(state);
 
         let location;
 

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomIframeManager.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomIframeManager.js
@@ -11,6 +11,9 @@ export default class ZoomIframeManager {
      * @param {Object} options - Configuration for the new instance.
      * @param {string} options.apiKey - The Zoom client key to use for joining
      * meetings.
+     * @param {string} options.jwt - The JWT used to verify the Spot-TV instance
+     * while interacting with integration services that provide information on
+     * how to join Zoom meetings.
      * @param {string} options.meetingSignService - The url to call to encode
      * the meeting ID, per Zoom's requirements.
      * @param {HTMLElement} options.iframeTarget - The element to which to
@@ -52,6 +55,7 @@ export default class ZoomIframeManager {
     goToMeeting(meetingNumber, passWord, userName) {
         this._sendCommand(commands.JOIN, {
             apiKey: this._options.apiKey,
+            jwt: this._options.jwt,
             userName,
             passWord,
             meetingNumber,

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/ZoomMeetingFrame/ZoomMeetingFrame.js
@@ -52,6 +52,7 @@ export class ZoomMeetingFrame extends AbstractMeetingFrame {
         this._zoomIframeManager = new ZoomIframeManager({
             apiKey: this.props.apiKey,
             iframeTarget: this._rootRef.current,
+            jwt: this.props.jwt,
             meetingSignService: this.props.meetingSignService,
             onMeetingUpdateReceived: this._onMeetingUpdateReceived
         });

--- a/spot-client/src/spot-tv/ui/loaders/withCalendar.js
+++ b/spot-client/src/spot-tv/ui/loaders/withCalendar.js
@@ -7,8 +7,7 @@ import {
     getCalendarEmail,
     getCalendarType,
     getJwt,
-    getJwtDomains,
-    getMeetingDomainsWhitelist,
+    getAllAllowedMeetingDomains,
     isSetupComplete,
     setCalendarEvents,
     setCalendarError
@@ -110,10 +109,7 @@ export class CalendarLoader extends AbstractLoader {
     _loadService() {
         calendarService.setConfig(
             this.props.calendarConfig,
-            [
-                ...this.props.meetingsDomainsWhitelist,
-                ...this.props.jwtDomains
-            ]
+            this.props.meetingsDomainsWhitelist
         );
 
         return calendarService.initialize(this.props.calendarType)
@@ -185,8 +181,7 @@ function mapStateToProps(state) {
                 && ((calendarType === calendarTypes.BACKEND && Boolean(jwt))
                         || Boolean(calendarEmail)),
         jwt,
-        jwtDomains: getJwtDomains(state),
-        meetingsDomainsWhitelist: getMeetingDomainsWhitelist(state)
+        meetingsDomainsWhitelist: getAllAllowedMeetingDomains(state)
     };
 }
 

--- a/spot-client/src/spot-tv/ui/views/meeting.js
+++ b/spot-client/src/spot-tv/ui/views/meeting.js
@@ -24,6 +24,7 @@ import { isBackendEnabled } from 'common/backend';
 import { logger } from 'common/logger';
 import { ROUTES } from 'common/routing';
 import { Loading } from 'common/ui';
+import { findWhitelistedMeetingUrl } from 'common/utils';
 
 import { disconnectAllTemporaryRemotes, setMeetingSummary } from './../../app-state';
 import {
@@ -82,9 +83,9 @@ export class Meeting extends React.Component {
         this._useJwt = false;
 
         if (this._queryParams.location && props.jwt) {
-            const { host } = new URL(this._queryParams.location);
-
-            this._useJwt = props.jwtDomains.includes(host);
+            this._useJwt = Boolean(findWhitelistedMeetingUrl(
+                [ this._queryParams.location ], props.jwtDomains
+            ));
         }
 
         this.state = {

--- a/spot-client/src/zoom/sdk/sdk.js
+++ b/spot-client/src/zoom/sdk/sdk.js
@@ -102,6 +102,7 @@ class Sdk {
 
         const {
             apiKey,
+            jwt,
             meetingNumber,
             meetingSignService,
             passWord = '',
@@ -129,6 +130,7 @@ class Sdk {
                     role: 0
                 }),
                 headers: {
+                    'Authorization': `Bearer ${jwt}`,
                     'content-type': 'application/json'
                 },
                 method: 'POST',


### PR DESCRIPTION
So only validated Spot instances can request
a signed Zoom meeting number. The getJwtDomains
selector has been modified so that Zoom is
automatically injected as a JWT domain if
Zoom is enabled--this follows the pattern
set by getAllAllowedMeetingDomains.

Built on top of https://github.com/jitsi/jitsi-meet-spot/pull/718.