### PR TITLE
fix(logging) - fix parsing log error for flow with logging endpoint

### DIFF
--- a/spot-client/src/common/logger/PostToEndpoint/PostToEndpoint.js
+++ b/spot-client/src/common/logger/PostToEndpoint/PostToEndpoint.js
@@ -54,7 +54,7 @@ export default class PostToEndpoint {
                     return accumulator;
                 }
 
-                accumulator.push(JSON.parse(event));
+                accumulator.push(event);
 
                 return accumulator;
             } catch (e) {


### PR DESCRIPTION
- fix parsing log error as now log does not have anymore a JSON structure, for flow when environment config has LOGGING: { ENDPOINT: 'url' } (ex pilot)
- issue introduced in this PR, where structure changed from `object` to beautify `string` (https://github.com/jitsi/jitsi-meet-spot/pull/941/files#diff-6646582b07b7f8b4ebb9b3c29f0b51896877046d210a798c4602fe172d62e23cL15)

Error:
<img width="1198" alt="Screenshot 2022-12-07 at 1 39 58 PM" src="https://user-images.githubusercontent.com/686842/206208510-cc4801b2-1c41-41aa-a481-2a5861bf8243.png">

Before:
<img width="1257" alt="Screenshot 2022-12-07 at 4 28 54 PM" src="https://user-images.githubusercontent.com/686842/206208626-a95c6358-4585-4e9f-819a-92826e390d3c.png">

After:
<img width="613" alt="Screenshot 2022-12-07 at 4 14 40 PM" src="https://user-images.githubusercontent.com/686842/206208672-6fd7c103-12ae-42e7-bf5d-cac4ed7f08cf.png">

