### PR TITLE
feat: don't activate beacons on permanently paired remotes

### DIFF
--- a/spot-client/src/spot-remote/ui/views/JoinCodeEntry.test.js
+++ b/spot-client/src/spot-remote/ui/views/JoinCodeEntry.test.js
@@ -27,6 +27,7 @@ describe('JoinCodeEntry', () => {
     let historyMock,
         locationMock,
         onDisconnectSpy,
+        sendJoinCodeNeededSpy,
         updateReadyStatusSpy;
 
     beforeEach(() => {
@@ -37,6 +38,7 @@ describe('JoinCodeEntry', () => {
             pathname: '/'
         };
         onDisconnectSpy = jest.fn();
+        sendJoinCodeNeededSpy = jest.fn();
         updateReadyStatusSpy = jest.fn();
     });
 
@@ -52,6 +54,7 @@ describe('JoinCodeEntry', () => {
             history: historyMock,
             location: locationMock,
             onDisconnect: onDisconnectSpy,
+            sendJoinCodeNeeded: sendJoinCodeNeededSpy,
             t: mockT,
             updateReadyStatus: updateReadyStatusSpy,
             ...propOverrides

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -47,6 +47,7 @@ export class JoinCodeEntry extends React.Component {
         onDisconnect: PropTypes.func,
         permanentPairingCode: PropTypes.string,
         productName: PropTypes.string,
+        sendJoinCodeNeeded: PropTypes.func,
         shareDomain: PropTypes.string,
         t: PropTypes.func,
         updateReadyStatus: PropTypes.func
@@ -121,6 +122,11 @@ export class JoinCodeEntry extends React.Component {
 
             return;
         }
+
+        // By this time, we determined that we're waiting for
+        // a join code to be entered, so we're telling it to the
+        // API to react (if need be).
+        this.props.sendJoinCodeNeeded();
     }
 
     /**
@@ -400,6 +406,15 @@ function mapDispatchToProps(dispatch) {
          */
         onDisconnect() {
             dispatch(disconnectFromSpotTV());
+        },
+
+        /**
+         * Tells the API that the remote is waiting for a join code.
+         *
+         * @returns {void}
+         */
+        sendJoinCodeNeeded() {
+            dispatch(sendApiMessage('joinCodeNeeded'));
         },
 
         /**


### PR DESCRIPTION
This PR makes the controller smarter by only activating beacon detection when the remote is waiting for a join code to be entered (not permanently paired, not in a meeting..etc).