### PR TITLE
feat(client): improve modal and add hang up confirmation

### DIFF
--- a/spot-client/src/common/css/_hangup-modal.scss
+++ b/spot-client/src/common/css/_hangup-modal.scss
@@ -1,0 +1,31 @@
+.hangup-modal-select {
+    @include centered-content;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 360px;
+    text-align: center;
+    width: 100%;
+
+    .content {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .footer {
+        align-items: center;
+        display: flex;
+        padding: 24px;
+        justify-content: center;
+        width: 100%;
+    }
+
+    .hangup-button {
+        display: block;
+        font-size: 19px;
+    }
+
+    .description {
+        font-size: 19px;
+    }
+}

--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -8,6 +8,7 @@
     top: 0;
     width: 100%;
     backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
 
     .modal-shroud {
         height: 100%;

--- a/spot-client/src/common/css/_modal.scss
+++ b/spot-client/src/common/css/_modal.scss
@@ -4,10 +4,10 @@
     height: 100%;
     justify-content: center;
     left: 0;
-    pointer-events: none;
     position: fixed;
     top: 0;
     width: 100%;
+    backdrop-filter: blur(2px);
 
     .modal-shroud {
         height: 100%;
@@ -24,7 +24,9 @@
         overflow: auto;
         pointer-events: all;
         position: relative;
-
+        border: 1px solid rgb(61, 61, 61);
+        box-shadow: rgba(20, 20, 20, 0.6) 0px 4px 25px 4px;
+        border-radius: 6px;
 
         @media #{$mqw-tablet} {
             background-color: var(--container-bg-color);

--- a/spot-client/src/common/css/index.scss
+++ b/spot-client/src/common/css/index.scss
@@ -31,6 +31,7 @@
 @import './desktop-picker.scss';
 @import './dial-pad.scss';
 @import './electron.scss';
+@import './hangup-modal';
 @import './help-view.scss';
 @import './home-view.scss';
 @import './idle-cursor.scss';

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -102,6 +102,10 @@
         "rate": "Rate your experience",
         "thanks": "Thanks for using {{ productName }}!"
     },
+    "hangup": {
+        "confirmation" : "Are you sure you want to hang up?",
+        "button": "Hang up"
+    },
     "help": {
         "howToConnect": "Open {{ url }} in a desktop Google Chrome browser in the conference room to set it up and obtain a share key. Next enter the {{ codeLength }}-character share key in this app.",
         "isRemote": "This app is a remote controller for a conference room."

--- a/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupButton.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupButton.js
@@ -1,4 +1,4 @@
-import { hangUp } from 'common/app-state';
+import { showModal } from 'common/app-state';
 import { CallEnd } from 'common/icons';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 
 
 import { NavButton } from './../../nav';
+import HangupModal from './HangupModal';
 
 /**
  * A component for leaving a meeting in progress.
@@ -39,7 +40,7 @@ HangupButton.propTypes = {
 function mapDispatchToProps(dispatch) {
     return {
         onHangup() {
-            dispatch(hangUp());
+            dispatch(showModal(HangupModal));
         }
     };
 }

--- a/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
@@ -7,7 +7,7 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 /**
- * Implements a modal to adjust the volume of the spot tv remotely.
+ * Implements a modal dialog for confirming that the user wants to hang up.
  */
 export class HangupModal extends React.Component {
     static propTypes = {

--- a/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
@@ -1,0 +1,72 @@
+import { hideModal, hangUp } from 'common/app-state';
+import { Button, Modal } from 'common/ui';
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+
+/**
+ * Implements a modal to adjust the volume of the spot tv remotely.
+ */
+export class HangupModal extends React.Component {
+    static propTypes = {
+        onClose: PropTypes.func,
+        t: PropTypes.func
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { t } = this.props;
+
+        return (
+            <Modal
+                onClose = { this.props.onClose }
+                qaId = 'hangup-modal'>
+                <div className = 'hangup-modal-select'>
+                    <div className = 'content'>
+                        <div className = 'description'>
+                            { t('hangup.confirmation') }
+                        </div>
+                    </div>
+                    <div className = 'footer'>
+                        <Button
+                            appearance = 'primary'
+                            className = 'hangup-button'
+                            color='secondary'
+                            onClick = { this.props.onHangup }
+                            qaId = 'hangup-button'>
+                               { t('hangup.button') }
+                        </Button>
+                    </div>                
+                </div>
+            </Modal>
+        );
+    }
+}
+
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        onClose() {
+            dispatch(hideModal());
+        },
+        onHangup() {
+            dispatch(hangUp());
+            dispatch(hideModal());
+        }
+    };
+}
+
+export default connect(null, mapDispatchToProps)(withTranslation()(HangupModal));

--- a/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
+++ b/spot-client/src/spot-remote/ui/components/meeting-toolbar/buttons/HangupModal.js
@@ -1,6 +1,5 @@
-import { hideModal, hangUp } from 'common/app-state';
+import { hangUp, hideModal } from 'common/app-state';
 import { Button, Modal } from 'common/ui';
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withTranslation } from 'react-i18next';
@@ -12,6 +11,7 @@ import { connect } from 'react-redux';
 export class HangupModal extends React.Component {
     static propTypes = {
         onClose: PropTypes.func,
+        onHangup: PropTypes.func,
         t: PropTypes.func
     };
 
@@ -38,12 +38,12 @@ export class HangupModal extends React.Component {
                         <Button
                             appearance = 'primary'
                             className = 'hangup-button'
-                            color='secondary'
+                            color = 'secondary'
                             onClick = { this.props.onHangup }
                             qaId = 'hangup-button'>
-                               { t('hangup.button') }
+                            { t('hangup.button') }
                         </Button>
-                    </div>                
+                    </div>
                 </div>
             </Modal>
         );


### PR DESCRIPTION
Add some enhancements to modal (make it can't be clicked through)
![Screenshot 2024-08-05 at 11 22 47](https://github.com/user-attachments/assets/6e0eaa4d-17c0-46ef-b344-b2d26da78d3c)
Add hang up confirmation.
![Screenshot 2024-08-05 at 11 53 53](https://github.com/user-attachments/assets/7a725e5e-0634-4b4e-9860-61e6fb6d2a23)
