### PR TITLE
Migrate spot to TypeScript: Add TS config, convert app.js and SpotTvRestrictedRoute.js

### DIFF
--- a/spot-client/babel.config.js
+++ b/spot-client/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    presets: [ '@babel/preset-env', '@babel/preset-react' ]
+    presets: [ '@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript' ]
 };

--- a/spot-client/package-lock.json
+++ b/spot-client/package-lock.json
@@ -7,18 +7,25 @@
         "": {
             "name": "spot",
             "version": "0.0.1",
+            "dependencies": {
+                "@mui/base": "^5.0.0-alpha.113"
+            },
             "devDependencies": {
                 "@babel/core": "7.20.5",
                 "@babel/eslint-parser": "7.19.1",
                 "@babel/eslint-plugin": "7.19.1",
                 "@babel/preset-env": "7.20.2",
                 "@babel/preset-react": "7.18.6",
+                "@babel/preset-typescript": "^7.28.5",
                 "@jest/globals": "29.3.1",
                 "@jitsi/eslint-config": "4.1.5",
                 "@jitsi/js-utils": "2.0.5",
                 "@jitsi/logger": "2.0.1",
                 "@mui/icons-material": "5.11.0",
                 "@mui/material": "5.11.4",
+                "@types/react": "^18.3.27",
+                "@types/react-dom": "^18.3.7",
+                "@types/react-router-dom": "^5.3.3",
                 "@wojtekmaj/enzyme-adapter-react-17": "0.8.0",
                 "babel-core": "7.0.0-bridge.0",
                 "babel-jest": "29.3.1",
@@ -67,6 +74,7 @@
                 "string-replace-loader": "3.1.0",
                 "strophe.js": "1.2.16",
                 "style-loader": "3.3.1",
+                "typescript": "^5.9.3",
                 "webpack": "5.94.0",
                 "webpack-cli": "5.0.1",
                 "webpack-dev-server": "4.13.2",
@@ -91,13 +99,15 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -213,41 +223,41 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+            "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.23.0",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
-                "jsesc": "^2.5.1"
+                "@babel/parser": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-            "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.27.3"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -294,24 +304,35 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.5.tgz",
-            "integrity": "sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
+            "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.18.6",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-member-expression-to-functions": "^7.18.9",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/helper-replace-supers": "^7.19.1",
-                "@babel/helper-split-export-declaration": "^7.18.6"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/traverse": "^7.28.5",
+                "semver": "^6.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
@@ -390,6 +411,16 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-hoist-variables": {
             "version": "7.22.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
@@ -403,65 +434,70 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
-            "integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.18.9"
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-            "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.20.2",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.28.3"
             },
             "engines": {
                 "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-            "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -485,40 +521,32 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
-            "integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-member-expression-to-functions": "^7.18.9",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/traverse": "^7.19.1",
-                "@babel/types": "^7.19.0"
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.20.2"
             },
-            "engines": {
-                "node": ">=6.9.0"
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-            "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.20.0"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -537,28 +565,31 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-            "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -592,25 +623,15 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/highlight": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/parser": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.5"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1014,12 +1035,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-            "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.18.6"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1131,12 +1153,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
-            "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.19.0"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1386,14 +1409,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.19.6.tgz",
-            "integrity": "sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helper-plugin-utils": "^7.19.0",
-                "@babel/helper-simple-access": "^7.19.4"
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1685,6 +1708,26 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-transform-typescript": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
+            "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
@@ -1850,62 +1893,78 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/runtime": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-            "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+        "node_modules/@babel/preset-typescript": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+            "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+                "@babel/plugin-transform-typescript": "^7.28.5"
             },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+            "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.23.0",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.0",
-                "@babel/types": "^7.23.0",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.5",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.5",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.5",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.20",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1985,31 +2044,51 @@
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.10.5",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
-            "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/sheet": "^1.2.1",
-                "@emotion/utils": "^1.2.0",
-                "@emotion/weak-memoize": "^0.3.0",
-                "stylis": "4.1.3"
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
             }
         },
-        "node_modules/@emotion/hash": {
+        "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-            "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
+        },
+        "node_modules/@emotion/cache/node_modules/@emotion/weak-memoize": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emotion/cache/node_modules/stylis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
             "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
-            "dev": true,
             "dependencies": {
                 "@emotion/memoize": "^0.8.0"
             }
@@ -2017,8 +2096,7 @@
         "node_modules/@emotion/memoize": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==",
-            "dev": true
+            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
         },
         "node_modules/@emotion/react": {
             "version": "11.10.5",
@@ -2051,25 +2129,32 @@
             }
         },
         "node_modules/@emotion/serialize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
-            "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
-                "@emotion/hash": "^0.9.0",
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/unitless": "^0.8.0",
-                "@emotion/utils": "^1.2.0",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
                 "csstype": "^3.0.2"
             }
         },
+        "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@emotion/sheet": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
-            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==",
-            "dev": true
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@emotion/styled": {
             "version": "11.10.5",
@@ -2101,12 +2186,11 @@
             }
         },
         "node_modules/@emotion/unitless": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-            "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.0",
@@ -2120,16 +2204,19 @@
             }
         },
         "node_modules/@emotion/utils": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-            "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==",
-            "dev": true
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
             "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@es-joy/jsdoccomment": {
             "version": "0.43.1",
@@ -3033,16 +3120,18 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -3070,7 +3159,8 @@
             "version": "5.0.0-alpha.113",
             "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.113.tgz",
             "integrity": "sha512-XSjvyQWATM8uk+EJZvYna8D21kOXC42lwb3q4K70btuGieKlCIQLaHTTDV2OfD4+JfT4o3NJy3I4Td2co31RZA==",
-            "dev": true,
+            "deprecated": "This package has been replaced by @base-ui-components/react",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.20.7",
                 "@emotion/is-prop-valid": "^1.2.0",
@@ -3100,10 +3190,10 @@
             }
         },
         "node_modules/@mui/base/node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-            "dev": true
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "license": "MIT"
         },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.11.4",
@@ -3193,13 +3283,14 @@
             "dev": true
         },
         "node_modules/@mui/private-theming": {
-            "version": "5.11.2",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.2.tgz",
-            "integrity": "sha512-qZwMaqRFPwlYmqwVKblKBGKtIjJRAj3nsvX93pOmatsXyorW7N/0IPE/swPgz1VwChXhHO75DwBEx8tB+aRMNg==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+            "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.20.7",
-                "@mui/utils": "^5.11.2",
+                "@babel/runtime": "^7.23.9",
+                "@mui/utils": "^5.17.1",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -3207,11 +3298,11 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -3220,14 +3311,16 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.11.0.tgz",
-            "integrity": "sha512-AF06K60Zc58qf0f7X+Y/QjaHaZq16znliLnGc9iVrV/+s8Ln/FCoeNuFvhlCbZZQ5WQcJvcy59zp0nXrklGGPQ==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+            "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@emotion/cache": "^11.10.5",
-                "csstype": "^3.1.1",
+                "@babel/runtime": "^7.23.9",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -3235,12 +3328,12 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.4.1",
                 "@emotion/styled": "^11.3.0",
-                "react": "^17.0.0 || ^18.0.0"
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@emotion/react": {
@@ -3252,18 +3345,19 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "5.11.4",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.4.tgz",
-            "integrity": "sha512-fE2Ts33V5zh7ouciwXgMm/a6sLvjIj9OMeojuHNYY7BStTxparC/Fp9CNUZNJwt76U6ZJC59aYScFSRQKbW08g==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+            "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.20.7",
-                "@mui/private-theming": "^5.11.2",
-                "@mui/styled-engine": "^5.11.0",
-                "@mui/types": "^7.2.3",
-                "@mui/utils": "^5.11.2",
-                "clsx": "^1.2.1",
-                "csstype": "^3.1.1",
+                "@babel/runtime": "^7.23.9",
+                "@mui/private-theming": "^5.17.1",
+                "@mui/styled-engine": "^5.18.0",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -3271,13 +3365,13 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
                 "@emotion/styled": "^11.3.0",
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@emotion/react": {
@@ -3291,13 +3385,23 @@
                 }
             }
         },
-        "node_modules/@mui/types": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.3.tgz",
-            "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==",
+        "node_modules/@mui/system/node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@mui/types": {
+            "version": "7.2.24",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+            "license": "MIT",
             "peerDependencies": {
-                "@types/react": "*"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -3306,33 +3410,49 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "5.11.2",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.2.tgz",
-            "integrity": "sha512-AyizuHHlGdAtH5hOOXBW3kriuIwUIKUIgg0P7LzMvzf6jPhoQbENYqY6zJqfoZ7fAWMNNYT8mgN5EftNGzwE2w==",
-            "dev": true,
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+            "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.20.7",
-                "@types/prop-types": "^15.7.5",
-                "@types/react-is": "^16.7.1 || ^17.0.0",
+                "@babel/runtime": "^7.23.9",
+                "@mui/types": "~7.2.15",
+                "@types/prop-types": "^15.7.12",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "react-is": "^18.2.0"
+                "react-is": "^19.0.0"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/utils/node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@mui/utils/node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-            "dev": true
+            "version": "19.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+            "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+            "license": "MIT"
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -3434,10 +3554,10 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-            "dev": true,
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -3606,6 +3726,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/history": {
+            "version": "4.7.11",
+            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/hoist-non-react-statics": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -3737,10 +3864,10 @@
             "dev": true
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.5",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-            "dev": true
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "license": "MIT"
         },
         "node_modules/@types/qs": {
             "version": "6.9.7",
@@ -3755,23 +3882,47 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "17.0.52",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
-            "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
-            "dev": true,
+            "version": "18.3.27",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+            "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+            "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
-                "@types/scheduler": "*",
-                "csstype": "^3.0.2"
+                "csstype": "^3.2.2"
             }
         },
-        "node_modules/@types/react-is": {
-            "version": "17.0.3",
-            "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
-            "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@types/react-router": {
+            "version": "5.1.20",
+            "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+            "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@types/history": "^4.7.11",
                 "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-router-dom": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+            "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router": "*"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -3787,12 +3938,6 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-            "dev": true
-        },
-        "node_modules/@types/scheduler": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
             "dev": true
         },
         "node_modules/@types/semver": {
@@ -5653,7 +5798,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
             "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6119,10 +6263,11 @@
             "dev": true
         },
         "node_modules/csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/data-urls": {
             "version": "3.0.2",
@@ -11259,8 +11404,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
             "version": "3.13.1",
@@ -11434,15 +11578,16 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/json-parse-even-better-errors": {
@@ -11666,7 +11811,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -12875,7 +13019,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13287,10 +13430,11 @@
             "dev": true
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-            "dev": true
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -13524,7 +13668,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -13697,7 +13840,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -13722,7 +13864,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -13757,8 +13898,7 @@
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-redux": {
             "version": "8.0.5",
@@ -13983,12 +14123,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-            "dev": true
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.1",
@@ -14362,7 +14496,6 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -15261,7 +15394,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
             "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
@@ -15498,15 +15633,6 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15668,17 +15794,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
-            "peer": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/uc.micro": {
@@ -16552,13 +16678,14 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
             }
         },
         "@babel/compat-data": {
@@ -16642,37 +16769,37 @@
             }
         },
         "@babel/generator": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+            "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.23.0",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
-                "jsesc": "^2.5.1"
+                "@babel/parser": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
             },
             "dependencies": {
                 "@jridgewell/gen-mapping": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-                    "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+                    "version": "0.3.13",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+                    "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
                     "dev": true,
                     "requires": {
-                        "@jridgewell/set-array": "^1.0.1",
-                        "@jridgewell/sourcemap-codec": "^1.4.10",
-                        "@jridgewell/trace-mapping": "^0.3.9"
+                        "@jridgewell/sourcemap-codec": "^1.5.0",
+                        "@jridgewell/trace-mapping": "^0.3.24"
                     }
                 }
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-            "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.27.3"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -16706,18 +16833,26 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.5.tgz",
-            "integrity": "sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
+            "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.18.6",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-member-expression-to-functions": "^7.18.9",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/helper-replace-supers": "^7.19.1",
-                "@babel/helper-split-export-declaration": "^7.18.6"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/traverse": "^7.28.5",
+                "semver": "^6.3.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
@@ -16777,6 +16912,12 @@
                 "@babel/types": "^7.23.0"
             }
         },
+        "@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true
+        },
         "@babel/helper-hoist-variables": {
             "version": "7.22.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
@@ -16787,52 +16928,49 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
-            "integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.9"
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-            "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
             "dev": true,
             "requires": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.20.2",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.28.3"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-            "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.27.1"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "dev": true
         },
         "@babel/helper-remap-async-to-generator": {
@@ -16848,34 +16986,24 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
-            "integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-member-expression-to-functions": "^7.18.9",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/traverse": "^7.19.1",
-                "@babel/types": "^7.19.0"
-            }
-        },
-        "@babel/helper-simple-access": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.20.2"
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
             }
         },
         "@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-            "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.20.0"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -16888,21 +17016,21 @@
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true
         },
         "@babel/helper-validator-option": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-            "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true
         },
         "@babel/helper-wrap-function": {
@@ -16928,22 +17056,14 @@
                 "@babel/types": "^7.20.5"
             }
         },
-        "@babel/highlight": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+        "@babel/parser": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.22.20",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "@babel/types": "^7.28.5"
             }
-        },
-        "@babel/parser": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-            "dev": true
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
             "version": "7.18.6",
@@ -17206,12 +17326,12 @@
             }
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-            "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.18.6"
+                "@babel/helper-plugin-utils": "^7.27.1"
             }
         },
         "@babel/plugin-syntax-logical-assignment-operators": {
@@ -17287,12 +17407,12 @@
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
-            "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.19.0"
+                "@babel/helper-plugin-utils": "^7.27.1"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -17446,14 +17566,13 @@
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.19.6.tgz",
-            "integrity": "sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helper-plugin-utils": "^7.19.0",
-                "@babel/helper-simple-access": "^7.19.4"
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -17631,6 +17750,19 @@
                 "@babel/helper-plugin-utils": "^7.18.9"
             }
         },
+        "@babel/plugin-transform-typescript": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
+            "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1"
+            }
+        },
         "@babel/plugin-transform-unicode-escapes": {
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
@@ -17768,53 +17900,58 @@
                 "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
             }
         },
-        "@babel/runtime": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-            "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+        "@babel/preset-typescript": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+            "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
             "dev": true,
             "requires": {
-                "regenerator-runtime": "^0.13.11"
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+                "@babel/plugin-transform-typescript": "^7.28.5"
             }
         },
+        "@babel/runtime": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
+        },
         "@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             }
         },
         "@babel/traverse": {
-            "version": "7.23.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+            "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.23.0",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.0",
-                "@babel/types": "^7.23.0",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.5",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.5",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.5",
+                "debug": "^4.3.1"
             }
         },
         "@babel/types": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.20",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             }
         },
         "@bcoe/v8-coverage": {
@@ -17878,31 +18015,48 @@
             }
         },
         "@emotion/cache": {
-            "version": "11.10.5",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
-            "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
             "dev": true,
             "requires": {
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/sheet": "^1.2.1",
-                "@emotion/utils": "^1.2.0",
-                "@emotion/weak-memoize": "^0.3.0",
-                "stylis": "4.1.3"
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
+            },
+            "dependencies": {
+                "@emotion/memoize": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+                    "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+                    "dev": true
+                },
+                "@emotion/weak-memoize": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+                    "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+                    "dev": true
+                },
+                "stylis": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+                    "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+                    "dev": true
+                }
             }
         },
         "@emotion/hash": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-            "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "dev": true
         },
         "@emotion/is-prop-valid": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
             "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
-            "dev": true,
             "requires": {
                 "@emotion/memoize": "^0.8.0"
             }
@@ -17910,8 +18064,7 @@
         "@emotion/memoize": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==",
-            "dev": true
+            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
         },
         "@emotion/react": {
             "version": "11.10.5",
@@ -17932,24 +18085,30 @@
             }
         },
         "@emotion/serialize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
-            "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "requires": {
-                "@emotion/hash": "^0.9.0",
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/unitless": "^0.8.0",
-                "@emotion/utils": "^1.2.0",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
                 "csstype": "^3.0.2"
+            },
+            "dependencies": {
+                "@emotion/memoize": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+                    "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+                    "dev": true
+                }
             }
         },
         "@emotion/sheet": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
-            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
             "dev": true
         },
         "@emotion/styled": {
@@ -17969,12 +18128,10 @@
             }
         },
         "@emotion/unitless": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-            "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "dev": true
         },
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.0",
@@ -17986,16 +18143,18 @@
             "requires": {}
         },
         "@emotion/utils": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-            "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
             "dev": true
         },
         "@emotion/weak-memoize": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
             "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@es-joy/jsdoccomment": {
             "version": "0.43.1",
@@ -18691,15 +18850,15 @@
             }
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -18725,7 +18884,6 @@
             "version": "5.0.0-alpha.113",
             "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.113.tgz",
             "integrity": "sha512-XSjvyQWATM8uk+EJZvYna8D21kOXC42lwb3q4K70btuGieKlCIQLaHTTDV2OfD4+JfT4o3NJy3I4Td2co31RZA==",
-            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.20.7",
                 "@emotion/is-prop-valid": "^1.2.0",
@@ -18738,10 +18896,9 @@
             },
             "dependencies": {
                 "react-is": {
-                    "version": "18.2.0",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-                    "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-                    "dev": true
+                    "version": "18.3.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+                    "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
                 }
             }
         },
@@ -18789,69 +18946,81 @@
             }
         },
         "@mui/private-theming": {
-            "version": "5.11.2",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.2.tgz",
-            "integrity": "sha512-qZwMaqRFPwlYmqwVKblKBGKtIjJRAj3nsvX93pOmatsXyorW7N/0IPE/swPgz1VwChXhHO75DwBEx8tB+aRMNg==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+            "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.20.7",
-                "@mui/utils": "^5.11.2",
+                "@babel/runtime": "^7.23.9",
+                "@mui/utils": "^5.17.1",
                 "prop-types": "^15.8.1"
             }
         },
         "@mui/styled-engine": {
-            "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.11.0.tgz",
-            "integrity": "sha512-AF06K60Zc58qf0f7X+Y/QjaHaZq16znliLnGc9iVrV/+s8Ln/FCoeNuFvhlCbZZQ5WQcJvcy59zp0nXrklGGPQ==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+            "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.20.6",
-                "@emotion/cache": "^11.10.5",
-                "csstype": "^3.1.1",
+                "@babel/runtime": "^7.23.9",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             }
         },
         "@mui/system": {
-            "version": "5.11.4",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.4.tgz",
-            "integrity": "sha512-fE2Ts33V5zh7ouciwXgMm/a6sLvjIj9OMeojuHNYY7BStTxparC/Fp9CNUZNJwt76U6ZJC59aYScFSRQKbW08g==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+            "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.20.7",
-                "@mui/private-theming": "^5.11.2",
-                "@mui/styled-engine": "^5.11.0",
-                "@mui/types": "^7.2.3",
-                "@mui/utils": "^5.11.2",
-                "clsx": "^1.2.1",
-                "csstype": "^3.1.1",
+                "@babel/runtime": "^7.23.9",
+                "@mui/private-theming": "^5.17.1",
+                "@mui/styled-engine": "^5.18.0",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
+            },
+            "dependencies": {
+                "clsx": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+                    "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+                    "dev": true
+                }
             }
         },
         "@mui/types": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.3.tgz",
-            "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==",
-            "dev": true,
+            "version": "7.2.24",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
             "requires": {}
         },
         "@mui/utils": {
-            "version": "5.11.2",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.2.tgz",
-            "integrity": "sha512-AyizuHHlGdAtH5hOOXBW3kriuIwUIKUIgg0P7LzMvzf6jPhoQbENYqY6zJqfoZ7fAWMNNYT8mgN5EftNGzwE2w==",
-            "dev": true,
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+            "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
             "requires": {
-                "@babel/runtime": "^7.20.7",
-                "@types/prop-types": "^15.7.5",
-                "@types/react-is": "^16.7.1 || ^17.0.0",
+                "@babel/runtime": "^7.23.9",
+                "@mui/types": "~7.2.15",
+                "@types/prop-types": "^15.7.12",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "react-is": "^18.2.0"
+                "react-is": "^19.0.0"
             },
             "dependencies": {
+                "clsx": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+                    "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+                },
                 "react-is": {
-                    "version": "18.2.0",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-                    "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-                    "dev": true
+                    "version": "19.2.0",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+                    "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA=="
                 }
             }
         },
@@ -18935,10 +19104,9 @@
             }
         },
         "@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-            "dev": true
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
         },
         "@sinclair/typebox": {
             "version": "0.24.51",
@@ -19099,6 +19267,12 @@
                 "@types/node": "*"
             }
         },
+        "@types/history": {
+            "version": "4.7.11",
+            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+            "dev": true
+        },
         "@types/hoist-non-react-statics": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -19230,10 +19404,9 @@
             "dev": true
         },
         "@types/prop-types": {
-            "version": "15.7.5",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-            "dev": true
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
         },
         "@types/qs": {
             "version": "6.9.7",
@@ -19248,23 +19421,41 @@
             "dev": true
         },
         "@types/react": {
-            "version": "17.0.52",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
-            "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
-            "dev": true,
+            "version": "18.3.27",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+            "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+            "devOptional": true,
             "requires": {
                 "@types/prop-types": "*",
-                "@types/scheduler": "*",
-                "csstype": "^3.0.2"
+                "csstype": "^3.2.2"
             }
         },
-        "@types/react-is": {
-            "version": "17.0.3",
-            "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
-            "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+        "@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "@types/react-router": {
+            "version": "5.1.20",
+            "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+            "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
             "dev": true,
             "requires": {
+                "@types/history": "^4.7.11",
                 "@types/react": "*"
+            }
+        },
+        "@types/react-router-dom": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+            "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+            "dev": true,
+            "requires": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router": "*"
             }
         },
         "@types/react-transition-group": {
@@ -19280,12 +19471,6 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-            "dev": true
-        },
-        "@types/scheduler": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
             "dev": true
         },
         "@types/semver": {
@@ -20707,8 +20892,7 @@
         "clsx": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "dev": true
+            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
         },
         "co": {
             "version": "4.6.0",
@@ -21064,10 +21248,10 @@
             }
         },
         "csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "devOptional": true
         },
         "data-urls": {
             "version": "3.0.2",
@@ -24871,8 +25055,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -25009,9 +25192,9 @@
             }
         },
         "jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true
         },
         "json-parse-even-better-errors": {
@@ -25204,7 +25387,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -26140,8 +26322,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
             "version": "1.13.4",
@@ -26437,9 +26618,9 @@
             "dev": true
         },
         "picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
         },
         "picomatch": {
@@ -26603,7 +26784,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -26731,7 +26911,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -26748,7 +26927,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -26768,8 +26946,7 @@
         "react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "react-redux": {
             "version": "8.0.5",
@@ -26943,12 +27120,6 @@
             "requires": {
                 "regenerate": "^1.4.2"
             }
-        },
-        "regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-            "dev": true
         },
         "regenerator-transform": {
             "version": "0.15.1",
@@ -27205,7 +27376,6 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -27927,7 +28097,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
             "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -28095,12 +28267,6 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
-        "to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-            "dev": true
-        },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -28223,11 +28389,10 @@
             }
         },
         "typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-            "dev": true,
-            "peer": true
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true
         },
         "uc.micro": {
             "version": "2.1.0",

--- a/spot-client/package.json
+++ b/spot-client/package.json
@@ -5,12 +5,16 @@
         "@babel/eslint-plugin": "7.19.1",
         "@babel/preset-env": "7.20.2",
         "@babel/preset-react": "7.18.6",
+        "@babel/preset-typescript": "^7.28.5",
         "@jest/globals": "29.3.1",
         "@jitsi/eslint-config": "4.1.5",
         "@jitsi/js-utils": "2.0.5",
         "@jitsi/logger": "2.0.1",
         "@mui/icons-material": "5.11.0",
         "@mui/material": "5.11.4",
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.7",
+        "@types/react-router-dom": "^5.3.3",
         "@wojtekmaj/enzyme-adapter-react-17": "0.8.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "29.3.1",
@@ -59,6 +63,7 @@
         "string-replace-loader": "3.1.0",
         "strophe.js": "1.2.16",
         "style-loader": "3.3.1",
+        "typescript": "^5.9.3",
         "webpack": "5.94.0",
         "webpack-cli": "5.0.1",
         "webpack-dev-server": "4.13.2",
@@ -81,5 +86,8 @@
         "start:dev": "webpack-dev-server",
         "test": "jest"
     },
-    "version": "0.0.1"
+    "version": "0.0.1",
+    "dependencies": {
+        "@mui/base": "^5.0.0-alpha.113"
+    }
 }

--- a/spot-client/src/app.tsx
+++ b/spot-client/src/app.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Redirect, Route, Switch, withRouter, RouteComponentProps } from 'react-router-dom';
 
 import {
     apiMessageReceived,
@@ -19,10 +22,6 @@ import {
     Notifications,
     ReconnectIndicator
 } from 'common/ui';
-import PropTypes from 'prop-types';
-import React from 'react';
-import { connect } from 'react-redux';
-import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 import {
     Help,
     JoinCodeEntry,
@@ -54,24 +53,27 @@ import 'spot-tv/analytics';
 // This import enables tunneling Electron logs through the spot-client logging service
 import 'spot-tv/electron-logs';
 
+interface Props extends RouteComponentProps {
+    dispatch: (action: any) => void;
+    productName: string;
+    spotClientVersion: string;
+}
+
+interface State {
+    hideCursor: boolean;
+}
+
 /**
  * The root of the application which determines what view should be displayed.
  */
-export class App extends React.Component {
-    static propTypes = {
-        dispatch: PropTypes.func,
-        location: PropTypes.object,
-        productName: PropTypes.string,
-        spotClientVersion: PropTypes.string
-    };
-
+export class App extends React.Component<Props, State> {
     /**
      * Initializes a new {@code App} instance.
      *
-     * @param {Object} props - The read-only properties with which the new
+     * @param {Props} props - The read-only properties with which the new
      * instance is to be initialized.
      */
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
 
         this.state = {
@@ -156,17 +158,17 @@ export class App extends React.Component {
      * Implements React's {@link Component#render()}.
      *
      * @inheritdoc
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
     render() {
         const rootClassName
             = `app ${this.state.hideCursor ? 'idleCursor' : ''}`;
 
         return (
-            <ErrorBoundary errorComponent = { FatalError }>
+            <ErrorBoundary errorComponent={FatalError}>
                 <IdleCursorDetector
-                    onCursorIdleChange = { this._onCursorIdleChange }>
-                    <div className = { rootClassName }>
+                    onCursorIdleChange={this._onCursorIdleChange}>
+                    <div className={rootClassName}>
                         <Background />
                         <Notifications />
                         <Switch>
@@ -177,24 +179,24 @@ export class App extends React.Component {
                                  */
                             }
                             <SpotTvRestrictedRoute
-                                path = { ROUTES.MEETING }
-                                render = { this._renderMeetingView } />
+                                path={ROUTES.MEETING}
+                                render={this._renderMeetingView} />
                             <SpotTvRestrictedRoute
-                                path = { ROUTES.OUTLOOK_OAUTH }
-                                render = { this._renderOutlookOauthView } />
+                                path={ROUTES.OUTLOOK_OAUTH}
+                                render={this._renderOutlookOauthView} />
                             <SpotTvRestrictedRoute
-                                path = { ROUTES.SETUP }
-                                render = { this._renderSetupView }
-                                requireSetup = { false } />
+                                path={ROUTES.SETUP}
+                                render={this._renderSetupView}
+                                requireSetup={false} />
                             <Redirect
-                                from = { ROUTES.OLD_HOME }
-                                to = { ROUTES.HOME } />
+                                from={ROUTES.OLD_HOME}
+                                to={ROUTES.HOME} />
                             <SpotTvRestrictedRoute
-                                path = { ROUTES.HOME }
-                                render = { this._renderHomeView } />
+                                path={ROUTES.HOME}
+                                render={this._renderHomeView} />
                             <Route
-                                path = { ROUTES.UNSUPPORTED_BROWSER }
-                                render = { this._renderUnsupportedBrowserView } />
+                                path={ROUTES.UNSUPPORTED_BROWSER}
+                                render={this._renderUnsupportedBrowserView} />
 
                             {
 
@@ -203,24 +205,24 @@ export class App extends React.Component {
                                  */
                             }
                             <Route
-                                path = { ROUTES.HELP }
-                                render = { this._renderHelpView } />
+                                path={ROUTES.HELP}
+                                render={this._renderHelpView} />
                             <Route
-                                path = { ROUTES.SHARE }
-                                render = { this._renderShareView } />
+                                path={ROUTES.SHARE}
+                                render={this._renderShareView} />
                             <Route
-                                path = { ROUTES.SHARE_HELP }
-                                render = { this._renderShareHelpView } />
+                                path={ROUTES.SHARE_HELP}
+                                render={this._renderShareHelpView} />
                             <Route
-                                path = { ROUTES.REMOTE_CONTROL }
-                                render = { this._renderRemoteControlView } />
-                            <Route render = { this._renderJoinCodeEntry } />
+                                path={ROUTES.REMOTE_CONTROL}
+                                render={this._renderRemoteControlView} />
+                            <Route render={this._renderJoinCodeEntry} />
                         </Switch>
                     </div>
                     <ModalManager />
                     <ReconnectIndicator />
                     <FeedbackOverlay />
-                    { isElectron() && <ExitElectron /> }
+                    {isElectron() && <ExitElectron />}
                 </IdleCursorDetector>
             </ErrorBoundary>
         );
@@ -233,7 +235,7 @@ export class App extends React.Component {
      * @private
      * @returns {void}
      */
-    _onCursorIdleChange(cursorIsIdle) {
+    private _onCursorIdleChange(cursorIsIdle: boolean): void {
         this.setState({ hideCursor: cursorIsIdle });
     }
 
@@ -244,7 +246,7 @@ export class App extends React.Component {
      * @private
      * @returns {void}
      */
-    _onKeyDown() {
+    private _onKeyDown(): void {
         document.body.classList.remove('using-mouse');
     }
 
@@ -254,7 +256,7 @@ export class App extends React.Component {
      * @private
      * @returns {void}
      */
-    _onMouseDown() {
+    private _onMouseDown(): void {
         document.body.classList.add('using-mouse');
     }
 
@@ -264,7 +266,7 @@ export class App extends React.Component {
      * @param {Object} event - The message event posted.
      * @returns {void}
      */
-    _onPostMessage({ data }) {
+    private _onPostMessage({ data }: { data: any }): void {
         try {
             const parsedMessage = typeof data === 'object' ? data : JSON.parse(data);
 
@@ -285,7 +287,7 @@ export class App extends React.Component {
      * @private
      * @returns {void}
      */
-    _onTouchStart() {
+    private _onTouchStart(): void {
         /** No-op. */
     }
 
@@ -293,9 +295,9 @@ export class App extends React.Component {
      * Returns the Spot-Remote help view.
      *
      * @private
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
-    _renderHelpView() {
+    private _renderHelpView(): JSX.Element {
         return this._renderSpotRemoteViewWithHelp(Help);
     }
 
@@ -303,9 +305,9 @@ export class App extends React.Component {
      * Returns the Spot TV home (calendar) view.
      *
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderHomeView() {
+    private _renderHomeView(): JSX.Element {
         return this._renderSpotViewWithRemoteControl(Home, 'home');
     }
 
@@ -313,9 +315,9 @@ export class App extends React.Component {
      * Returns the Spot-Remote join code entry view.
      *
      * @private
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
-    _renderJoinCodeEntry() {
+    private _renderJoinCodeEntry(): JSX.Element {
         return this._renderSpotRemoteViewWithHelp(JoinCodeEntry);
     }
 
@@ -323,9 +325,9 @@ export class App extends React.Component {
      * Returns the Spot TV in-meeting view.
      *
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderMeetingView() {
+    private _renderMeetingView(): JSX.Element {
         return this._renderSpotViewWithRemoteControl(Meeting, 'meeting');
     }
 
@@ -333,9 +335,9 @@ export class App extends React.Component {
      * Returns the Spot-TV view for processing an Outlook oauth redirect.
      *
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderOutlookOauthView() {
+    private _renderOutlookOauthView(): JSX.Element {
         return <OutlookOauth />;
     }
 
@@ -343,9 +345,9 @@ export class App extends React.Component {
      * Returns the Spot-Remote remote control view.
      *
      * @private
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
-    _renderRemoteControlView() {
+    private _renderRemoteControlView(): JSX.Element {
         return this._renderSpotRemoteViewWithHelp(RemoteControl);
     }
 
@@ -353,11 +355,11 @@ export class App extends React.Component {
      * Returns the Spot TV setup view.
      *
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderSetupView() {
+    private _renderSetupView(): JSX.Element {
         return (
-            <SpotView name = { 'setup' }>
+            <SpotView name={'setup'}>
                 <Setup />
                 <FeedbackOpener />
             </SpotView>
@@ -368,9 +370,9 @@ export class App extends React.Component {
      * Returns the Spot-Remote view explaining how to use share mode.
      *
      * @private
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
-    _renderShareHelpView() {
+    private _renderShareHelpView(): JSX.Element {
         return this._renderSpotRemoteViewWithHelp(ShareHelp);
     }
 
@@ -378,19 +380,19 @@ export class App extends React.Component {
      * Returns the Spot-Remote share-only mode view.
      *
      * @private
-     * @returns {ReactElement}
+     * @returns {JSX.Element}
      */
-    _renderShareView() {
+    private _renderShareView(): JSX.Element {
         return this._renderSpotRemoteViewWithHelp(ShareView);
     }
 
     /**
      * Helper for displaying a consistent view across Spot-Remote views.
      *
-     * @param {Component} View - The Spot-Remove view component to show.
-     * @returns {ReactElement}
+     * @param {React.ComponentType} View - The Spot-Remove view component to show.
+     * @returns {JSX.Element}
      */
-    _renderSpotRemoteViewWithHelp(View) {
+    private _renderSpotRemoteViewWithHelp(View: React.ComponentType): JSX.Element {
         return (
             <div>
                 <View />
@@ -403,18 +405,18 @@ export class App extends React.Component {
      * Helper to ensure all Spot TV views share the same wrapper responsible
      * for maintaining the remote control service.
      *
-     * @param {ReactComponent} View - The child to display within the remote
+     * @param {React.ComponentType} View - The child to display within the remote
      * control service loader.
      * @param {string} name - The name associate with the view. Used for remotes
      * to identify what view the spot is showing.
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderSpotViewWithRemoteControl(View, name) {
+    private _renderSpotViewWithRemoteControl(View: React.ComponentType, name: string): JSX.Element {
         return (
             <SpotTVRemoteControlLoader>
                 <WiredScreenshareDetector />
-                <SpotView name = { name }>
+                <SpotView name={name}>
                     <View />
                 </SpotView>
             </SpotTVRemoteControlLoader>
@@ -426,11 +428,11 @@ export class App extends React.Component {
      * current environment.
      *
      * @private
-     * @returns {ReactComponent}
+     * @returns {JSX.Element}
      */
-    _renderUnsupportedBrowserView() {
+    private _renderUnsupportedBrowserView(): JSX.Element {
         return (
-            <SpotView name = { 'unsupported' }>
+            <SpotView name={'unsupported'}>
                 <UnsupportedBrowser />
             </SpotView>
         );
@@ -444,7 +446,7 @@ export class App extends React.Component {
  * @private
  * @returns {Object}
  */
-function mapStateToProps(state) {
+function mapStateToProps(state: any) {
     return {
         spotClientVersion: getSpotClientVersion(state),
         productName: getProductName(state)

--- a/spot-client/src/spot-tv/routing/SpotTvRestrictedRoute.tsx
+++ b/spot-client/src/spot-tv/routing/SpotTvRestrictedRoute.tsx
@@ -1,0 +1,75 @@
+import { getPermanentPairingCode, isBackendEnabled } from 'common/backend';
+import { isSupportedSpotTvBrowser } from 'common/detection';
+import { ROUTES } from 'common/routing';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Redirect, Route, RouteProps } from 'react-router-dom';
+
+interface Props extends RouteProps {
+    isBackendSetupComplete?: boolean;
+    requireSetup?: boolean;
+}
+
+/**
+ * Creates a Route which only allows the view to be displayed if on a supported
+ * browser, otherwise redirects to the unsupported browser route.
+ */
+export class SpotTvRestrictedRoute extends React.PureComponent<Props> {
+    static defaultProps = {
+        requireSetup: true
+    };
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        if (!isSupportedSpotTvBrowser()) {
+            return <Redirect to={ROUTES.UNSUPPORTED_BROWSER} />;
+        }
+
+        const {
+            requireSetup,
+            isBackendSetupComplete,
+            ...routeProps
+        } = this.props;
+
+        if (requireSetup && !isBackendSetupComplete) {
+            return <Redirect to={ROUTES.SETUP} />;
+        }
+
+        return <Route {...routeProps} />;
+    }
+}
+
+/**
+ * Selects parts of the Redux state to pass in with the props of
+ * {@code SpotTvRestrictedRoute}.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function mapStateToProps(state: any) {
+    return {
+        isBackendSetupComplete: isBackendEnabled(state)
+            ? Boolean(getPermanentPairingCode(state))
+            : true
+    };
+}
+
+/**
+ * Creates actions which can update Redux state. Purposefully returns an empty
+ * object as a hack to  remove dispatch from props.
+ *
+ * @param {Function} dispatch - The Redux dispatch function to update state.
+ * @private
+ * @returns {Object}
+ */
+function mapDispatchToProps() {
+    return {};
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SpotTvRestrictedRoute);

--- a/spot-client/tsconfig.json
+++ b/spot-client/tsconfig.json
@@ -1,0 +1,39 @@
+{
+    "compilerOptions": {
+        "target": "es2018",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es6"
+        ],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": false,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "baseUrl": ".",
+        "paths": {
+            "common/*": [
+                "src/common/*"
+            ],
+            "spot-remote/*": [
+                "src/spot-remote/*"
+            ],
+            "spot-tv/*": [
+                "src/spot-tv/*"
+            ]
+        }
+    },
+    "include": [
+        "src/app.tsx",
+        "src/spot-tv/routing/SpotTvRestrictedRoute.tsx"
+    ]
+}

--- a/spot-client/webpack.config.js
+++ b/spot-client/webpack.config.js
@@ -52,16 +52,16 @@ module.exports = () => {
                             require.resolve('@babel/plugin-proposal-optional-chaining')
                         ]
                     },
-                    test: /\.js$/
+                    test: /\.js$|\.ts$|\.tsx$/
                 }
             ]
         },
         plugins: [
             detectCircularDeps
-                && new CircularDependencyPlugin({
-                    exclude: /node_modules/,
-                    failOnError: true
-                }),
+            && new CircularDependencyPlugin({
+                exclude: /node_modules/,
+                failOnError: true
+            }),
             new CopyWebpackPlugin({
                 patterns: [
                     {
@@ -93,6 +93,7 @@ module.exports = () => {
             minimize: isProduction
         },
         resolve: {
+            extensions: [ '.js', '.ts', '.tsx' ],
             modules: [ path.resolve('./src'), path.resolve('./node_modules') ]
         }
     };


### PR DESCRIPTION
This PR introduces initial TypeScript migration of jitsi-meet-spot by adding various configuration changes and converting app.js to app.tsx
This is a sample migration to demonstrate feasibility and set up the groundwork for a broader TypeScript migration across the codebase.
Addresses issue #1143