### PR TITLE
Param to enable volume control

### DIFF
--- a/spot-client/src/common/app-state/spot-tv/reducer.js
+++ b/spot-client/src/common/app-state/spot-tv/reducer.js
@@ -20,6 +20,7 @@ const DEFAULT_STATE = {
     tileView: false,
     videoMuted: true,
     view: undefined,
+    volumeControlSupported: false,
     waitingForMeetingStart: false
 
     // FIXME: setting the default prevents wired screensharing from being

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -101,5 +101,7 @@ export function isConnectedToSpot(state) {
  * @returns {boolean}
  */
 export function isVolumeControlSupported(state) {
-    return Boolean(state.spotTv.electron);
+    const { electron, volumeControlSupported } = state.spotTv;
+
+    return Boolean(electron || volumeControlSupported);
 }

--- a/spot-client/src/common/app-state/spot-tv/spotTv.test.js
+++ b/spot-client/src/common/app-state/spot-tv/spotTv.test.js
@@ -93,7 +93,19 @@ describe('spotTv state', () => {
         });
 
         it('is enabled when in electron', () => {
-            dispatch(actions.setSpotTVState({ electron: true }));
+            dispatch(actions.setSpotTVState({
+                electron: true,
+                volumeControlSupported: false
+            }));
+
+            expect(selectors.isVolumeControlSupported(getState())).toBe(true);
+        });
+
+        it('is enabled when receives start param', () => {
+            dispatch(actions.setSpotTVState({
+                electron: false,
+                volumeControlSupported: true
+            }));
 
             expect(selectors.isVolumeControlSupported(getState())).toBe(true);
         });

--- a/spot-client/src/common/utils/store-persistence.js
+++ b/spot-client/src/common/utils/store-persistence.js
@@ -39,6 +39,7 @@ const keysToStore = [
     'setup.preferredSpeaker',
     'spot-tv/backend.longLivedPairingCodeInfo',
     'spotTv.fixedCodeSegment',
+    'spotTv.volumeControlSupported',
     'spotRemote.completedOnboarding',
     'spotRemote.mostRecentCountryCode',
     'wiredScreenshare.deviceLabel',
@@ -104,7 +105,8 @@ function parsePersistedState(state) {
             longLivedPairingCodeInfo: state['spot-tv/backend'].longLivedPairingCodeInfo
         },
         spotTv: {
-            fixedCodeSegment: state.spotTv.fixedCodeSegment
+            fixedCodeSegment: state.spotTv.fixedCodeSegment,
+            volumeControlSupported: state.spotTv.volumeControlSupported
         },
         spotRemote: {
             completedOnboarding: state.spotRemote.completedOnboarding,
@@ -142,9 +144,7 @@ export function getPersistedState() {
 export function setPersistedState(store) {
     const newState = parsePersistedState(store.getState());
 
-    // Check if cached state exists to intentionally skip a save request being
-    // triggered due to the initial hydrating of the redux store.
-    if (cachedState && hasUpdateOfInterest(cachedState, newState)) {
+    if (!cachedState || hasUpdateOfInterest(cachedState, newState)) {
         persistence.set(STORE_PERSISTENCE_KEY, newState);
     }
 

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -30,6 +30,7 @@ import {
     remoteControlClient
 } from 'common/remote-control';
 import {
+    getBoolean,
     getPersistedState,
     loadScript,
     setPersistedState
@@ -48,7 +49,14 @@ for (const [ key, value ] of queryParams.entries()) {
 
 const store = createStore(
     ReducerRegistry.combineReducers(reducers),
-    defaultsDeep({}, getPersistedState(), {
+    defaultsDeep({}, {
+        spotTv: {
+            // This needs to overwrite the persisted value if it's defined in the params
+            volumeControlSupported: startParams.volumeControlSupported
+                ? getBoolean(startParams.volumeControlSupported)
+                : undefined
+        }
+    }, getPersistedState(), {
         config: {
             ...setDefaultValues(window.JitsiMeetSpotConfig)
         },

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -65,6 +65,7 @@ const presenceToStore = [
     'tileView',
     'videoMuted',
     'view',
+    'volumeControlSupported',
     'waitingForMeetingStart',
     'wiredScreensharingEnabled'
 ];


### PR DESCRIPTION
This PR allows the spot tv runtime environment to append a `volumeControlSupported` param to enable the hardware volume control functionality if the runtime environment supports that.

Please note it's rebased on top of https://github.com/jitsi/jitsi-meet-spot/pull/766 so please approve that first