### PR TITLE
fix(logging): revert logger update due to invalid json format

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -8967,8 +8967,8 @@
             }
         },
         "jitsi-meet-logger": {
-            "version": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
-            "from": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
+            "version": "github:jitsi/jitsi-meet-logger#5da3033d647054457597920252b3387fa43a17fa",
+            "from": "github:jitsi/jitsi-meet-logger#5da3033d647054457597920252b3387fa43a17fa",
             "dev": true
         },
         "jquery": {

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -47,7 +47,7 @@
         "inspectpack": "4.2.2",
         "jest": "24.9.0",
         "jest-fetch-mock": "3.0.1",
-        "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
+        "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5da3033d647054457597920252b3387fa43a17fa",
         "jquery": "3.4.1",
         "js-utils": "github:jitsi/js-utils#400ce825d3565019946ee75d86ed773c6f21e117",
         "jsdoc": "3.6.3",


### PR DESCRIPTION
Logger used to return a json stringified object, but the
latest version includes a timestamp as the beginning. For
now the easiest/safest way to unblock the next release I
see is reverting this update.