### PR TITLE
fix(ui,share-button) - fix share button ui

### DIFF
--- a/spot-client/src/spot-remote/ui/components/screenshare/ScreenshareButton.js
+++ b/spot-client/src/spot-remote/ui/components/screenshare/ScreenshareButton.js
@@ -57,7 +57,7 @@ export class ScreenshareButton extends React.Component {
             <NavButton
                 className = { screenshareButtonStyles }
                 onClick = { this._onToggleScreenshare }
-                qaId = { screensharingType ? 'stop-share' : 'start-share' }
+                qaId = { screensharingType ? 'stop-share-button' : 'start-share-button' }
                 subIcon = { this._renderScreenshareSubIcon() }>
                 <ScreenShareOutlined />
             </NavButton>


### PR DESCRIPTION
- fix share button UI when screensharing is on
- issue introduced from e2e webdriverio changes: 'stop-share' is also used in another place as a container and has flex:1 which increases width of item