### PR TITLE
feat(client) unbundle lib-jitsi-meet

### DIFF
--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -44,7 +44,6 @@
                 "jest-environment-jsdom": "29.3.1",
                 "jest-fetch-mock": "3.0.3",
                 "jsdoc": "4.0.3",
-                "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1691.0.0+255d8f49/lib-jitsi-meet.tgz",
                 "libphonenumber-js": "1.10.15",
                 "lodash.bindall": "4.4.0",
                 "lodash.debounce": "4.0.8",
@@ -2238,12 +2237,6 @@
             "optional": true,
             "peer": true
         },
-        "node_modules/@hapi/bourne": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-            "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-            "dev": true
-        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.8",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -2984,46 +2977,6 @@
             "integrity": "sha512-+ibs+vIj6HUSY34KaXPjSkhP8gAu31knwx6iSJtXDi+mZuhmDOa8JD4K8ij/CD7wrY7u5DNJW5b590qpBZQ0jw==",
             "dev": true
         },
-        "node_modules/@jitsi/rtcstats": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
-            "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
-            "dev": true,
-            "dependencies": {
-                "@jitsi/js-utils": "^2.0.0",
-                "sdp": "^3.0.3",
-                "uuid": "^8.3.2"
-            }
-        },
-        "node_modules/@jitsi/sdp-interop": {
-            "version": "1.0.5",
-            "resolved": "git+https://git@github.com/jitsi/sdp-interop.git#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
-            "integrity": "sha512-80u69QNTBArnCd1CGbTTrl/8AsZOOMF82dQhrgXBQAnrimdpomX1fMZ82ZkxyWyYvRMPG167u43Tp8y1g2DLNA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "lodash.clonedeep": "4.5.0",
-                "sdp-transform": "2.14.1"
-            }
-        },
-        "node_modules/@jitsi/sdp-interop/node_modules/sdp-transform": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
-            "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==",
-            "dev": true,
-            "bin": {
-                "sdp-verify": "checker.js"
-            }
-        },
-        "node_modules/@jitsi/sdp-simulcast": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@jitsi/sdp-simulcast/-/sdp-simulcast-0.4.0.tgz",
-            "integrity": "sha512-jXJM3/XM853UwPlxhSJx5Fc13G4158RIeTgjis3lA286Y7lp18GOR0xFlRvx/5UyhtE3qT2NzSmAwR+CpJohFw==",
-            "dev": true,
-            "dependencies": {
-                "sdp-transform": "2.3.0"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -3490,291 +3443,6 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-            "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-            "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-            "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-            "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-            "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-            "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-            "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-            "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-            "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-            "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-            "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-            "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-            "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-            "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-            "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-            "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-            "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-            "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-            "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
         "node_modules/@sinclair/typebox": {
             "version": "0.24.51",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -3798,12 +3466,6 @@
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
             }
-        },
-        "node_modules/@testrtc/watchrtc-sdk": {
-            "version": "1.36.3",
-            "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
-            "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg==",
-            "dev": true
         },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
@@ -4589,16 +4251,6 @@
                 "react": "^17.0.0-0"
             }
         },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-            "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4609,12 +4261,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "dev": true
-        },
-        "node_modules/@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
             "dev": true
         },
         "node_modules/abab": {
@@ -4962,25 +4608,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array.prototype.map": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.5.tgz",
-            "integrity": "sha512-gfaKntvwqYIuC7mLLyv2wzZIJqrRhn5PZ9EfFejSx6a78sV7iDsGpG9P+3oUPtm1Rerqm6nrKS4FYuTIvWfo3g==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/array.prototype.tosorted": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
@@ -5005,12 +4632,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/async-es": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async-es/-/async-es-3.2.4.tgz",
-            "integrity": "sha512-GFHAAfmW7GzEiHFR6DvE5WMm6+js9pb+RLm+m1UpsyMX+I4j/R4QVw2Te664q+fvDVOz7Y0bORPDNvQS7BJ3Hw==",
-            "dev": true
-        },
         "node_modules/async-foreach": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
@@ -5027,15 +4648,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
-        },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/babel-core": {
             "version": "7.0.0-bridge.0",
@@ -5316,12 +4928,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "node_modules/base64-js": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
         "node_modules/batch": {
@@ -6518,12 +6124,6 @@
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
             "dev": true
         },
-        "node_modules/current-executing-script": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/current-executing-script/-/current-executing-script-0.1.3.tgz",
-            "integrity": "sha1-t5jfxYtc+LAPsEwd8KwmY5Z+LHA=",
-            "dev": true
-        },
         "node_modules/data-urls": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -6542,12 +6142,6 @@
             "version": "1.11.7",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
             "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
-            "dev": true
-        },
-        "node_modules/debounce": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
             "dev": true
         },
         "node_modules/debug": {
@@ -7130,12 +6724,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
-        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -7155,31 +6743,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-            "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.0",
-                "has-symbols": "^1.0.1",
-                "is-arguments": "^1.1.0",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.5",
-                "isarray": "^2.0.5"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-get-iterator/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true
         },
         "node_modules/es-module-lexer": {
             "version": "1.5.4",
@@ -8467,15 +8030,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "dependencies": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "node_modules/flat-cache": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -8538,30 +8092,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/fs-extra/node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/fs-minipass": {
@@ -9594,22 +9124,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9673,24 +9187,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "dev": true,
-            "dependencies": {
-                "ci-info": "^2.0.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
-        },
-        "node_modules/is-ci/node_modules/ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
         },
         "node_modules/is-core-module": {
             "version": "2.10.0",
@@ -9765,15 +9261,6 @@
             "dev": true,
             "optional": true,
             "peer": true
-        },
-        "node_modules/is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.2",
@@ -9858,15 +9345,6 @@
             "engines": {
                 "node": ">= 0.4"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10070,28 +9548,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/iterate-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
-            "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/iterate-value": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-            "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-            "dev": true,
-            "dependencies": {
-                "es-get-iterator": "^1.0.2",
-                "iterate-iterator": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jest": {
@@ -12019,27 +11475,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonfile/node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -12051,22 +11486,6 @@
             },
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/karma-rollup-preprocessor": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-            "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
-            "dev": true,
-            "dependencies": {
-                "chokidar": "^3.3.1",
-                "debounce": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            },
-            "peerDependencies": {
-                "rollup": ">= 1.0.0"
             }
         },
         "node_modules/kind-of": {
@@ -12085,15 +11504,6 @@
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.9"
-            }
-        },
-        "node_modules/klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kleur": {
@@ -12144,99 +11554,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/lib-jitsi-meet": {
-            "version": "0.0.0",
-            "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1691.0.0+255d8f49/lib-jitsi-meet.tgz",
-            "integrity": "sha512-olw/14fGI4BpQtM9p87VE49GSTa6838Lw6xbkx7YnxDv9WJURh/DfTHqvKr68AfHfcIFFgZTWAbibAsD/LXsIg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jitsi/js-utils": "2.1.3",
-                "@jitsi/logger": "2.0.2",
-                "@jitsi/rtcstats": "9.5.1",
-                "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
-                "@jitsi/sdp-simulcast": "0.4.0",
-                "@testrtc/watchrtc-sdk": "1.36.3",
-                "async-es": "3.2.4",
-                "base64-js": "1.3.1",
-                "current-executing-script": "0.1.3",
-                "jquery": "3.6.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.debounce": "4.0.8",
-                "lodash.isequal": "4.5.0",
-                "patch-package": "6.5.1",
-                "promise.allsettled": "1.0.4",
-                "sdp-transform": "2.3.0",
-                "strophe.js": "1.5.0",
-                "strophejs-plugin-disco": "0.0.2",
-                "strophejs-plugin-stream-management": "git+https://github.com/jitsi/strophejs-plugin-stream-management#679be5902097ed612fb5062b5549f3f32b6f5f47",
-                "uuid": "8.1.0",
-                "webrtc-adapter": "8.1.1"
-            }
-        },
-        "node_modules/lib-jitsi-meet/node_modules/@jitsi/js-utils": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.1.3.tgz",
-            "integrity": "sha512-fXoNLu2JHQGPgzjCDG5qWPPStiXI+AxSzu1JIVY4dMULIFsw4a+doMgcjTIlSfB393J2xccKQYwZSejZUn9MEw==",
-            "dev": true,
-            "dependencies": {
-                "@hapi/bourne": "^3.0.0",
-                "bowser": "2.7.0",
-                "js-md5": "0.7.3"
-            }
-        },
-        "node_modules/lib-jitsi-meet/node_modules/@jitsi/logger": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
-            "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg==",
-            "dev": true
-        },
-        "node_modules/lib-jitsi-meet/node_modules/bowser": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
-            "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w==",
-            "dev": true
-        },
-        "node_modules/lib-jitsi-meet/node_modules/jquery": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-            "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-            "dev": true
-        },
-        "node_modules/lib-jitsi-meet/node_modules/strophe.js": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.5.0.tgz",
-            "integrity": "sha512-H5tE/tZxPR5xP3jhXyQwsjnMSwQMf7vrn9r1OkufTApyGHYe8WjzhsfxtL3AFhVu7vFjXPPZBrmUOTm1ccYgOA==",
-            "dev": true,
-            "dependencies": {
-                "abab": "^2.0.3",
-                "karma-rollup-preprocessor": "^7.0.8"
-            },
-            "optionalDependencies": {
-                "@xmldom/xmldom": "0.8.2",
-                "ws": "^8.5.0"
-            }
-        },
-        "node_modules/lib-jitsi-meet/node_modules/strophejs-plugin-stream-management": {
-            "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/jitsi/strophejs-plugin-stream-management.git#679be5902097ed612fb5062b5549f3f32b6f5f47",
-            "integrity": "sha512-pQUT174bznpLEVNAnJT2Q7lyoSaoIoo8LaVyglRx5rWwxpdHUcS+8NjfLYDlqM+rLcsO1uAKt/fMZ7j3clj9qg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "strophe.js": ">=1.3.4"
-            }
-        },
-        "node_modules/lib-jitsi-meet/node_modules/uuid": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-            "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/libphonenumber-js": {
@@ -12291,12 +11608,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.bindall/-/lodash.bindall-4.4.0.tgz",
             "integrity": "sha1-p7/Ugro9LnBxad/NyZPrv2w9eZg=",
-            "dev": true
-        },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
             "dev": true
         },
         "node_modules/lodash.debounce": {
@@ -13168,12 +12479,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "node_modules/nice-try": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
-        },
         "node_modules/node-forge": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -13778,15 +13083,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -13924,201 +13220,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/patch-package": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
-            "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
-            "dev": true,
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "cross-spawn": "^6.0.5",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "is-ci": "^2.0.0",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^5.6.0",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^1.10.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/patch-package/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/patch-package/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/patch-package/node_modules/cross-spawn": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-            "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            },
-            "engines": {
-                "node": ">=4.8"
-            }
-        },
-        "node_modules/patch-package/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/patch-package/node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/patch-package/node_modules/path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/patch-package/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/patch-package/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/patch-package/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/patch-package/node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
             }
         },
         "node_modules/path-exists": {
@@ -14404,26 +13505,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/promise.allsettled": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.4.tgz",
-            "integrity": "sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==",
-            "dev": true,
-            "dependencies": {
-                "array.prototype.map": "^1.0.3",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "get-intrinsic": "^1.0.2",
-                "iterate-value": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/prompts": {
@@ -15131,46 +14212,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-            "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "1.0.6"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.34.8",
-                "@rollup/rollup-android-arm64": "4.34.8",
-                "@rollup/rollup-darwin-arm64": "4.34.8",
-                "@rollup/rollup-darwin-x64": "4.34.8",
-                "@rollup/rollup-freebsd-arm64": "4.34.8",
-                "@rollup/rollup-freebsd-x64": "4.34.8",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-                "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-                "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-                "@rollup/rollup-linux-arm64-musl": "4.34.8",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-                "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-                "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-musl": "4.34.8",
-                "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-                "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-                "@rollup/rollup-win32-x64-msvc": "4.34.8",
-                "fsevents": "~2.3.2"
-            }
-        },
         "node_modules/rst-selector-parser": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -15401,21 +14442,6 @@
             "peer": true,
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/sdp": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
-            "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A==",
-            "dev": true
-        },
-        "node_modules/sdp-transform": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.3.0.tgz",
-            "integrity": "sha512-zR0e9ciWFezeaKLLpWCrOCiYmGIQN9jfO5Ayfs7m5k2/g9b2MEEIvQ/TTmymm167zozTNYSQoLGKDihMoTWkkw==",
-            "dev": true,
-            "bin": {
-                "sdp-verify": "checker.js"
             }
         },
         "node_modules/select-hose": {
@@ -16215,15 +15241,6 @@
             "integrity": "sha512-r/Uq7aqrusg25Y0qHwV48cFnMY6K/CuZdGt3EggRx3kY4sMv8lG+AFoMlrmTcYVMG1BaJvQfv9Cthw4Ll8z7fQ==",
             "dev": true
         },
-        "node_modules/strophejs-plugin-disco": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/strophejs-plugin-disco/-/strophejs-plugin-disco-0.0.2.tgz",
-            "integrity": "sha512-T9pJFzn1ZUqZ/we9+OvI5pFdrjeb4IBMbEjK+ZWEZV036wEl8l8GOtF8AJ3sIqOMtdIiFLdFu99JiGWd7yapAQ==",
-            "dev": true,
-            "peerDependencies": {
-                "strophe.js": "^1.2.12"
-            }
-        },
         "node_modules/style-loader": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -16474,18 +15491,6 @@
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "dev": true
-        },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -17205,19 +16210,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/webrtc-adapter": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.1.tgz",
-            "integrity": "sha512-1yXevP7TeZGmklEXkvQVrZp3fOSJlLeXNGCA7NovQokxgP3/e2T3EVGL0eKU87S9vKppWjvRWqnJeSANEspOBg==",
-            "dev": true,
-            "dependencies": {
-                "sdp": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0",
-                "npm": ">=3.10.0"
-            }
-        },
         "node_modules/websocket-driver": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -17502,6 +16494,8 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -19085,12 +18079,6 @@
             "optional": true,
             "peer": true
         },
-        "@hapi/bourne": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-            "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-            "dev": true
-        },
         "@humanwhocodes/config-array": {
             "version": "0.11.8",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -19657,44 +18645,6 @@
             "integrity": "sha512-+ibs+vIj6HUSY34KaXPjSkhP8gAu31knwx6iSJtXDi+mZuhmDOa8JD4K8ij/CD7wrY7u5DNJW5b590qpBZQ0jw==",
             "dev": true
         },
-        "@jitsi/rtcstats": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
-            "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
-            "dev": true,
-            "requires": {
-                "@jitsi/js-utils": "^2.0.0",
-                "sdp": "^3.0.3",
-                "uuid": "^8.3.2"
-            }
-        },
-        "@jitsi/sdp-interop": {
-            "version": "git+https://git@github.com/jitsi/sdp-interop.git#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
-            "integrity": "sha512-80u69QNTBArnCd1CGbTTrl/8AsZOOMF82dQhrgXBQAnrimdpomX1fMZ82ZkxyWyYvRMPG167u43Tp8y1g2DLNA==",
-            "dev": true,
-            "from": "@jitsi/sdp-interop@git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
-            "requires": {
-                "lodash.clonedeep": "4.5.0",
-                "sdp-transform": "2.14.1"
-            },
-            "dependencies": {
-                "sdp-transform": {
-                    "version": "2.14.1",
-                    "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
-                    "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==",
-                    "dev": true
-                }
-            }
-        },
-        "@jitsi/sdp-simulcast": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@jitsi/sdp-simulcast/-/sdp-simulcast-0.4.0.tgz",
-            "integrity": "sha512-jXJM3/XM853UwPlxhSJx5Fc13G4158RIeTgjis3lA286Y7lp18GOR0xFlRvx/5UyhtE3qT2NzSmAwR+CpJohFw==",
-            "dev": true,
-            "requires": {
-                "sdp-transform": "2.3.0"
-            }
-        },
         "@jridgewell/gen-mapping": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -19990,158 +18940,6 @@
             "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
             "dev": true
         },
-        "@rollup/rollup-android-arm-eabi": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-            "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-android-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-            "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-darwin-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-            "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-darwin-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-            "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-freebsd-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-            "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-freebsd-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-            "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-            "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-            "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-            "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-arm64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-            "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-            "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-            "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-            "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-            "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-x64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-            "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-linux-x64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-            "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-            "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-            "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "@rollup/rollup-win32-x64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-            "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "@sinclair/typebox": {
             "version": "0.24.51",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -20165,12 +18963,6 @@
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
             }
-        },
-        "@testrtc/watchrtc-sdk": {
-            "version": "1.36.3",
-            "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
-            "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg==",
-            "dev": true
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -20860,13 +19652,6 @@
                 "prop-types": "^15.7.0"
             }
         },
-        "@xmldom/xmldom": {
-            "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-            "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
-            "dev": true,
-            "optional": true
-        },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -20877,12 +19662,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "dev": true
-        },
-        "@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
             "dev": true
         },
         "abab": {
@@ -21143,19 +19922,6 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
-        "array.prototype.map": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.5.tgz",
-            "integrity": "sha512-gfaKntvwqYIuC7mLLyv2wzZIJqrRhn5PZ9EfFejSx6a78sV7iDsGpG9P+3oUPtm1Rerqm6nrKS4FYuTIvWfo3g==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            }
-        },
         "array.prototype.tosorted": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
@@ -21177,12 +19943,6 @@
             "optional": true,
             "peer": true
         },
-        "async-es": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async-es/-/async-es-3.2.4.tgz",
-            "integrity": "sha512-GFHAAfmW7GzEiHFR6DvE5WMm6+js9pb+RLm+m1UpsyMX+I4j/R4QVw2Te664q+fvDVOz7Y0bORPDNvQS7BJ3Hw==",
-            "dev": true
-        },
         "async-foreach": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
@@ -21195,12 +19955,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
-        },
-        "at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "dev": true
         },
         "babel-core": {
@@ -21415,12 +20169,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "base64-js": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
         "batch": {
@@ -22321,12 +21069,6 @@
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
             "dev": true
         },
-        "current-executing-script": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/current-executing-script/-/current-executing-script-0.1.3.tgz",
-            "integrity": "sha1-t5jfxYtc+LAPsEwd8KwmY5Z+LHA=",
-            "dev": true
-        },
         "data-urls": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -22342,12 +21084,6 @@
             "version": "1.11.7",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
             "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
-            "dev": true
-        },
-        "debounce": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
             "dev": true
         },
         "debug": {
@@ -22794,12 +21530,6 @@
                 "unbox-primitive": "^1.0.2"
             }
         },
-        "es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
-        },
         "es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -22811,30 +21541,6 @@
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true
-        },
-        "es-get-iterator": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-            "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.0",
-                "has-symbols": "^1.0.1",
-                "is-arguments": "^1.1.0",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.5",
-                "isarray": "^2.0.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-                    "dev": true
-                }
-            }
         },
         "es-module-lexer": {
             "version": "1.5.4",
@@ -23795,15 +22501,6 @@
                 "path-exists": "^4.0.0"
             }
         },
-        "find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "requires": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "flat-cache": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -23843,26 +22540,6 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true
-        },
-        "fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-                    "dev": true
-                }
-            }
         },
         "fs-minipass": {
             "version": "2.1.0",
@@ -24625,16 +23302,6 @@
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true
         },
-        "is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            }
-        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -24680,23 +23347,6 @@
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true
-        },
-        "is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "dev": true,
-            "requires": {
-                "ci-info": "^2.0.0"
-            },
-            "dependencies": {
-                "ci-info": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-                    "dev": true
-                }
-            }
         },
         "is-core-module": {
             "version": "2.10.0",
@@ -24747,12 +23397,6 @@
             "dev": true,
             "optional": true,
             "peer": true
-        },
-        "is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "dev": true
         },
         "is-negative-zero": {
             "version": "2.0.2",
@@ -24810,12 +23454,6 @@
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
             }
-        },
-        "is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "dev": true
         },
         "is-shared-array-buffer": {
             "version": "1.0.2",
@@ -24966,22 +23604,6 @@
             "requires": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
-            }
-        },
-        "iterate-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
-            "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
-            "dev": true
-        },
-        "iterate-value": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-            "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-            "dev": true,
-            "requires": {
-                "es-get-iterator": "^1.0.2",
-                "iterate-iterator": "^1.0.1"
             }
         },
         "jest": {
@@ -26416,24 +25038,6 @@
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-                    "dev": true
-                }
-            }
-        },
         "jsx-ast-utils": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -26442,16 +25046,6 @@
             "requires": {
                 "array-includes": "^3.1.5",
                 "object.assign": "^4.1.3"
-            }
-        },
-        "karma-rollup-preprocessor": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-            "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
-            "dev": true,
-            "requires": {
-                "chokidar": "^3.3.1",
-                "debounce": "^1.2.0"
             }
         },
         "kind-of": {
@@ -26467,15 +25061,6 @@
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.9"
-            }
-        },
-        "klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "kleur": {
@@ -26514,90 +25099,6 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
-            }
-        },
-        "lib-jitsi-meet": {
-            "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1691.0.0+255d8f49/lib-jitsi-meet.tgz",
-            "integrity": "sha512-olw/14fGI4BpQtM9p87VE49GSTa6838Lw6xbkx7YnxDv9WJURh/DfTHqvKr68AfHfcIFFgZTWAbibAsD/LXsIg==",
-            "dev": true,
-            "requires": {
-                "@jitsi/js-utils": "2.1.3",
-                "@jitsi/logger": "2.0.2",
-                "@jitsi/rtcstats": "9.5.1",
-                "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
-                "@jitsi/sdp-simulcast": "0.4.0",
-                "@testrtc/watchrtc-sdk": "1.36.3",
-                "async-es": "3.2.4",
-                "base64-js": "1.3.1",
-                "current-executing-script": "0.1.3",
-                "jquery": "3.6.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.debounce": "4.0.8",
-                "lodash.isequal": "4.5.0",
-                "patch-package": "6.5.1",
-                "promise.allsettled": "1.0.4",
-                "sdp-transform": "2.3.0",
-                "strophe.js": "1.5.0",
-                "strophejs-plugin-disco": "0.0.2",
-                "strophejs-plugin-stream-management": "git+https://github.com/jitsi/strophejs-plugin-stream-management#679be5902097ed612fb5062b5549f3f32b6f5f47",
-                "uuid": "8.1.0",
-                "webrtc-adapter": "8.1.1"
-            },
-            "dependencies": {
-                "@jitsi/js-utils": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.1.3.tgz",
-                    "integrity": "sha512-fXoNLu2JHQGPgzjCDG5qWPPStiXI+AxSzu1JIVY4dMULIFsw4a+doMgcjTIlSfB393J2xccKQYwZSejZUn9MEw==",
-                    "dev": true,
-                    "requires": {
-                        "@hapi/bourne": "^3.0.0",
-                        "bowser": "2.7.0",
-                        "js-md5": "0.7.3"
-                    }
-                },
-                "@jitsi/logger": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
-                    "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg==",
-                    "dev": true
-                },
-                "bowser": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
-                    "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w==",
-                    "dev": true
-                },
-                "jquery": {
-                    "version": "3.6.1",
-                    "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-                    "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-                    "dev": true
-                },
-                "strophe.js": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.5.0.tgz",
-                    "integrity": "sha512-H5tE/tZxPR5xP3jhXyQwsjnMSwQMf7vrn9r1OkufTApyGHYe8WjzhsfxtL3AFhVu7vFjXPPZBrmUOTm1ccYgOA==",
-                    "dev": true,
-                    "requires": {
-                        "@xmldom/xmldom": "0.8.7",
-                        "abab": "^2.0.3",
-                        "karma-rollup-preprocessor": "^7.0.8",
-                        "ws": "^8.5.0"
-                    }
-                },
-                "strophejs-plugin-stream-management": {
-                    "version": "git+ssh://git@github.com/jitsi/strophejs-plugin-stream-management.git#679be5902097ed612fb5062b5549f3f32b6f5f47",
-                    "integrity": "sha512-pQUT174bznpLEVNAnJT2Q7lyoSaoIoo8LaVyglRx5rWwxpdHUcS+8NjfLYDlqM+rLcsO1uAKt/fMZ7j3clj9qg==",
-                    "dev": true,
-                    "from": "strophejs-plugin-stream-management@git+https://github.com/jitsi/strophejs-plugin-stream-management#679be5902097ed612fb5062b5549f3f32b6f5f47",
-                    "requires": {}
-                },
-                "uuid": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-                    "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-                    "dev": true
-                }
             }
         },
         "libphonenumber-js": {
@@ -26646,12 +25147,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.bindall/-/lodash.bindall-4.4.0.tgz",
             "integrity": "sha1-p7/Ugro9LnBxad/NyZPrv2w9eZg=",
-            "dev": true
-        },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
             "dev": true
         },
         "lodash.debounce": {
@@ -27333,12 +25828,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "nice-try": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
-        },
         "node-forge": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -27795,12 +26284,6 @@
                 "word-wrap": "~1.2.3"
             }
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true
-        },
         "p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -27899,147 +26382,6 @@
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true
-        },
-        "patch-package": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
-            "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
-            "dev": true,
-            "requires": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "cross-spawn": "^6.0.5",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "is-ci": "^2.0.0",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^5.6.0",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^1.10.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "cross-spawn": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-                    "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "open": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-                    "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-                    "dev": true,
-                    "requires": {
-                        "is-docker": "^2.0.0",
-                        "is-wsl": "^2.1.1"
-                    }
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                    "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-                    "dev": true
-                },
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-                    "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                    "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                }
-            }
         },
         "path-exists": {
             "version": "4.0.0",
@@ -28245,20 +26587,6 @@
             "requires": {
                 "err-code": "^2.0.2",
                 "retry": "^0.12.0"
-            }
-        },
-        "promise.allsettled": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.4.tgz",
-            "integrity": "sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==",
-            "dev": true,
-            "requires": {
-                "array.prototype.map": "^1.0.3",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "get-intrinsic": "^1.0.2",
-                "iterate-value": "^1.0.2"
             }
         },
         "prompts": {
@@ -28787,36 +27115,6 @@
                 "glob": "^7.1.3"
             }
         },
-        "rollup": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-            "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@rollup/rollup-android-arm-eabi": "4.34.8",
-                "@rollup/rollup-android-arm64": "4.34.8",
-                "@rollup/rollup-darwin-arm64": "4.34.8",
-                "@rollup/rollup-darwin-x64": "4.34.8",
-                "@rollup/rollup-freebsd-arm64": "4.34.8",
-                "@rollup/rollup-freebsd-x64": "4.34.8",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-                "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-                "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-                "@rollup/rollup-linux-arm64-musl": "4.34.8",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-                "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-                "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-musl": "4.34.8",
-                "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-                "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-                "@rollup/rollup-win32-x64-msvc": "4.34.8",
-                "@types/estree": "1.0.6",
-                "fsevents": "~2.3.2"
-            }
-        },
         "rst-selector-parser": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -28975,18 +27273,6 @@
                     "peer": true
                 }
             }
-        },
-        "sdp": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
-            "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A==",
-            "dev": true
-        },
-        "sdp-transform": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.3.0.tgz",
-            "integrity": "sha512-zR0e9ciWFezeaKLLpWCrOCiYmGIQN9jfO5Ayfs7m5k2/g9b2MEEIvQ/TTmymm167zozTNYSQoLGKDihMoTWkkw==",
-            "dev": true
         },
         "select-hose": {
             "version": "2.0.0",
@@ -29630,13 +27916,6 @@
             "integrity": "sha512-r/Uq7aqrusg25Y0qHwV48cFnMY6K/CuZdGt3EggRx3kY4sMv8lG+AFoMlrmTcYVMG1BaJvQfv9Cthw4Ll8z7fQ==",
             "dev": true
         },
-        "strophejs-plugin-disco": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/strophejs-plugin-disco/-/strophejs-plugin-disco-0.0.2.tgz",
-            "integrity": "sha512-T9pJFzn1ZUqZ/we9+OvI5pFdrjeb4IBMbEjK+ZWEZV036wEl8l8GOtF8AJ3sIqOMtdIiFLdFu99JiGWd7yapAQ==",
-            "dev": true,
-            "requires": {}
-        },
         "style-loader": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -29809,15 +28088,6 @@
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "dev": true
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
         },
         "tmpl": {
             "version": "1.0.5",
@@ -30339,15 +28609,6 @@
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true
         },
-        "webrtc-adapter": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.1.tgz",
-            "integrity": "sha512-1yXevP7TeZGmklEXkvQVrZp3fOSJlLeXNGCA7NovQokxgP3/e2T3EVGL0eKU87S9vKppWjvRWqnJeSANEspOBg==",
-            "dev": true,
-            "requires": {
-                "sdp": "^3.0.2"
-            }
-        },
         "websocket-driver": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -30569,7 +28830,9 @@
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "yargs": {
             "version": "17.6.2",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -36,7 +36,6 @@
         "jest-environment-jsdom": "29.3.1",
         "jest-fetch-mock": "3.0.3",
         "jsdoc": "4.0.3",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1691.0.0+255d8f49/lib-jitsi-meet.tgz",
         "libphonenumber-js": "1.10.15",
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",

--- a/spot-client/src/common/app-state/config/default-config.js
+++ b/spot-client/src/common/app-state/config/default-config.js
@@ -71,6 +71,14 @@ export default {
         || `https://${DEFAULT_DOMAIN}/external_api.js`,
 
     /**
+     * The URL from which to load lib-jitsi-meet.
+     *
+     * @type {string}
+     */
+    LJM_SRC: process.env.LJM_SRC
+        || `https://${DEFAULT_DOMAIN}/libs/lib-jitsi-meet.min.js`,
+
+    /**
      * Configuration object for websites which can be opened from the app.
      */
     EXTERNAL_LINKS: {

--- a/spot-client/src/common/app-state/config/selectors.js
+++ b/spot-client/src/common/app-state/config/selectors.js
@@ -98,6 +98,16 @@ export function getExternalApiUrl(state) {
 }
 
 /**
+ * A selector which returns the URL for loading lib-jitsi-meet.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {string}
+ */
+export function getLjmUrl(state) {
+    return state.config.LJM_SRC;
+}
+
+/**
  * A selector which returns how often the Spot-TV should change its join code.
  *
  * @param {Object} state - The Redux state.

--- a/spot-client/src/common/vendor/jitsi-meet-js-provider.js
+++ b/spot-client/src/common/vendor/jitsi-meet-js-provider.js
@@ -1,25 +1,34 @@
-import JitsiMeetJS from 'lib-jitsi-meet';
+/* global JitsiMeetJS */
 
 /**
- * Prevent JitsiMeetJS from spamming the console.
+ * A flag to track whether the JitsiMeetJS library has been initialized.
  */
-JitsiMeetJS.setLogLevel('trace');
-
-const loggers = {
-    'modules/RTC/TraceablePeerConnection.js': 'info',
-    'modules/statistics/CallStats.js': 'info',
-    'modules/xmpp/strophe.util.js': 'log'
-};
-
-for (const [ id, level ] of Object.entries(loggers)) {
-    JitsiMeetJS.setLogLevelById(level, id);
-}
+let _initialized = false;
 
 /**
  * A wrapper around the global JitsiMeetJS, as loaded by lib-jitsi-meet.
  */
 export default {
     get() {
-        return JitsiMeetJS;
+        if (!_initialized) {
+            // Prevent JitsiMeetJS from spamming the console.
+            JitsiMeetJS.setLogLevel('trace');
+
+            const loggers = {
+                'modules/RTC/TraceablePeerConnection.js': 'info',
+                'modules/statistics/CallStats.js': 'info',
+                'modules/xmpp/strophe.util.js': 'log'
+            };
+
+            for (const [ id, level ] of Object.entries(loggers)) {
+                JitsiMeetJS.setLogLevelById(level, id);
+            }
+
+            JitsiMeetJS.init({});
+
+            _initialized = true;
+        }
+
+        return window.JitsiMeetJS;
     }
 };

--- a/spot-client/src/index.js
+++ b/spot-client/src/index.js
@@ -4,6 +4,7 @@ import reducers, {
     getDesktopSharingFramerate,
     getDeviceId,
     getExternalApiUrl,
+    getLjmUrl,
     routeChanged,
     setBootstrapStarted,
     setDefaultValues,
@@ -157,7 +158,10 @@ history.listen(location => {
     store.dispatch(routeChanged(location));
 });
 
-loadScript(getExternalApiUrl(reduxState))
+Promise.all([
+    loadScript(getExternalApiUrl(reduxState)),
+    loadScript(getLjmUrl(reduxState))
+])
     .then(() => {
         render(
             <Provider store = { store }>


### PR DESCRIPTION
Use the one coming from the deployment, just like the external API.

This is not ideal either, but it feels more resilient than having an old version rot.

The ideal scenario would be to drop it entirely or at least limit it to the absolute minimum.