### PR TITLE
feat(spot-client): enable https for dev webpack

### DIFF
--- a/spot-client/webpack.config.js
+++ b/spot-client/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
         contentBase: path.join(__dirname, '/'),
         historyApiFallback: true,
         host: '0.0.0.0',
+        https: true,
         port: 8000,
         publicPath: '/dist/'
     },

--- a/spot-webdriver/constants/index.js
+++ b/spot-webdriver/constants/index.js
@@ -1,4 +1,4 @@
-const TEST_SERVER_URL = process.env.TEST_SERVER_URL || 'http://localhost:8000';
+const TEST_SERVER_URL = process.env.TEST_SERVER_URL || 'https://localhost:8000';
 
 module.exports = {
     /**


### PR DESCRIPTION
Without it Chrome will not allow access to the audio/video devices.