### PR TITLE
electron: add audio-input and allow-jit

### DIFF
--- a/spot-electron/entitlements.mac.plist
+++ b/spot-electron/entitlements.mac.plist
@@ -2,11 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <key>com.apple.security.device.bluetooth</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>


### PR DESCRIPTION
Try adding 'audio-input' because com.apple.security.device.microphone does not always work.

I don't understand the 'allow-jit' flag, but the internet says it's javascript core related, so better to have it.