### PR TITLE
fix(deps): use jitsi fork of quietjs

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -9400,8 +9400,8 @@
             }
         },
         "lib-quiet-js": {
-            "version": "github:virtuacoplenny/quiet-js#8d39b3d26e039a1ea4110e8c6eec717423de8d0e",
-            "from": "github:virtuacoplenny/quiet-js#lenny/rewrite",
+            "version": "github:jitsi/quiet-js#939beeaa824c0a088958cbbefab19e549f2e0deb",
+            "from": "github:jitsi/quiet-js#939beeaa824c0a088958cbbefab19e549f2e0deb",
             "dev": true
         },
         "libphonenumber-js": {

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -53,7 +53,7 @@
         "jsdoc": "3.6.3",
         "jwt-decode": "2.2.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#a909e594868b17f0c72c85f2a231384f4cb1ea61",
-        "lib-quiet-js": "github:virtuacoplenny/quiet-js#lenny/rewrite",
+        "lib-quiet-js": "github:jitsi/quiet-js#939beeaa824c0a088958cbbefab19e549f2e0deb",
         "libphonenumber-js": "1.7.29",
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",


### PR DESCRIPTION
Brief history: the queitjs fork currently in
use was supposed to be temporary, but was worked
on with the maintainer of quietjs. Another spot
team member was supposed to work on the "official"
quietjs rewrite but did not deliver so the
temporary fork continued to be used. So for
now, with ultrasound work not close to being
on the radar, the temporary fork has been combined
into jitsi's official quietjs fork.