### PR TITLE
feat(client): add recording consent dialog

### DIFF
--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -76,8 +76,8 @@
         "build:dev": "webpack --config ./webpack.config.js --progress",
         "build:prod": "NODE_ENV=production webpack --config ./webpack.config.js --progress",
         "docs": "jsdoc -c ./jsdoc.config.js",
-        "lint": "eslint .",
-        "lint:fix": "eslint . --fix",
+        "lint": "eslint . --max-warnings=0",
+        "lint:fix": "eslint . --fix --max-warnings=0",
         "start:dev": "webpack-dev-server",
         "test": "jest"
     },

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -77,6 +77,7 @@
         "build:prod": "NODE_ENV=production webpack --config ./webpack.config.js --progress",
         "docs": "jsdoc -c ./jsdoc.config.js",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "start:dev": "webpack-dev-server",
         "test": "jest"
     },

--- a/spot-client/src/common/app-state/spot-tv/selectors.js
+++ b/spot-client/src/common/app-state/spot-tv/selectors.js
@@ -24,6 +24,7 @@ export function getInMeetingStatus(state) {
         kicked: state.spotTv.kicked,
         meetingDisplayName: state.spotTv.meetingDisplayName,
         needPassword: state.spotTv.needPassword,
+        recordingConsentDialogOpen: state.spotTv.recordingConsentDialogOpen,
         screensharingType: state.spotTv.screensharingType,
         tileView: state.spotTv.tileView,
         videoMuted: state.spotTv.videoMuted,

--- a/spot-client/src/common/css/_recording-consent-modal.scss
+++ b/spot-client/src/common/css/_recording-consent-modal.scss
@@ -1,0 +1,41 @@
+.recording-consent-modal {
+    @include centered-content;
+    flex-direction: column;
+    font-family: 'Arial', sans-serif;
+    min-width: 360px;
+    width: 600px;
+
+    .content {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .footer {
+        display: flex;
+        gap: 12px;
+    }
+    
+   // Rule that applies to all classes starting with 'understand-button'
+    [class*="understand-button"] {
+        flex: 1;
+        font-size: 21px;
+        font-weight: 600;
+    }
+    
+    .understand-button-unmute {
+        background-color: white;
+        color: black;
+    }
+
+    .description {
+        font-size: 21px;
+        font-weight: 400;
+        padding-bottom: 40px;
+    }
+
+    .title {
+        font-size: 29px;
+        font-weight: 600;
+        padding-bottom: 40px;
+    }
+}

--- a/spot-client/src/common/css/index.scss
+++ b/spot-client/src/common/css/index.scss
@@ -44,6 +44,7 @@
 @import './password_prompt.scss';
 @import './notifications.scss';
 @import './reconnect.scss';
+@import './recording-consent-modal';
 @import './screenshare.scss';
 @import './select.scss';
 @import './temp.scss';

--- a/spot-client/src/common/i18n/en.json
+++ b/spot-client/src/common/i18n/en.json
@@ -114,6 +114,12 @@
         "enterCode": "Enter a share key",
         "visibleAt": "Your key is visible on the {{ productName }} TV"
     },
+    "recording": {
+        "understand": "I understand, keep me muted for now",
+        "understandAndUnmute": "I understand, please unmute me",
+        "inProgressTitle": "Recording in progress",
+        "inProgressDescription": "This meeting is being recorded and analyzed by AI. Your audio and video have been muted. If you choose to unmute, you consent to being recorded."
+    },
     "screenshare": {
         "alreadyActive": "Cannot start wireless screenshare while screenshare is active.",
         "controlRoom": "Use your computer to control the meeting room",

--- a/spot-client/src/common/remote-control/constants.js
+++ b/spot-client/src/common/remote-control/constants.js
@@ -21,6 +21,12 @@ export const COMMANDS = {
     GO_TO_MEETING: 'goToMeeting',
 
     /**
+     * Grant recording consent for the current meeting with the option
+     * unmute parameter devices.
+     */
+    GRANT_RECORDING_CONSENT: 'grantRecordingConsent',
+
+    /**
      * End the current meeting.
      */
     HANG_UP: 'hangup',

--- a/spot-client/src/common/remote-control/remoteControlClient.js
+++ b/spot-client/src/common/remote-control/remoteControlClient.js
@@ -306,6 +306,18 @@ export class RemoteControlClient extends BaseRemoteControlService {
     }
 
     /**
+     * Requests a {@code RemoteControlServer} to grant or consent
+     * for recording the meeting.
+     * @param {boolean} unmute - Whether or not to also unmute the devices.
+     * @returns {Promise} Resolves if the command has been acknowledged.
+     *
+     */
+    grantRecordingConsent(unmute) {
+        return this._sendCommand(COMMANDS.GRANT_RECORDING_CONSENT, { unmute });
+    }
+
+
+    /**
      * Requests a {@code RemoteControlServer} to send touch tones into a meeting.
      * This is intended for interaction with an IVR requesting additional
      * conference details for dialing in.

--- a/spot-client/src/spot-remote/app-state/actions.js
+++ b/spot-client/src/spot-remote/app-state/actions.js
@@ -56,6 +56,7 @@ const presenceToStore = [
     'kicked',
     'meetingDisplayName',
     'needPassword',
+    'recordingConsentDialogOpen',
     'remoteJoinCode',
     'roomName',
     'screensharing',

--- a/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
+++ b/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
@@ -1,3 +1,4 @@
+import { hideModal } from 'common/app-state';
 import { remoteControlClient } from 'common/remote-control';
 import { Button, Modal } from 'common/ui';
 import PropTypes from 'prop-types';
@@ -12,6 +13,7 @@ import { connect } from 'react-redux';
  */
 class RecordingConsentDialog extends React.Component {
     static propTypes = {
+        hideModal: PropTypes.func,
         onConsent: PropTypes.func,
         onConsentWithUnmute: PropTypes.func,
         t: PropTypes.func
@@ -25,6 +27,8 @@ class RecordingConsentDialog extends React.Component {
      */
     _onConsent = () => {
         remoteControlClient.grantRecordingConsent(false);
+
+        this.props.hideModal();
     };
 
     /**
@@ -35,6 +39,8 @@ class RecordingConsentDialog extends React.Component {
      */
     _onConsentWithUnmute = () => {
         remoteControlClient.grantRecordingConsent(true);
+
+        this.props.hideModal();
     };
 
     /**
@@ -80,4 +86,24 @@ class RecordingConsentDialog extends React.Component {
     }
 }
 
-export default connect(null, null)(withTranslation()(RecordingConsentDialog));
+/**
+ * Creates actions which can update Redux state.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps(dispatch) {
+    return {
+        /**
+         * Closes the currently displayed modal.
+         *
+         * @returns {void}
+         */
+        hideModal() {
+            dispatch(hideModal());
+        }
+    };
+}
+
+export default connect(null, mapDispatchToProps)(withTranslation()(RecordingConsentDialog));

--- a/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
+++ b/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
  * when a recording is in progress. The dialog provides two options: consent to
  * recording while remaining muted, or consent to recording and unmute the user.
  */
-export class RecordingConsentDialog extends React.Component {
+class RecordingConsentDialog extends React.Component {
     static propTypes = {
         onConsent: PropTypes.func,
         onConsentWithUnmute: PropTypes.func,

--- a/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
+++ b/spot-client/src/spot-remote/ui/components/recording-consent/RecordingConsentDialog.js
@@ -1,0 +1,83 @@
+import { remoteControlClient } from 'common/remote-control';
+import { Button, Modal } from 'common/ui';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+
+/**
+ * A modal dialog component that displays a recording consent notification to users
+ * when a recording is in progress. The dialog provides two options: consent to
+ * recording while remaining muted, or consent to recording and unmute the user.
+ */
+export class RecordingConsentDialog extends React.Component {
+    static propTypes = {
+        onConsent: PropTypes.func,
+        onConsentWithUnmute: PropTypes.func,
+        t: PropTypes.func
+    };
+
+    /**
+     * Handler for when user consents to recording without unmuting.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onConsent = () => {
+        remoteControlClient.grantRecordingConsent(false);
+    };
+
+    /**
+     * Handler for when user consents to recording and wants to unmute.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onConsentWithUnmute = () => {
+        remoteControlClient.grantRecordingConsent(true);
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { t } = this.props;
+
+        return (
+            <Modal
+                qaId = 'recording-consent-modal'>
+                <div className = 'recording-consent-modal'>
+                    <div className = 'content'>
+                        <div className = 'title'>
+                            { t('recording.inProgressTitle') }
+                        </div>
+                        <div className = 'description'>
+                            { t('recording.inProgressDescription') }
+                        </div>
+                    </div>
+                    <div className = 'footer'>
+                        <Button
+                            appearance = 'primary'
+                            className = 'understand-button-unmute'
+                            onClick = { this._onConsentWithUnmute }
+                            qaId = 'understand-unmute-button'>
+                            { t('recording.understandAndUnmute') }
+                        </Button>
+                        <Button
+                            appearance = 'primary'
+                            className = 'understand-button'
+                            onClick = { this._onConsent }
+                            qaId = 'understand-button'>
+                            { t('recording.understand') }
+                        </Button>
+                    </div>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+export default connect(null, null)(withTranslation()(RecordingConsentDialog));

--- a/spot-client/src/spot-remote/ui/components/recording-consent/index.js
+++ b/spot-client/src/spot-remote/ui/components/recording-consent/index.js
@@ -1,0 +1,1 @@
+export { default as RecordingConsentDialog } from './RecordingConsentDialog';

--- a/spot-client/src/spot-remote/ui/components/recording-consent/index.js
+++ b/spot-client/src/spot-remote/ui/components/recording-consent/index.js
@@ -1,1 +1,0 @@
-export { default as RecordingConsentDialog } from './RecordingConsentDialog';

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -101,8 +101,6 @@ export class InCall extends React.Component {
         // Only show or hide the recording consent dialog if its state has changed
         if (!prevDialogOpen && currentDialogOpen) {
             this.props.onShowModal(RecordingConsentDialog);
-        } else if (prevDialogOpen && !currentDialogOpen) {
-            this.props.hideModal(); // Use this.props to avoid shadowing
         }
     }
 

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -4,7 +4,8 @@ import {
     getInvitedPhoneNumber,
     getMeetingCancelTimeout,
     hangUp,
-    hideModal
+    hideModal,
+    showModal
 } from 'common/app-state';
 import { LoadingIcon, Modal } from 'common/ui';
 import PropTypes from 'prop-types';
@@ -22,6 +23,7 @@ import {
     MeetingHeader,
     PasswordPrompt
 } from '../../components';
+import { RecordingConsentDialog } from '../../components/recording-consent'; // Add this import
 import { formatPhoneNumber } from '../../utils/formatPhoneNumber';
 
 import { MeetingToolbar } from './../../components/meeting-toolbar';
@@ -40,8 +42,10 @@ export class InCall extends React.Component {
         meetingDisplayName: PropTypes.string,
         onForceStopWirelessScreenshare: PropTypes.func,
         onHangUp: PropTypes.func,
+        onShowModal: PropTypes.func, // Add this line
         onShowScreenshareModal: PropTypes.func,
         onSubmitPassword: PropTypes.func,
+        recordingConsentDialogOpen: PropTypes.bool, // Add this line
         showPasswordPrompt: PropTypes.bool,
         t: PropTypes.func
     };
@@ -81,10 +85,24 @@ export class InCall extends React.Component {
      *
      * @inheritdoc
      */
-    componentDidUpdate() {
-        if (this._showCancelMeetingTimeout && this.props.inMeeting) {
+    componentDidUpdate(prevProps) {
+        // Handle recording consent dialog state changes
+        const { recordingConsentDialogOpen: prevDialogOpen } = prevProps;
+        const {
+            inMeeting,
+            recordingConsentDialogOpen: currentDialogOpen
+        } = this.props;
+
+        if (this._showCancelMeetingTimeout && inMeeting) {
             clearTimeout(this._showCancelMeetingTimeout);
             this._showCancelMeetingTimeout = null;
+        }
+
+        // Only show or hide the recording consent dialog if its state has changed
+        if (!prevDialogOpen && currentDialogOpen) {
+            this.props.onShowModal(RecordingConsentDialog);
+        } else if (prevDialogOpen && !currentDialogOpen) {
+            this.props.hideModal(); // Use this.props to avoid shadowing
         }
     }
 
@@ -181,6 +199,7 @@ function mapStateToProps(state) {
         kicked,
         meetingCancelTimeout: getMeetingCancelTimeout(state),
         meetingDisplayName,
+        recordingConsentDialogOpen: state.spotTv?.recordingConsentDialogOpen,
         showPasswordPrompt: needPassword
     };
 }
@@ -219,6 +238,16 @@ function mapDispatchToProps(dispatch) {
          */
         onHangUp() {
             return dispatch(hangUp(true));
+        },
+
+        /**
+         * Shows a modal with the specified component.
+         *
+         * @param {React.Component} component - The component to show in the modal.
+         * @returns {void}
+         */
+        onShowModal(component) {
+            dispatch(showModal(component));
         },
 
         /**

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -190,7 +190,8 @@ function mapStateToProps(state) {
         inMeeting,
         kicked,
         meetingDisplayName,
-        needPassword
+        needPassword,
+        recordingConsentDialogOpen
     } = getInMeetingStatus(state);
 
     return {
@@ -199,7 +200,7 @@ function mapStateToProps(state) {
         kicked,
         meetingCancelTimeout: getMeetingCancelTimeout(state),
         meetingDisplayName,
-        recordingConsentDialogOpen: state.spotTv?.recordingConsentDialogOpen,
+        recordingConsentDialogOpen,
         showPasswordPrompt: needPassword
     };
 }

--- a/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
+++ b/spot-client/src/spot-remote/ui/views/remote-views/in-call.js
@@ -23,7 +23,7 @@ import {
     MeetingHeader,
     PasswordPrompt
 } from '../../components';
-import { RecordingConsentDialog } from '../../components/recording-consent'; // Add this import
+import RecordingConsentDialog from '../../components/recording-consent/RecordingConsentDialog';
 import { formatPhoneNumber } from '../../utils/formatPhoneNumber';
 
 import { MeetingToolbar } from './../../components/meeting-toolbar';
@@ -42,10 +42,10 @@ export class InCall extends React.Component {
         meetingDisplayName: PropTypes.string,
         onForceStopWirelessScreenshare: PropTypes.func,
         onHangUp: PropTypes.func,
-        onShowModal: PropTypes.func, // Add this line
+        onShowModal: PropTypes.func,
         onShowScreenshareModal: PropTypes.func,
         onSubmitPassword: PropTypes.func,
-        recordingConsentDialogOpen: PropTypes.bool, // Add this line
+        recordingConsentDialogOpen: PropTypes.bool,
         showPasswordPrompt: PropTypes.bool,
         t: PropTypes.func
     };

--- a/spot-client/src/spot-tv/ui/components/meeting-frame/JitsiMeetingFrame/JitsiMeetingFrame.js
+++ b/spot-client/src/spot-tv/ui/components/meeting-frame/JitsiMeetingFrame/JitsiMeetingFrame.js
@@ -79,6 +79,7 @@ export class JitsiMeetingFrame extends AbstractMeetingFrame {
             '_onParticipantLeft',
             '_onPasswordRequired',
             '_onRaiseHandChange',
+            '_onRecordingConsentDialogOpen',
             '_onReportDeviceError',
             '_onScreenshareChange',
             '_onScreenshareDeviceConnected',
@@ -201,6 +202,8 @@ export class JitsiMeetingFrame extends AbstractMeetingFrame {
             'raiseHandUpdated', this._onRaiseHandChange);
         this._jitsiApi.addListener(
             'readyToClose', this._onMeetingLeave);
+        this._jitsiApi.addListener(
+            'recordingConsentDialogOpen', this._onRecordingConsentDialogOpen);
         this._jitsiApi.addListener(
             'screenSharingStatusChanged', this._onScreenshareChange);
         this._jitsiApi.addListener(
@@ -392,7 +395,12 @@ export class JitsiMeetingFrame extends AbstractMeetingFrame {
             }
 
             break;
-
+        case COMMANDS.GRANT_RECORDING_CONSENT:
+            this._jitsiApi.executeCommand(
+                'grantRecordingConsent',
+                data.unmute
+            );
+            break;
         case COMMANDS.SEND_TOUCH_TONES:
             this._playTouchTone(data.tones);
             break;
@@ -621,6 +629,24 @@ export class JitsiMeetingFrame extends AbstractMeetingFrame {
         logger.error('device error occurred within the meeting', {
             type,
             message
+        });
+    }
+
+    /**
+     * Callback invoked when the recording consent dialog is opened.
+     * This is used to update the sport remote state to show the recording consent
+     * dialog view.
+     *
+     * @param {boolean} open - Whether the recording consent dialog is
+     * currently open or not.
+     * @private
+     * @returns {void}
+     */
+    _onRecordingConsentDialogOpen({ open }) {
+        logger.log('recording consent dialog state open changed: ', open);
+
+        this.props.updateSpotTvState({
+            recordingConsentDialogOpen: open
         });
     }
 


### PR DESCRIPTION
Whenever the recording consent dialog pops up on jitsi-meet also show it in the spot remote.
<img width="330" alt="Screenshot 2025-06-13 at 15 04 20" src="https://github.com/user-attachments/assets/797a3e8f-892f-41cb-9694-6b96df90c8c5" />

Depends on: https://github.com/jitsi/jitsi-meet/pull/16141