### PR TITLE
fix(error-boundary): remove View component usage

### DIFF
--- a/spot-client/src/common/ui/views/fatal-error.js
+++ b/spot-client/src/common/ui/views/fatal-error.js
@@ -8,8 +8,6 @@ import { ROUTES } from 'common/routing';
 
 import { Countdown, StatusOverlay } from './../components';
 
-import View from './view';
-
 /**
  * A component for showing a potentially fatal error has occurred and providing
  * the ability to reload the app or reset app state.
@@ -42,14 +40,12 @@ export class FatalError extends React.Component {
      */
     render() {
         return (
-            <View name = 'error'>
-                <StatusOverlay title = { this.props.t('appStatus.unexpectedError') }>
-                    <div>{ this.props.t('appStatus.willReload') }</div>
-                    <Countdown
-                        onCountdownComplete = { this._onReload }
-                        startTime = { 10 } />
-                </StatusOverlay>
-            </View>
+            <StatusOverlay title = { this.props.t('appStatus.unexpectedError') }>
+                <div>{ this.props.t('appStatus.willReload') }</div>
+                <Countdown
+                    onCountdownComplete = { this._onReload }
+                    startTime = { 10 } />
+            </StatusOverlay>
         );
     }
 


### PR DESCRIPTION
The View component uses RCS to notify remotes
of the TV's current view. However, if an error
occurred in RCS, it is possible that trying to
use View will cause another error in RCS,
preventing the error boundary from displaying.
Instead, just show the status overlay and
let the TV reconnect.