### PR TITLE
fix(client,wireless-ss) fix sharing Chrome tabs

### DIFF
--- a/spot-client/src/common/media/av-utils.js
+++ b/spot-client/src/common/media/av-utils.js
@@ -50,7 +50,10 @@ export default {
             ...mediaConfiguration,
             devices: [ 'desktop' ]
         })
-        .then(jitsiLocalTracks => jitsiLocalTracks[0]);
+
+        // TODO: Skip audio track when sharing a Chrome tab. There should be a way
+        // to disable that on LJM.
+        .then(jitsiLocalTracks => jitsiLocalTracks.find(t => t.isVideoTrack()));
     },
 
     /**


### PR DESCRIPTION
Ignore the audio track sicne due to how constraints are handled in LJM we'll always end up getting one.