### PR TITLE
add meeting state native command

### DIFF
--- a/spot-client/src/spot-tv/native-functions/middleware.js
+++ b/spot-client/src/spot-tv/native-functions/middleware.js
@@ -1,10 +1,17 @@
 
-import { SPOT_TV_SET_REMOTE_JOIN_CODE, SPOT_TV_SET_STATE } from 'common/app-state';
+import { SPOT_TV_SET_REMOTE_JOIN_CODE, SPOT_TV_SET_STATE, getCurrentView } from 'common/app-state';
 import { BOOTSTRAP_COMPLETE } from 'common/app-state/bootstrap';
-import { MiddlewareRegistry } from 'common/redux';
+import { MiddlewareRegistry, StateListenerRegistry } from 'common/redux';
 import { SET_LONG_LIVED_PAIRING_CODE_INFO, getLongLivedPairingCodeInfo } from 'spot-tv/backend';
 import nativeCommands from './native-commands';
 import nativeController from './native-controller';
+
+/**
+ * State listener to listen to meeting status changes.
+ */
+StateListenerRegistry.register(state => getCurrentView(state) === 'meeting', inMeeting => {
+    nativeCommands.sendMeetingStatus(inMeeting ? 1 : 0);
+});
 
 /**
  * The redux middleware for the native-controller feature.

--- a/spot-client/src/spot-tv/native-functions/native-commands.js
+++ b/spot-client/src/spot-tv/native-functions/native-commands.js
@@ -39,6 +39,22 @@ export default class NativeCommands {
     }
 
     /**
+     * Informs the runtime that the meeting status has changed.
+     *
+     * 0: Idle (not in meeting)
+     * 1: In meeting
+     * (More statuses to come, e.g. content sharing).
+     *
+     * @param {number} status - The new meeting status.
+     * @returns {void}
+     */
+    static sendMeetingStatus(status) {
+        nativeController.sendMessage('meetingStatus', {
+            status
+        });
+    }
+
+    /**
      * Informs the runtime that the state of update-ability has changed.
      *
      * @param {boolean} okToUpdate - True if ok to update, false otherwise.


### PR DESCRIPTION
This PR adds a new native API signal: meeting state.

This is required for the PolyOS api ```CallState```: https://ftp-usa.polycom.com/~betasupport/BETA/G7500/javadoc/index.html?com/poly/polyos/app/CallState.html