### PR TITLE
signal llpc through the API

### DIFF
--- a/spot-client/src/spot-tv/native-functions/native-controller/middleware.js
+++ b/spot-client/src/spot-tv/native-functions/native-controller/middleware.js
@@ -2,7 +2,7 @@
 import { SPOT_TV_SET_REMOTE_JOIN_CODE, SPOT_TV_SET_STATE } from 'common/app-state';
 import { BOOTSTRAP_COMPLETE } from 'common/app-state/bootstrap';
 import { MiddlewareRegistry } from 'common/redux';
-
+import { SET_LONG_LIVED_PAIRING_CODE_INFO, getLongLivedPairingCodeInfo } from 'spot-tv/backend';
 import nativeController from './native-controller';
 
 /**
@@ -11,12 +11,16 @@ import nativeController from './native-controller';
  * @param {Store} store - The redux store.
  * @returns {Function}
  */
-MiddlewareRegistry.register(() => next => action => {
+MiddlewareRegistry.register(({ getState }) => next => action => {
     const result = next(action);
 
     switch (action.type) {
     case BOOTSTRAP_COMPLETE:
         nativeController._sendSpotClientReady();
+        sendLongLivedPairingCode(getLongLivedPairingCodeInfo(getState()));
+        break;
+    case SET_LONG_LIVED_PAIRING_CODE_INFO:
+        sendLongLivedPairingCode(action.longLivedPairingCodeInfo);
         break;
     case SPOT_TV_SET_REMOTE_JOIN_CODE:
         nativeController.sendMessage('updateJoinCode', {
@@ -30,6 +34,18 @@ MiddlewareRegistry.register(() => next => action => {
 
     return result;
 });
+
+/**
+ * Sends the long lived pairing code through the external API when updated.
+ *
+ * @param {Object} codeInfo - The pairing code info we have on record.
+ * @returns {void}
+ */
+function sendLongLivedPairingCode(codeInfo) {
+    nativeController.sendMessage('updateLongLivedPairingCode', {
+        longLivedPairingCode: (codeInfo || {}).code
+    });
+}
 
 /**
  * Sends part of the new state through the external API if necessary.

--- a/spot-client/src/spot-tv/native-functions/native-controller/native-controller.js
+++ b/spot-client/src/spot-tv/native-functions/native-controller/native-controller.js
@@ -100,6 +100,8 @@ class NativeController extends Emitter {
             args
         };
 
+        logger.info(`Sending native command ${JSON.stringify(commandObject)}`);
+
         if (this.ipcRenderer) {
             this.ipcRenderer.send('native-command', commandObject);
         } else if (this.messageSender) {


### PR DESCRIPTION
Turned out that the fact that temp controllers disconnect on leave, makes us unable to use that pairing method for poly remotes. Therefore I added this additional step to signal the long lived pairing code the same way as we signal the temp code, so then the poly remote can use that instead