### PR TITLE
fix(p2p): catch RTCDataChannel.send error

### DIFF
--- a/spot-client/src/common/remote-control/P2PSignalingClient.js
+++ b/spot-client/src/common/remote-control/P2PSignalingClient.js
@@ -143,11 +143,14 @@ export default class P2PSignalingClient extends P2PSignalingBase {
         };
 
         const promise = new Promise(function (resolve, reject) {
-            this._peerConnection.sendDataChannelMessage(JSON.stringify({
+            if (!this._peerConnection.sendDataChannelMessage(JSON.stringify({
                 requestId,
                 command,
                 data
-            }));
+            }))) {
+                this._p2pSignalingRequests.delete(requestId);
+                reject('Failed to send command over P2P');
+            }
 
             this.resolve = resolve;
             this.reject = reject;

--- a/spot-client/src/common/webrtc/PeerConnection.js
+++ b/spot-client/src/common/webrtc/PeerConnection.js
@@ -182,15 +182,22 @@ export default class PeerConnection extends Emitter {
      * Sends a message over the data channel. Can be used only if the data channel is currently active.
      *
      * @param {string} message - A string to send.
-     * @returns {void}
-     * @throws an error if {@link isDataChannelActive} returns {@code false}.
+     * @returns {boolean}
      */
     sendDataChannelMessage(message) {
         if (!this.isDataChannelActive()) {
-            throw new Error('Data channel is not ready');
+            return false;
         }
 
-        this._dataChannel.send(message);
+        try {
+            this._dataChannel.send(message);
+
+            return true;
+        } catch (error) {
+            logger.error('sendDataChannelMessage failed', { error });
+
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
If send is called from the RTCDataChannel 'onmessage' event callback,
the channel's ready state or peerconnection's ICE state may not be up
to date and the app may crash while trying to send on closed connection.

Make sendDataChannelMessage return boolean and never throw. Handles
the result only where it matters.