### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/spot-client/src/common/utils/random.js
+++ b/spot-client/src/common/utils/random.js
@@ -8,5 +8,5 @@ export function generateRandomString(length) {
     // XXX the method may not always give desired length above 9
     return Math.random()
         .toString(36)
-        .substr(2, length);
+        .slice(2, 2 + length);
 }

--- a/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.js
@@ -175,7 +175,7 @@ export class SelfFillingNameEntry extends React.Component {
 
             // Otherwise show the random name letter-by-letter.
             this.setState({
-                animatingPlaceholder: this._fullGeneratedMeetingName.substr(
+                animatingPlaceholder: this._fullGeneratedMeetingName.slice(
                     0, currentLengthToShow)
             });
 

--- a/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.test.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-name-entry/SelfFillingNameEntry.test.js
@@ -60,7 +60,7 @@ describe('SelfFillingNameEntry', () => {
             jest.advanceTimersByTime(animationRevealRate + 1);
 
             expect(selfFillingNameEntry.state().animatingPlaceholder)
-                .toBe(RANDOM_MEETING.substr(0, 1));
+                .toBe(RANDOM_MEETING.slice(0, 1));
         });
 
         it('shows one character at a time', () => {
@@ -69,7 +69,7 @@ describe('SelfFillingNameEntry', () => {
             for (let i = 0; i < RANDOM_MEETING.length; i++) {
                 jest.advanceTimersByTime(100);
                 expect(selfFillingNameEntry.state().animatingPlaceholder)
-                    .toBe(RANDOM_MEETING.substr(0, i + 1));
+                    .toBe(RANDOM_MEETING.slice(0, i + 1));
             }
         });
 

--- a/spot-client/src/spot-remote/ui/views/join-code-entry.js
+++ b/spot-client/src/spot-remote/ui/views/join-code-entry.js
@@ -89,7 +89,7 @@ export class JoinCodeEntry extends React.Component {
         let code = codeMatch && (codeMatch[1] || codeMatch[2]);
 
         if (!code && this.props.location.hash && this.props.location.hash.includes('#/?')) {
-            const parts = this.props.location.hash.substr(3);
+            const parts = this.props.location.hash.slice(3);
             const queryParams = new URLSearchParams(parts);
 
             code = queryParams.get('code');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.