### PR TITLE
fix(electron) handle connectivity problems more gracefully

### DIFF
--- a/spot-electron/src/application-window/applicationwindow.js
+++ b/spot-electron/src/application-window/applicationwindow.js
@@ -3,6 +3,7 @@ const isDev = require('electron-is-dev');
 const process = require('process');
 
 const { defaultSpotURL } = require('../../config');
+const { clientController } = require('../client-control');
 const { logger, fileLogger } = require('../logger');
 const { OnlineDetector } = require('../online-detector');
 
@@ -29,6 +30,20 @@ function createApplicationWindow() {
 
     let showCrashPageTimeout = null;
 
+    let meetingStatus = 0; /* Not in a meeting. */
+
+    clientController.addListener('meetingStatus', ({ status }) => {
+        logger.info(`Current meeting status: ${status}`);
+
+        meetingStatus = status;
+
+        // Re-evaluate if we should show the offline overlay after coming back from
+        // a meeting.
+        if (meetingStatus === 0 && !onlineDetector.getLastOnlineStatus()) {
+            applicationWindow.loadFile('src/static/offline.html');
+        }
+    });
+
     applicationWindow = new BrowserWindow({
         webPreferences: {
             contextIsolation: false,
@@ -39,6 +54,14 @@ function createApplicationWindow() {
     // Set event handlers
     onlineDetector.addListener(OnlineDetector.ONLINE_STATUS_CHANGED, isOnline => {
         clearTimeout(showCrashPageTimeout);
+
+        logger.warn(`Online status changed: ${isOnline}`);
+
+        if (meetingStatus !== 0) {
+            logger.debug('Ignoring online state change while in a meeting');
+
+            return;
+        }
 
         if (isOnline) {
             applicationWindow.loadURL(defaultSpotURL);

--- a/spot-electron/src/application-window/applicationwindow.js
+++ b/spot-electron/src/application-window/applicationwindow.js
@@ -35,10 +35,10 @@ function createApplicationWindow() {
 
         // Pause the online detector while in a meeting so it doesn't disrupt them.
         // Re-arm it when the meeting ends.
-        if (status !== 0) {
-            onlineDetector.pause();
-        } else {
+        if (status === 0) {
             onlineDetector.start();
+        } else {
+            onlineDetector.pause();
         }
     });
 


### PR DESCRIPTION
If we briefly go offline, the meeting will be closed. Instead, ignore offline events while in a meeting, since the network may come back up and the meeting would recover just fine.